### PR TITLE
fixes #1346 - Plot tool doesn't work on ArcScene

### DIFF
--- a/cea/interfaces/arcgis/arcgishelper.py
+++ b/cea/interfaces/arcgis/arcgishelper.py
@@ -428,8 +428,11 @@ def list_buildings(scenario):
     startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
     command = [get_python_exe(), '-u', '-m', 'cea.interfaces.arcgis.list_buildings', scenario]
-    buildings_string = subprocess.check_output(command, startupinfo=startupinfo)
-    return [b.strip() for b in buildings_string.split(',')]
+    try:
+        buildings_string = subprocess.check_output(command, startupinfo=startupinfo)
+        return [b.strip() for b in buildings_string.split(',')]
+    except subprocess.CalledProcessError:
+        return []
 
 
 BUILDERS = {  # dict[cea.config.Parameter, ParameterInfoBuilder]


### PR DESCRIPTION
To test:

- `cea install-toolbox`
- rename the scenario in your config file (like, add `.bak` to the end or something)
- refresh the `CityEnergyAnalyst.pyt`

Expect the toolbox to now work without an error.

Oh, BTW, while I was at it i did some profiling to make sure it's not our fault that loading the toolbox takes so long. It's not. It's in the arcpy stuff.