### PR TITLE
Use appropriate InputLocator to list building names

### DIFF
--- a/cea/demand/building_properties.py
+++ b/cea/demand/building_properties.py
@@ -312,7 +312,7 @@ class BuildingProperties(object):
         envelope['Aroof'] = np.nan
 
         # call all building geometry files in a loop
-        for building_name in envelope.index:
+        for building_name in locator.get_zone_building_names():
             geometry_data = pd.read_csv(locator.get_radiation_metadata(building_name))
             geometry_data_sum = geometry_data.groupby(by='TYPE').sum()
             # do this in case the daysim radiation file did not included window
@@ -700,12 +700,12 @@ def get_prop_solar(locator, prop_rc_model, prop_envelope, gv, use_daysim_radiati
         list_Isol = []
 
         # for every building
-        for building_name in prop_envelope.index:
+        for building_name in locator.get_zone_building_names():
             I_sol = calc_Isol_daysim(building_name, locator, prop_envelope, prop_rc_model, thermal_resistance_surface,
                                      window_frame_fraction)
             list_Isol.append(I_sol)
 
-        result = pd.DataFrame({'Name': prop_envelope.index, 'I_sol': list_Isol})
+        result = pd.DataFrame({'Name': list(locator.get_zone_building_names()), 'I_sol': list_Isol})
 
     elif not use_daysim_radiation:
 


### PR DESCRIPTION
Building names in building_properties.py were being listed by using `envelope.index` instead of the appropriate input locator (`locator.get_zone_building_names()`). This created problems in certain cases, so it needed to be fixed.