### PR TITLE
Minor changes to Windows install

### DIFF
--- a/docs/installation-guide-ubuntu.rst
+++ b/docs/installation-guide-ubuntu.rst
@@ -11,7 +11,7 @@ Prerequisites
 #. Download and install `Github Desktop (64-bit) <https://desktop.github.com/>`__.
 #. Download and install `Anaconda (64-bit) for python 2.7 <https://www.anaconda.com/download/>`__.
    OR `Miniconda(64-bit) for python 2.7 <https://conda.io/miniconda.html>`__.
-#. Download and install `Pycharm Community edition (64-bit) <https://www.anaconda.com/download/>`__.
+#. Download and install `Pycharm Community edition (64-bit) <https://www.jetbrains.com/pycharm/download/#section=windows>`__.
    OR your own favorite editor.
 #. Download and install `Daysim <https://daysim.ning.com/page/download>`__.
 

--- a/docs/installation-on-windows.rst
+++ b/docs/installation-on-windows.rst
@@ -11,7 +11,7 @@ Prerequisites
 #. Download and install `Github Desktop (64-bit) <https://desktop.github.com/>`__.
 #. Download and install `Anaconda (64-bit) for python 2.7 <https://www.anaconda.com/download/>`__.
    OR `Miniconda(64-bit) for python 2.7 <https://conda.io/miniconda.html>`__.
-#. Download and install `Pycharm Community edition (64-bit) <https://www.anaconda.com/download/>`__.
+#. Download and install `Pycharm Community edition (64-bit) <https://www.jetbrains.com/pycharm/download/#section=windows>`__.
    OR your own favorite editor.
 #. Download and install `Daysim <https://daysim.ning.com/page/download>`__.
 #. Download and install  ArcGIS 10.5 - only if you would like to use ArcGIS visuals.
@@ -19,11 +19,13 @@ Prerequisites
 Installation
 ~~~~~~~~~~~~
 
+#. Open Github Desktop from the start menu.
+#. Press Ctrl+Shift+O (clone repository) and select the URL tab.
+#. Paste the CEA Github address: https://github.com/architecture-building-systems/CityEnergyAnalyst
+#. Click Clone
 #. Open Anaconda prompt (terminal console) from the start menu.
-#. Type ``cd Documents`` and press ENTER.
-#. Type ``git clone https://github.com/architecture-building-systems/CityEnergyAnalyst.git`` and press ENTER.
-#. Type ``cd Documents\CityEnergyAnalyst`` and press ENTER.
-#. Type ``conda env create`` and press ENTER.and ``activate cea``
+#. Type ``cd Documents\Github\CityEnergyAnalyst`` and press ENTER.
+#. Type ``conda env create`` and press ENTER.
 #. Type ``activate cea`` and press ENTER.
 #. Type ``pip install -e .[dev]`` and press ENTER (mind the dot '.' included in this comand!).
 #. Type ``cea install-toolbox`` and press ENTER.
@@ -32,17 +34,18 @@ Configure of Pycharm
 ~~~~~~~~~~~~~~~~~~~~
 
 #. Open PyCharm from the start menu and open project CityEnergyAnalyst (stored where you downloaded CEA (/Documents).
-#. Open File>Settings>Project:CityEnergyAnalyst>Project Interpreter>Project Interpreter.
-#. Click on the settings button (it looks like a wheel), and click in Addlocal.
+#. Open *File>Settings>Project:CityEnergyAnalyst>Project Interpreter>Project Interpreter*.
+#. Click on the settings button (it looks like a wheel) next to the current interpreter path, and click Add.
+#. Click ``Conda Environment`` from the left hand list and select existing environment.
 #. Point to the location of your conda environment. It should look something like
    ``C:\Users\your_name\Anaconda2\envs\cea\python.exe`` or
    ``C:\Users\your_name\AppData\Local\conda\conda\envs\cea\python.exe``.
    Where 'your_name' represents your user name in windows.
 #. Click apply changes.
-#. Now add your conda environment ``C:\Users\your_name\Anaconda2\envs\cea``
-   to your environment variable ``PATH``. The environment variable is located
-   under Environment Variables in the tab Advanced in System Properties in the Control Panel.
-#. Restart PyCharm if open.
+#. Open **cmd.exe** from the start menu.
+#. Type ``cd *conda2\envs\cea`` and hit ENTER.
+#. Type ``set PATH=%PATH%;%CD%`` and hit ENTER.
+#. Close cmd.exe and restart PyCharm if open.
 
 .. note:: We advise to follow the above guide precisely. Especially the ``conda env create`` command can trip up users
     with previous experience in Anaconda / Miniconda as it looks very similar to the ``conda create`` command often

--- a/docs/installation-on-windows.rst
+++ b/docs/installation-on-windows.rst
@@ -30,8 +30,8 @@ Installation
 #. Type ``pip install -e .[dev]`` and press ENTER (mind the dot '.' included in this comand!).
 #. Type ``cea install-toolbox`` and press ENTER.
 
-Configure of Pycharm
-~~~~~~~~~~~~~~~~~~~~
+Configuration of Pycharm
+~~~~~~~~~~~~~~~~~~~~~~~
 
 #. Open PyCharm from the start menu and open project CityEnergyAnalyst (stored where you downloaded CEA (/Documents).
 #. Open *File>Settings>Project:CityEnergyAnalyst>Project Interpreter>Project Interpreter*.


### PR DESCRIPTION
I have updated the clone process of github repos to operate through the github desktop app rather than conda prompt. this will setup github desktop as well as clone the repos.

i have also updated pycharm set up slightly to reflect new interface and have updated path via cmd to avoid any confusion.

finally i have changed the link for pycharm from anaconda home page to jetbrains dl address for both ubuntu and windows install docs.