### PR TITLE
I1128 fix demand output

### DIFF
--- a/cea/default.config
+++ b/cea/default.config
@@ -140,7 +140,7 @@ buildings.category = Advanced
 
 loads-output =
 loads-output.type = MultiChoiceParameter
-loads-output.choices = QEf, QHf, QCf, Ef, Qhsf, Qhs, Qhsf_lat, Qwwf, Qww, Qcsf, Qcs, Qcsf_lat, Qcdataf, Qcref, Qhprof, Edataf, Ealf, Eaf, Elf, Eref, Eauxf, Eauxf_ve, Eauxf_hs, Eauxf_cs, Eauxf_ww, Eauxf_fw, Eprof, Ecaf, Egenf_cs, Qgain_light, Qgain_app, Qgain_pers, Qgain_data, Qgain_base, Qgain_roof, Qgain_vent, Qgain_wall, Qgain_wind, I_sol, I_rad
+loads-output.choices = QEf, QHf, QCf, Ef, Egenf_cs, Qhs_sen_shu, Qhs_sen_ahu, Qhs_lat_ahu, Qhs_sen_aru, Qhs_lat_aru, Qhs_sen_sys, Qhs_lat_sys, Qhs_em_ls, Qhs_dis_ls, Qhs, Qhsf, Qhsf_lat, Qwwf, Qww, Qhsf_shu, Qhsf_ahu, Qhsf_aru, Qcdataf, Qcref, Qcs_sen_scu, Qcs_sen_ahu, Qcsf_scu, Qcsf_ahu, Qcsf_aru, Qcs_lat_ahu, Qcs_sen_aru, Qcs_lat_aru, Qcs_sen_sys, Qcs_lat_sys, Qcs_em_ls, Qcs_dis_ls, Qcsf, Qcs, Qcsf_lat, Qhprof, Edataf, Ealf, Eaf, Elf, Eref, Eauxf, Eauxf_ve, Eauxf_hs, Eauxf_cs, Eauxf_ww, Eauxf_fw, Eprof, Ecaf, Egenf_cs, Q_gain_sen_app, Q_gain_sen_light, Q_gain_sen_peop, Q_gain_sen_data, Q_loss_sen_ref, Q_gain_sen_env, Q_gain_sen_vent, Q_gain_sen_wind, I_sol, I_rad, Q_gain_lat_peop, mcpwwf, mcpdataf, mcpref, mcptw, mcpcsf_ahu, mcpcsf_aru, mcpcsf_scu, mcphsf_ahu, mcphsf_aru, mcphsf_shu, mcpcsf, mcphsf, Twwf_sup, T_int, T_ext, Twwf_re, Tcdataf_re, Tcdataf_sup, Tcref_re, Tcref_sup, Tcsf_re_ahu, Tcsf_re_aru, Tcsf_re_scu, Tcsf_sup_ahu, Tcsf_sup_aru, Tcsf_sup_scu, Thsf_re_ahu, Thsf_re_aru, Thsf_re_shu, Thsf_sup_ahu, Thsf_sup_aru, Thsf_sup_shu, Thsf_sup, Tcsf_sup, Thsf_re, Tcsf_re, Name, Af_m2, Aroof_m2, GFA_m2, people0
 loads-output.help = a list of loads to run the simulation for - leave blank to simulate all loads in demand_writers
 loads-output.category = Advanced
 

--- a/cea/default.config
+++ b/cea/default.config
@@ -140,19 +140,19 @@ buildings.category = Advanced
 
 loads-output =
 loads-output.type = MultiChoiceParameter
-loads-output.choices = QEf, QHf, QCf, Ef, Egenf_cs, Qhs_sen_shu, Qhs_sen_ahu, Qhs_lat_ahu, Qhs_sen_aru, Qhs_lat_aru, Qhs_sen_sys, Qhs_lat_sys, Qhs_em_ls, Qhs_dis_ls, Qhs, Qhsf, Qhsf_lat, Qwwf, Qww, Qhsf_shu, Qhsf_ahu, Qhsf_aru, Qcdataf, Qcref, Qcs_sen_scu, Qcs_sen_ahu, Qcsf_scu, Qcsf_ahu, Qcsf_aru, Qcs_lat_ahu, Qcs_sen_aru, Qcs_lat_aru, Qcs_sen_sys, Qcs_lat_sys, Qcs_em_ls, Qcs_dis_ls, Qcsf, Qcs, Qcsf_lat, Qhprof, Edataf, Ealf, Eaf, Elf, Eref, Eauxf, Eauxf_ve, Eauxf_hs, Eauxf_cs, Eauxf_ww, Eauxf_fw, Eprof, Ecaf, Egenf_cs, Q_gain_sen_app, Q_gain_sen_light, Q_gain_sen_peop, Q_gain_sen_data, Q_loss_sen_ref, Q_gain_sen_env, Q_gain_sen_vent, Q_gain_sen_wind, I_sol, I_rad, Q_gain_lat_peop, mcpwwf, mcpdataf, mcpref, mcptw, mcpcsf_ahu, mcpcsf_aru, mcpcsf_scu, mcphsf_ahu, mcphsf_aru, mcphsf_shu, mcpcsf, mcphsf, Twwf_sup, T_int, T_ext, Twwf_re, Tcdataf_re, Tcdataf_sup, Tcref_re, Tcref_sup, Tcsf_re_ahu, Tcsf_re_aru, Tcsf_re_scu, Tcsf_sup_ahu, Tcsf_sup_aru, Tcsf_sup_scu, Thsf_re_ahu, Thsf_re_aru, Thsf_re_shu, Thsf_sup_ahu, Thsf_sup_aru, Thsf_sup_shu, Thsf_sup, Tcsf_sup, Thsf_re, Tcsf_re, Name, Af_m2, Aroof_m2, GFA_m2, people0
+loads-output.choices = QEf, QHf, QCf, Ef, Egenf_cs, Qhs_sen_shu, Qhs_sen_ahu, Qhs_lat_ahu, Qhs_sen_aru, Qhs_lat_aru, Qhs_sen_sys, Qhs_lat_sys, Qhs_em_ls, Qhs_dis_ls, Qhs, Qhsf, Qhsf_lat, Qwwf, Qww, Qhsf_shu, Qhsf_ahu, Qhsf_aru, Qcdataf, Qcref, Qcs_sen_scu, Qcs_sen_ahu, Qcsf_scu, Qcsf_ahu, Qcsf_aru, Qcs_lat_ahu, Qcs_sen_aru, Qcs_lat_aru, Qcs_sen_sys, Qcs_lat_sys, Qcs_em_ls, Qcs_dis_ls, Qcsf, Qcs, Qcsf_lat, Qhprof, Edataf, Ealf, Eaf, Elf, Eref, Eauxf, Eauxf_ve, Eauxf_hs, Eauxf_cs, Eauxf_ww, Eauxf_fw, Eprof, Ecaf, Egenf_cs, Q_gain_sen_app, Q_gain_sen_light, Q_gain_sen_peop, Q_gain_sen_data, Q_loss_sen_ref, Q_gain_sen_env, Q_gain_sen_vent, Q_gain_sen_wind, I_sol, I_rad, Q_gain_lat_peop
 loads-output.help = a list of loads to run the simulation for - leave blank to simulate all loads in demand_writers
 loads-output.category = Advanced
 
 massflows-output =
 massflows-output.type = MultiChoiceParameter
-massflows-output.choices = mcphsf, mcpcsf, mcpwwf, mcpdataf, mcpref, mcptw
+massflows-output.choices = mcpwwf, mcpdataf, mcpref, mcptw, mcpcsf_ahu, mcpcsf_aru, mcpcsf_scu, mcphsf_ahu, mcphsf_aru, mcphsf_shu, mcpcsf, mcphsf
 massflows-output.help = a list of massflowrates to run the simulation for - leave blank to simulate all massflows in demand_writers
 massflows-output.category = Advanced
 
 temperatures-output =
 temperatures-output.type = MultiChoiceParameter
-temperatures-output.choices = Twwf_sup, T_int, T_ext, Twwf_re, Thsf_sup, Thsf_re, Tcsf_sup, Tcsf_re, Tcdataf_re, Tcdataf_sup, Tcref_re, Tcref_sup
+temperatures-output.choices =   Twwf_sup, T_int, T_ext, Twwf_re, Tcdataf_re, Tcdataf_sup, Tcref_re, Tcref_sup, Tcsf_re_ahu, Tcsf_re_aru, Tcsf_re_scu, Tcsf_sup_ahu, Tcsf_sup_aru, Tcsf_sup_scu, Thsf_re_ahu, Thsf_re_aru, Thsf_re_shu, Thsf_sup_ahu, Thsf_sup_aru, Thsf_sup_shu, Thsf_sup, Tcsf_sup, Thsf_re, Tcsf_re
 temperatures-output.help = a list of temperatures to run the simulation for - leave blank to simulate all temperatures in demand_writers
 temperatures-output.category = Advanced
 

--- a/cea/demand/demand_writers.py
+++ b/cea/demand/demand_writers.py
@@ -29,7 +29,7 @@ class DemandWriter(object):
             self.load_vars = ['QEf', 'QHf', 'QCf', 'Ef', 'Egenf_cs', 'Qhs_sen_shu', 'Qhs_sen_ahu', 'Qhs_lat_ahu',
                               'Qhs_sen_aru', 'Qhs_lat_aru', 'Qhs_sen_sys', 'Qhs_lat_sys', 'Qhs_em_ls', 'Qhs_dis_ls',
                               'Qhs', 'Qhsf', 'Qhsf_lat', 'Qwwf', 'Qww', 'Qhsf_shu', 'Qhsf_ahu', 'Qhsf_aru',
-                              'Qcs', 'Qcdataf', 'Qcref', 'Qcs_sen_scu', 'Qcs_sen_ahu',
+                              'Qcdataf', 'Qcref', 'Qcs_sen_scu', 'Qcs_sen_ahu',
                               'Qcsf_scu', 'Qcsf_ahu', 'Qcsf_aru',
                               'Qcs_lat_ahu', 'Qcs_sen_aru', 'Qcs_lat_aru', 'Qcs_sen_sys', 'Qcs_lat_sys', 'Qcs_em_ls',
                               'Qcs_dis_ls', 'Qcsf', 'Qcs', 'Qcsf_lat', 'Qhprof', 'Edataf', 'Ealf', 'Eaf', 'Elf',

--- a/cea/demand/demand_writers.py
+++ b/cea/demand/demand_writers.py
@@ -45,7 +45,8 @@ class DemandWriter(object):
         if not massflows:
             self.mass_flow_vars = ['mcpwwf', 'mcpdataf', 'mcpref', 'mcptw',
                                    'mcpcsf_ahu', 'mcpcsf_aru', 'mcpcsf_scu',
-                                   'mcphsf_ahu', 'mcphsf_aru', 'mcphsf_shu']
+                                   'mcphsf_ahu', 'mcphsf_aru', 'mcphsf_shu',
+                                   'mcpcsf', 'mcphsf']
         else:
             self.mass_flow_vars = massflows
 


### PR DESCRIPTION
The variables `mcpcsf_kWperC` and `mcphsf_kWperC` reintroduced to demand output `.csv`.

Valid choices updated in the `default.config` file.