### PR TITLE
adding region to data-helper tool

### DIFF
--- a/cea/interfaces/cli/cli.config
+++ b/cea/interfaces/cli/cli.config
@@ -41,7 +41,7 @@ decentralized = cea.optimization.preprocessing.disconnected_building_main
 
 [config]
 demand = general:scenario general:weather general:multiprocessing demand
-data-helper = general:scenario data-helper
+data-helper = general:scenario general:region data-helper
 emissions = general:scenario emissions
 embodied-energy = general:scenario embodied-energy
 mobility = general:scenario


### PR DESCRIPTION
To test:

run `cea install-toolbox`, restart ArcGIS, check the `data-helper` tool. you should now be able to choose the region from the dropdown.