### PR TITLE
i1192-i1286-clean-total-demands-fixed-comfort-plot

### DIFF
--- a/cea/demand/demand_writers.py
+++ b/cea/demand/demand_writers.py
@@ -111,7 +111,7 @@ class DemandWriter(object):
         # treating time series data of loads from W to kW
         data = dict((x + '_kWh', np.nan_to_num(tsd[x]) / 1000) for x in self.load_vars)  # TODO: convert nan to num at the very end.
         # treating time series data of loads from W to kW
-        data = dict((x + '_kWh', np.nan_to_num(tsd[x]) / 1000) for x in self.load_plotting_vars)  # TODO: convert nan to num at the very end.
+        data.update(dict((x + '_kWh', np.nan_to_num(tsd[x]) / 1000) for x in self.load_plotting_vars))  # TODO: convert nan to num at the very end.
         # treating time series data of mass_flows from W/C to kW/C
         data.update(dict((x + '_kWperC', np.nan_to_num(tsd[x]) / 1000) for x in self.mass_flow_vars))  # TODO: convert nan to num at the very end.
         # treating time series data of temperatures from W/C to kW/C

--- a/cea/demand/demand_writers.py
+++ b/cea/demand/demand_writers.py
@@ -38,11 +38,12 @@ class DemandWriter(object):
                               'Qcs_dis_ls', 'Qcsf', 'Qcs', 'Qcsf_lat', 'Qhprof', 'Edataf', 'Ealf', 'Eaf', 'Elf',
                               'Eref', 'Eauxf', 'Eauxf_ve', 'Eauxf_hs', 'Eauxf_cs', 'Eauxf_ww', 'Eauxf_fw',
                               'Eprof', 'Ecaf', 'Egenf_cs']
-            self.load_vars.extend(TSD_KEYS_ENERGY_BALANCE_DASHBOARD)
-            self.load_vars.extend(TSD_KEYS_SOLAR)
 
         else:
             self.load_vars = loads
+
+        self.load_plotting_vars = TSD_KEYS_ENERGY_BALANCE_DASHBOARD
+        self.load_plotting_vars.extend(TSD_KEYS_SOLAR)
 
         if not massflows:
             self.mass_flow_vars = ['mcpwwf', 'mcpdataf', 'mcpref', 'mcptw',
@@ -109,6 +110,8 @@ class DemandWriter(object):
     def calc_hourly_dataframe(self, building_name, date, tsd):
         # treating time series data of loads from W to kW
         data = dict((x + '_kWh', np.nan_to_num(tsd[x]) / 1000) for x in self.load_vars)  # TODO: convert nan to num at the very end.
+        # treating time series data of loads from W to kW
+        data = dict((x + '_kWh', np.nan_to_num(tsd[x]) / 1000) for x in self.load_plotting_vars)  # TODO: convert nan to num at the very end.
         # treating time series data of mass_flows from W/C to kW/C
         data.update(dict((x + '_kWperC', np.nan_to_num(tsd[x]) / 1000) for x in self.mass_flow_vars))  # TODO: convert nan to num at the very end.
         # treating time series data of temperatures from W/C to kW/C
@@ -116,6 +119,7 @@ class DemandWriter(object):
         # get order of columns
         columns = ['Name', 'people', 'x_int']
         columns.extend([x + '_kWh' for x in self.load_vars])
+        columns.extend([x + '_kWh' for x in self.load_plotting_vars])
         columns.extend([x + '_kWperC' for x in self.mass_flow_vars])
         columns.extend([x + '_C' for x in self.temperature_vars])
         # add other default elements

--- a/cea/plots/demand/comfort_chart.py
+++ b/cea/plots/demand/comfort_chart.py
@@ -302,16 +302,20 @@ def calc_table(dict_graph):
                                                                  dict_graph['x_int_occupied_winter'],
                                                                  VERTICES_WINTER_COMFORT)
     winter_hours = len(dict_graph['t_op_occupied_winter'])
-    cell_winter_comfort = "{} ({:.0%})".format(count_winter_comfort, count_winter_comfort/winter_hours)
-    cell_winter_uncomfort = "{} ({:.0%})".format(count_winter_comfort, count_winter_uncomfort/winter_hours)
+    perc_winter_comfort = count_winter_comfort/winter_hours if winter_hours > 0 else 0
+    cell_winter_comfort = "{} ({:.0%})".format(count_winter_comfort, perc_winter_comfort)
+    perc_winter_uncomfort = count_winter_uncomfort / winter_hours if winter_hours > 0 else 0
+    cell_winter_uncomfort = "{} ({:.0%})".format(count_winter_uncomfort, perc_winter_uncomfort)
 
     # check summer comfort
     count_summer_comfort, count_summer_uncomfort = check_comfort(dict_graph['t_op_occupied_summer'],
                                                                  dict_graph['x_int_occupied_summer'],
                                                                  VERTICES_SUMMER_COMFORT)
     summer_hours = len(dict_graph['t_op_occupied_summer'])
-    cell_summer_comfort = "{} ({:.0%})".format(count_summer_comfort, count_summer_comfort/summer_hours)
-    cell_summer_uncomfort = "{} ({:.0%})".format(count_summer_comfort, count_summer_uncomfort/summer_hours)
+    perc_summer_comfort = count_summer_comfort / summer_hours if summer_hours > 0 else 0
+    cell_summer_comfort = "{} ({:.0%})".format(count_summer_comfort, perc_summer_comfort)
+    perc_summer_uncomfort = count_summer_uncomfort / summer_hours if summer_hours > 0 else 0
+    cell_summer_uncomfort = "{} ({:.0%})".format(count_summer_uncomfort, perc_summer_uncomfort)
 
     # draw table
     table = go.Table(domain=dict(x=[0.0, 1], y=[YAXIS_DOMAIN_GRAPH[1], 1.0]),


### PR DESCRIPTION
- removed unnecessary outputs from total demands (used only for building level energy balance plot)
- fixed comfort plot

fixes #1192 #1286 