### PR TITLE
1321 arcgis interface plotting of scenario comparison not interactive

### DIFF
--- a/cea/config.py
+++ b/cea/config.py
@@ -475,8 +475,7 @@ class SubfoldersParameter(ListParameter):
 
     def initialize(self, parser):
         # allow the parent option to be set
-        self._parent_section, self._parent_option = parser.get(self.section.name,
-                                                               self.name + '.parent').split(':')
+        self._parent = parser.get(self.section.name, self.name + '.parent')
 
     def decode(self, value):
         """Only return the folders that exist"""
@@ -484,7 +483,7 @@ class SubfoldersParameter(ListParameter):
         return [folder for folder in folders if folder in self.get_folders()]
 
     def get_folders(self):
-        parent = self.config.sections[self._parent_section].parameters[self._parent_option].get()
+        parent = self.replace_references(self._parent)
         try:
             return [folder for folder in os.listdir(parent) if os.path.isdir(os.path.join(parent, folder))]
         except:
@@ -560,6 +559,7 @@ def parse_string_to_list(line):
 def main():
     """Run some tests on the configuration module"""
     config = Configuration()
+    print(config.plots.scenarios)
     print(config.general.scenario)
     print(config.general.multiprocessing)
     # print(config.demand.heating_season_start)

--- a/cea/default.config
+++ b/cea/default.config
@@ -227,7 +227,7 @@ project.help = Path to the folder containing the scenarios
 
 scenarios = baseline, scenario1, scenario2
 scenarios.type = SubfoldersParameter
-scenarios.parent = scenario-plots:project
+scenarios.parent = {scenario-plots:project}
 scenarios.help = List of scenarios to plot (subdirectories of the project)
 
 output-file = {scenario-plots:project}/scenario-plots.pdf
@@ -243,7 +243,7 @@ project.help = Path to the folder containing the scenarios
 
 scenarios = baseline, scenario1, scenario2
 scenarios.type = SubfoldersParameter
-scenarios.parent = benchmark-graphs:project
+scenarios.parent = {benchmark-graphs:project}
 scenarios.help = List of scenarios to plot (subdirectories of the project)
 
 output-file = {benchmark-graphs:project}/benchmark-graphs.pdf
@@ -708,7 +708,7 @@ isheating.help = if centralized heating is required in the neighborhood.
 [plots]
 scenarios = baseline, scenario_A, scenario_B
 scenarios.type = SubfoldersParameter
-scenarios.parent = general:scenario/..
+scenarios.parent = {general:scenario}/..
 scenarios.help = Path to scenarios to run for comparison graphs
 
 buildings =

--- a/cea/default.config
+++ b/cea/default.config
@@ -701,8 +701,9 @@ isheating.type = BooleanParameter
 isheating.help = if centralized heating is required in the neighborhood.
 
 [plots]
-scenarios = C:/reference-case-open/baseline, C:/reference-case-open/scenario_A, C:/reference-case-open/scenario_B
-scenarios.type = ListParameter
+scenarios = baseline, scenario_A, scenario_B
+scenarios.type = SubfoldersParameter
+scenarios.parent = general:scenario/..
 scenarios.help = Path to scenarios to run for comparison graphs
 
 buildings =

--- a/cea/default.config
+++ b/cea/default.config
@@ -16,6 +16,11 @@ multiprocessing = true
 multiprocessing.type = BooleanParameter
 multiprocessing.help = Multiprocessing for quicker calculation, if available.
 
+debug = false
+debug.type = BooleanParameter
+debug.help = Enable debugging-specific behaviors.
+degub.category = Advanced
+
 [data-helper]
 archetypes = comfort, architecture, HVAC, internal-loads, supply, restrictions
 archetypes.type = MultiChoiceParameter

--- a/cea/interfaces/arcgis/CityEnergyAnalyst.py
+++ b/cea/interfaces/arcgis/CityEnergyAnalyst.py
@@ -228,6 +228,14 @@ class PlotsTool(CeaTool):
             parameters['plots:buildings'].filter.list = buildings
             parameters['plots:buildings'].value = []
 
+        # find subfolders if scenario changes
+        config = cea.config.Configuration()
+        config.scenario = parameters['general:scenario'].valueAsText
+        subfolders = config.sections['plots'].parameters['scenarios'].get_folders()
+        if set(subfolders) != set(parameters['plots:scenarios'].filter.list):
+            parameters['plots:scenarios'].filter.list = subfolders
+            parameters['plots:scenarios'].value = []
+
 
 class HeatmapsTool(CeaTool):
     def __init__(self):

--- a/cea/interfaces/arcgis/install_toolbox.py
+++ b/cea/interfaces/arcgis/install_toolbox.py
@@ -5,7 +5,7 @@ import os.path
 import cea.config
 
 
-def main(_):
+def main(config):
     """
     Perform the following steps:
 
@@ -27,7 +27,7 @@ def main(_):
         os.makedirs(toolbox_folder)
     shutil.copy(find_toolbox_src(), toolbox_dst)
 
-    copy_library(toolbox_folder)
+    copy_library(toolbox_folder, debug=config.debug)
     copy_config(toolbox_folder)
     copy_inputlocator(toolbox_folder)
 
@@ -36,7 +36,7 @@ def main(_):
     print('toolbox installed.')
 
 
-def copy_library(toolbox_folder):
+def copy_library(toolbox_folder, debug=False):
     """Copy the library functions"""
     lib_dst_folder = os.path.join(toolbox_folder, 'cea', 'interfaces', 'arcgis')
     if not os.path.exists(lib_dst_folder):
@@ -63,7 +63,9 @@ def copy_library(toolbox_folder):
 
 
     # during development, copy this file too
-    #shutil.copy(os.path.join(lib_src_folder, 'test.pyt'), toolbox_folder)
+    if debug:
+        print('Copying test.pyt...')
+        shutil.copy(os.path.join(lib_src_folder, 'test.pyt'), toolbox_folder)
 
 
 def copy_config(toolbox_folder):

--- a/cea/interfaces/arcgis/test.pyt
+++ b/cea/interfaces/arcgis/test.pyt
@@ -37,6 +37,14 @@ class PlotsTool(CeaTool):
             parameters['plots:buildings'].filter.list = buildings
             parameters['plots:buildings'].value = []
 
+        # find subfolders if scenario changes
+        config = cea.config.Configuration()
+        config.scenario = parameters['general:scenario'].valueAsText
+        subfolders = config.sections['plots'].parameters['scenarios'].get_folders()
+        if set(subfolders) != set(parameters['plots:scenarios'].filter.list):
+            parameters['plots:scenarios'].filter.list = subfolders
+            parameters['plots:scenarios'].value = []
+
 
 if __name__ == '__main__':
     parameters = list(get_parameters('photovoltaic'))

--- a/cea/interfaces/cli/cli.config
+++ b/cea/interfaces/cli/cli.config
@@ -85,7 +85,7 @@ create-new-project = create-new-project
 optimization = general:scenario optimization
 sewage-heat-exchanger = general:scenario sewage
 thermal-network-matrix = general:scenario thermal-network
-plots =  general:scenario plots
+plots =  general:region general:scenario plots
 network-layout = general:scenario network-layout
 decentralized = general:scenario disconnected-cooling
 

--- a/cea/interfaces/cli/cli.config
+++ b/cea/interfaces/cli/cli.config
@@ -60,7 +60,7 @@ photovoltaic-thermal = general:scenario general:weather solar:date-start solar:t
                        solar:panel-on-roof solar:panel-on-wall solar:annual-radiation-threshold   solar:solar-window-solstice
                        solar:t-in-pvt solar:dpl solar:fcr solar:ro solar:eff-pumping solar:k-msc-max
 radiation-daysim = general:scenario general:weather general:multiprocessing radiation-daysim
-install-toolbox = 
+install-toolbox = general:debug
 install-grasshopper =
 heatmaps = general:scenario heatmaps:file-to-analyze heatmaps:analysis-fields
 operation-costs = general:scenario operation-costs

--- a/cea/plots/comparisons/main.py
+++ b/cea/plots/comparisons/main.py
@@ -30,7 +30,7 @@ __status__ = "Production"
 
 def plots_main(config):
     # local variables
-    scenarios = config.plots.scenarios
+    scenarios = [os.path.join(config.scenario, '..', scenario) for scenario in config.plots.scenarios]
 
     # initialize class
     plots = Plots(scenarios)


### PR DESCRIPTION
Fixes #1321 - text copied from there:

I ended up fixing it with a generalization of how the SubfoldersParameter works (the parent is now a folder with references substituted, instead of a link to a property itself). To test:

- `cea install-toolbox`
- run the plots tool
- changing the scenario folder will change the list of scenarios to choose from for comparison

NOTE: `cea install-toolbox --debug true` will install a `test.pyt` as well, that contains just the plots tool. a bit quicker to open. BUT: check with the `CityEnergyAnalyst.pyt`, as that is the one we need to test.