### PR TITLE
import all functions from math library

### DIFF
--- a/cea/technologies/solar/photovoltaic.py
+++ b/cea/technologies/solar/photovoltaic.py
@@ -15,7 +15,7 @@ import pandas as pd
 from scipy import interpolate
 import cea.globalvar
 import cea.inputlocator
-import math
+from math import *
 from cea.utilities import epwreader
 from cea.utilities import solar_equations
 from cea.technologies.solar import constants

--- a/cea/utilities/solar_equations.py
+++ b/cea/utilities/solar_equations.py
@@ -8,7 +8,8 @@ import pandas as pd
 import ephem
 import datetime
 import collections
-from math import degrees, radians, cos, acos, tan, atan, sin, asin, pi
+from math import *
+#from math import degrees, radians, cos, acos, tan, atan, sin, asin, pi
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2015, Architecture and Building Systems - ETH Zurich"


### PR DESCRIPTION
this PR resolves #1278  
the `degrees` and `radians` functions from the math library is properly imported from the math library now 

to test, run `photovoltac.py` and `photovoltaic_thermal.py` with the reference case, or any test case you are running currently.