### PR TITLE
731 port cea to arcgis 10 5 for computerroom hil e65

### DIFF
--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "2.4a2"
+__version__ = "2.4a3"

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "2.4a3"
+__version__ = "2.4a4"

--- a/cea/interfaces/arcgis/install_toolbox.py
+++ b/cea/interfaces/arcgis/install_toolbox.py
@@ -64,7 +64,7 @@ def get_arcgis_paths():
     except WindowsError:
         key = _winreg.OpenKey(registry, r"SOFTWARE\ESRI\Desktop%s" % arcgis_version)
     install_dir, _ = _winreg.QueryValueEx(key, 'InstallDir')
-    paths = [os.path.join(install_dir, 'bin'),
+    paths = [os.path.join(install_dir, 'bin64'),
             os.path.join(install_dir, 'arcpy'),
             os.path.join(install_dir, 'scripts')]
     return paths

--- a/cea/resources/radiation_arcgis/radiation.py
+++ b/cea/resources/radiation_arcgis/radiation.py
@@ -414,7 +414,12 @@ def run_script_in_subprocess(script_name, *args):
     command = [get_python_exe(), '-u', script_full_path]
     command.extend(map(str, args))
     print(command)
-    process = subprocess.Popen(command, startupinfo=startupinfo, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    env = os.environ.copy()
+    env['PATH'] = ';'.join((r'c:\Python27\ArcGISx6410.5', env['PATH']))
+
+    process = subprocess.Popen(command, startupinfo=startupinfo, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                               env=env)
     while True:
         next_line = process.stdout.readline()
         if next_line == '' and process.poll() is not None:


### PR DESCRIPTION
@JIMENOFONSECA includes changes necessary to get CEA to run with 64bit Python in the ArcGIS environment for the HIL E65 computerroom. Also, upgrade to ArcGIS Desktop 10.5 and 64bit background processing.