### PR TITLE
1225 - Fix arcgis interface folder path pop-up

### DIFF
--- a/cea/config.py
+++ b/cea/config.py
@@ -329,6 +329,25 @@ class FileParameter(Parameter):
         except ConfigParser.NoOptionError:
             self._direction = 'input'
 
+        try:
+            self.nullable = parser.getboolean(self.section.name, self.name + '.nullable')
+        except ConfigParser.NoOptionError:
+            self.nullable = False
+
+    def encode(self, value):
+        if value is None:
+            if self.nullable:
+                return ''
+            else:
+                raise ValueError("Can't encode None for non-nullable FileParameter %s." % self.name)
+        return str(value)
+
+    def decode(self, value):
+        if not value and not self.nullable:
+            raise ValueError("Can't decode value for non-nullable FileParameter %s." % self.name)
+        else:
+            return value
+
 
 class JsonParameter(Parameter):
     """A parameter that gets / sets JSON data (useful for dictionaries, lists etc.)"""

--- a/cea/default.config
+++ b/cea/default.config
@@ -740,20 +740,26 @@ occupancy-types.help = a list of input variables to calibrate to (they refer to 
 occupancy-types.category = Advanced
 
 zone = {general:scenario}/inputs/building-geometry/zone.shp
-zone.type = PathParameter
+zone.type = FileParameter
+zone.extensions = shp
 zone.help = Path to the filename including geometry properties of buildings.
 
 district =
-district.type = StringParameter
+district.type = FileParameter
+district.extensions = shp
+district.nullable = true
 district.help = Path to the filename including geometry properties of buildings and surroundings. Leave empty if you do not want to consider shading effects.
 
 terrain = {general:scenario}/inputs/topography/terrain.tif
-terrain.type = PathParameter
+terrain.type = FileParameter
+terrain.extensions = tif tiff
 terrain.help = Path to the filename including a digital elevation model of the terrain
 
 streets =
-district.type = StringParameter
-district.help = Path to the filename including geometry streets. Leaave empty if you do not want to optimize a district heating or cooling network
+streets.type = FileParameter
+streets.extensions = shp
+streets.nullable = true
+streets.help = Path to the filename including geometry streets. Leave empty if you do not want to optimize a district heating or cooling network
 
 output-path = {general:scenario}/../..
 output-path.type = PathParameter

--- a/cea/interfaces/arcgis/arcgishelper.py
+++ b/cea/interfaces/arcgis/arcgishelper.py
@@ -386,6 +386,9 @@ class FileParameterInfoBuilder(ParameterInfoBuilder):
             parameter.filter.list = self.cea_parameter._extensions
         else:
             parameter.direction = 'Output'
+
+        if hasattr(self.cea_parameter, 'nullable') and self.cea_parameter.nullable:
+            parameter.parameterType = 'Optional'
         return parameter
 
 


### PR DESCRIPTION
This PR updates the `default.config` file to use `FileParameter` instead of `PathParameter` and `StringParameter` for the files used by `cea create-new-project`. The `cea/config.py` and `cea/interfaces/arcgis/arcgishelper.py` files were updated to allow `FileParameter` parameters to be "nullable" / optional.

Testing would ideally include trying out more than just this tool - especially other tools that use `FileParameter`.