### PR TITLE
steps to avoid Nan's and 0K temperature values

### DIFF
--- a/cea/optimization/constants.py
+++ b/cea/optimization/constants.py
@@ -319,3 +319,5 @@ DeltaP_Coeff = 104.81
 DeltaP_Origin = 59016
 
 Subst_n = 20  # Lifetime after A+W default 20
+
+ZERO_DEGREES_CELSIUS_IN_KELVIN = 273.15  # Use this value, where the default temperature is assigned as 0 degree C

--- a/cea/optimization/master/summarize_network.py
+++ b/cea/optimization/master/summarize_network.py
@@ -202,7 +202,7 @@ def calc_temp_withlosses(t0, Q, m, cp, case):
         else:
             t1 = t0 - Q / (m * cp)
     else:
-        t1 = 0
+        t1 = 273
     return t1
 
 def calc_return_temp(sum_t_m, sum_m):
@@ -219,7 +219,7 @@ def calc_return_temp(sum_t_m, sum_m):
     if sum_m > 0:
         tr = sum_t_m / sum_m
     else:
-        tr = 0
+        tr = 273
     return tr
 
 
@@ -246,7 +246,7 @@ def calc_supply_temp(tr, Q, m, cp, case):
         else:
             ts = tr - Q / (m * cp)
     else:
-        ts = 0
+        ts = 273
     return ts
 
 #============================

--- a/cea/optimization/master/summarize_network.py
+++ b/cea/optimization/master/summarize_network.py
@@ -179,31 +179,31 @@ def network_main(locator, total_demand, building_names, config, gv, key):
 # Supply and return temperatures
 # ============================
 
-def calc_temp_withlosses(t0, Q, m, cp, case):
+def calc_temp_withlosses(t0_K, Q_W, m_kgpers, cp, case):
     """
     This function calculates the new temperature of the distribution including losses
 
-    :param t0: current distribution temperature
-    :param Q: load including thermal losses
-    :param m: mass flow rate
+    :param t0_K: current distribution temperature
+    :param Q_W: load including thermal losses
+    :param m_kgpers: mass flow rate
     :param cp: specific heat capacity
     :param case: "positive": if there is an addition to the losses, :negative" otherwise
-    :type t0: float
-    :type Q: float
-    :type m: float
+    :type t0_K: float
+    :type Q_W: float
+    :type m_kgpers: float
     :type cp: float
     :type case: string
     :return: t1: new temperature of the distribution accounting for thermal losses in the grid
     :rtype: float
     """
-    if m > 0:
+    if m_kgpers > 0:
         if case == "positive":
-            t1 = t0 + Q / (m * cp)
+            t1_K = t0_K + Q_W / (m_kgpers * cp)
         else:
-            t1 = t0 - Q / (m * cp)
+            t1_K = t0_K - Q_W / (m_kgpers * cp)
     else:
-        t1 = 273
-    return t1
+        t1_K = ZERO_DEGREES_CELSIUS_IN_KELVIN
+    return t1_K
 
 def calc_return_temp(sum_t_m, sum_m):
     """
@@ -217,10 +217,10 @@ def calc_return_temp(sum_t_m, sum_m):
     :rtype: float
     """
     if sum_m > 0:
-        tr = sum_t_m / sum_m
+        tr_K = sum_t_m / sum_m
     else:
-        tr = 273
-    return tr
+        tr_K = ZERO_DEGREES_CELSIUS_IN_KELVIN
+    return tr_K
 
 
 def calc_supply_temp(tr, Q, m, cp, case):
@@ -242,31 +242,31 @@ def calc_supply_temp(tr, Q, m, cp, case):
     """
     if m > 0:
         if case == "DH":
-            ts = tr + Q / (m * cp)
+            ts_K = tr + Q / (m * cp)
         else:
-            ts = tr - Q / (m * cp)
+            ts_K = tr - Q / (m * cp)
     else:
-        ts = 273
-    return ts
+        ts_K = ZERO_DEGREES_CELSIUS_IN_KELVIN
+    return ts_K
 
 #============================
 # Thermal losses
 #============================
 
-def calc_piping_thermal_losses(Tnet, mmax, mmin, L, Tg, K, cp):
+def calc_piping_thermal_losses(Tnet_K, m_max_kgpers, m_min_kgpers, L, Tg, K, cp):
     """
     This function estimates the average thermal losses of a distribution for an hour of the year
 
-    :param Tnet: current temperature of the pipe
-    :param mmax: maximum mass flow rate in the pipe
-    :param mmin: minimum mass flow rate in the pipe
+    :param Tnet_K: current temperature of the pipe
+    :param m_max_kgpers: maximum mass flow rate in the pipe
+    :param m_min_kgpers: minimum mass flow rate in the pipe
     :param L: length of the pipe
     :param Tg: ground temperature
     :param K: linear transmittance coefficient (it accounts for insulation and pipe diameter)
     :param cp: specific heat capacity
-    :type Tnet: float
-    :type mmax: float
-    :type mmin: float
+    :type Tnet_K: float
+    :type m_max_kgpers: float
+    :type m_min_kgpers: float
     :type L: float
     :type Tg: float
     :type K: float
@@ -274,10 +274,10 @@ def calc_piping_thermal_losses(Tnet, mmax, mmin, L, Tg, K, cp):
     :return: Qloss: thermal lossess in the pipe.
     :rtype: float
     """
-    if mmin != 1E6:  # control variable see function fn.calc_min_flow
-        mavg = (mmax + mmin) / 2
-        Tx = Tg + (Tnet - Tg) * math.exp(-K * L / (mavg * cp))
-        Qloss = (Tnet - Tx) * mavg * cp
+    if m_min_kgpers != 1E6:  # control variable see function fn.calc_min_flow
+        mavg = (m_max_kgpers + m_min_kgpers) / 2
+        Tx = Tg + (Tnet_K - Tg) * math.exp(-K * L / (mavg * cp))
+        Qloss = (Tnet_K - Tx) * mavg * cp
     else:
         Qloss = 0
     return Qloss

--- a/cea/optimization/slave/least_cost.py
+++ b/cea/optimization/slave/least_cost.py
@@ -190,7 +190,7 @@ def least_cost_main(locator, master_to_slave_vars, solar_features, gv, prices):
                     E_coldsource_HPSew_W = float(Q_HPSew_cold_primary_W)
 
                 if (
-                MS_Var.GHP_on) == 1 and hour >= MS_Var.GHP_SEASON_ON and hour <= MS_Var.GHP_SEASON_OFF and Q_therm_req_W > 0:
+                MS_Var.GHP_on) == 1 and hour >= MS_Var.GHP_SEASON_ON and hour <= MS_Var.GHP_SEASON_OFF and Q_therm_req_W > 0 and tdhsup_K != tdhret_req_K:
                     # activating GHP plant if possible
 
                     srcGHP = 0
@@ -219,7 +219,7 @@ def least_cost_main(locator, master_to_slave_vars, solar_features, gv, prices):
                     E_GHP_req_W = E_GHP_req_W
                     E_coldsource_GHP_W = Q_GHP_cold_primary_W
 
-                if (MS_Var.HP_Lake_on) == 1 and Q_therm_req_W > 0 and HPLake_allowed == 1:  # run Heat Pump Lake
+                if (MS_Var.HP_Lake_on) == 1 and Q_therm_req_W > 0 and HPLake_allowed == 1 and tdhsup_K != tdhret_req_K:  # run Heat Pump Lake
                     sHPLake = 0
                     costHPLake = 0
                     Q_HPLake_gen_W = 0

--- a/cea/optimization/slave/least_cost.py
+++ b/cea/optimization/slave/least_cost.py
@@ -190,7 +190,7 @@ def least_cost_main(locator, master_to_slave_vars, solar_features, gv, prices):
                     E_coldsource_HPSew_W = float(Q_HPSew_cold_primary_W)
 
                 if (
-                MS_Var.GHP_on) == 1 and hour >= MS_Var.GHP_SEASON_ON and hour <= MS_Var.GHP_SEASON_OFF and Q_therm_req_W > 0 and tdhsup_K != tdhret_req_K:
+                MS_Var.GHP_on) == 1 and hour >= MS_Var.GHP_SEASON_ON and hour <= MS_Var.GHP_SEASON_OFF and Q_therm_req_W > 0 and not np.isclose(tdhsup_K, tdhret_req_K):
                     # activating GHP plant if possible
 
                     srcGHP = 0
@@ -219,7 +219,7 @@ def least_cost_main(locator, master_to_slave_vars, solar_features, gv, prices):
                     E_GHP_req_W = E_GHP_req_W
                     E_coldsource_GHP_W = Q_GHP_cold_primary_W
 
-                if (MS_Var.HP_Lake_on) == 1 and Q_therm_req_W > 0 and HPLake_allowed == 1 and tdhsup_K != tdhret_req_K:  # run Heat Pump Lake
+                if (MS_Var.HP_Lake_on) == 1 and Q_therm_req_W > 0 and HPLake_allowed == 1 and not np.isclose(tdhsup_K, tdhret_req_K):  # run Heat Pump Lake
                     sHPLake = 0
                     costHPLake = 0
                     Q_HPLake_gen_W = 0


### PR DESCRIPTION
While running optimization for a higher number of generations, there is a chance where the COP becomes negative and which in turn leads to negative costs. This was being caused because of the default values of temperatures in networks (in Kelvin) being '0'. Now I changed it to '273' (which is the default 0 in degree C). This fixed the issue of having negative costs and emissions. Also, while I was at it, fixed few loops where the denominator can become '0' and thus raising Nan's. These observations were not found prior because they occur once or twice in 1000 samples.