### PR TITLE
1390 arcgis interface should update the config file

### DIFF
--- a/cea/config.py
+++ b/cea/config.py
@@ -244,6 +244,7 @@ class Parameter(object):
         """
         self.name = name
         self.section = section
+        self.fqname = '%s:%s' % (section.name, self.name)
         self.config = config
         try:
             self.help = config.default_config.get(section.name, self.name + ".help", raw=True)

--- a/cea/interfaces/arcgis/CityEnergyAnalyst.py
+++ b/cea/interfaces/arcgis/CityEnergyAnalyst.py
@@ -29,10 +29,6 @@ __status__ = "Production"
 
 arcpy.env.overwriteOutput = True
 
-# I know this is bad form, but the locator will never really change, so I'm making it global to this file
-LOCATOR = cea.inputlocator.InputLocator(None)
-CONFIG = cea.config.Configuration(cea.config.DEFAULT_CONFIG)
-
 
 class Toolbox(object):
     """List the tools to show in the toolbox."""

--- a/cea/interfaces/arcgis/arcgishelper.py
+++ b/cea/interfaces/arcgis/arcgishelper.py
@@ -48,13 +48,9 @@ class CeaTool(object):
         return parameter_info
 
     def updateParameters(self, parameters):
-        # with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
-        #     f.write('on_dialog_show - data: %s\n' % ', '.join([str(p.hasBeenValidated) for p in parameters]))
         on_dialog_show = not any([p.hasBeenValidated for p in parameters])
         parameters = dict_parameters(parameters)
         config = cea.config.Configuration()
-        # with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
-        #     f.write('on_dialog_show: %s\n' % on_dialog_show)
         if on_dialog_show:
             # show the parameters as defined in the config file
             cea_parameters = {p.fqname: p for p in get_parameters(config, self.cea_tool)}

--- a/cea/interfaces/arcgis/arcgishelper.py
+++ b/cea/interfaces/arcgis/arcgishelper.py
@@ -33,7 +33,7 @@ class CeaTool(object):
         specially: it is represented as two parameter_infos, weather_name and weather_path."""
         config = cea.config.Configuration()
         parameter_infos = []
-        for parameter in get_parameters(self.cea_tool):
+        for parameter in get_parameters(config, self.cea_tool):
             if parameter.name == 'weather':
                 parameter_infos.extend(get_weather_parameter_info(config))
             else:
@@ -48,11 +48,28 @@ class CeaTool(object):
         return parameter_info
 
     def updateParameters(self, parameters):
+        # with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
+        #     f.write('on_dialog_show - data: %s\n' % ', '.join([str(p.hasBeenValidated) for p in parameters]))
+        on_dialog_show = not any([p.hasBeenValidated for p in parameters])
         parameters = dict_parameters(parameters)
-        if 'general:scenario' in parameters:
-            check_senario_exists(parameters)
-        if 'weather_name' in parameters:
-            update_weather_parameters(parameters)
+        config = cea.config.Configuration()
+        # with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
+        #     f.write('on_dialog_show: %s\n' % on_dialog_show)
+        if on_dialog_show:
+            # show the parameters as defined in the config file
+            cea_parameters = {p.fqname: p for p in get_parameters(config, self.cea_tool)}
+            for parameter_name in parameters.keys():
+                if parameter_name == 'weather_name':
+                    update_weather_parameters(parameters)
+                elif parameter_name == 'weather_path':
+                    continue
+                else:
+                    parameters[parameter_name].value = cea_parameters[parameter_name].get()
+        else:
+            if 'general:scenario' in parameters:
+                check_senario_exists(parameters)
+            if 'weather_name' in parameters:
+                update_weather_parameters(parameters)
 
 
     def execute(self, parameters, _):
@@ -77,12 +94,12 @@ class CeaTool(object):
         run_cli(self.cea_tool, **kwargs)
 
 
-def get_parameters(cea_tool):
+def get_parameters(config, cea_tool):
     """Return a list of cea.config.Parameter objects for each parameter associated with the tool."""
     cli_config = ConfigParser.SafeConfigParser()
     cli_config.read(os.path.join(os.path.dirname(__file__), '..', 'cli', 'cli.config'))
     option_list = cli_config.get('config', cea_tool).split()
-    for _, parameter in CONFIG.matching_parameters(option_list):
+    for _, parameter in config.matching_parameters(option_list):
         yield parameter
 
 
@@ -308,7 +325,7 @@ def get_parameter_info(cea_parameter, config):
     builder = BUILDERS[type(cea_parameter)](cea_parameter, config)
     try:
         arcgis_parameter = builder.get_parameter_info()
-        arcgis_parameter.value = builder.get_value()
+        # arcgis_parameter.value = builder.get_value()
         return arcgis_parameter
     except TypeError:
         raise TypeError('Failed to build arcpy.Parameter from %s ' % cea_parameter)

--- a/cea/interfaces/arcgis/test.pyt
+++ b/cea/interfaces/arcgis/test.pyt
@@ -29,6 +29,24 @@ class DemandTool(CeaTool):
         self.description = 'Calculate the Demand'
         self.category = 'Demand forecasting'
         self.canRunInBackground = False
+        with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
+            import datetime
+            f.write('DemandTool.__init__: %s\n' % datetime.datetime.now())
+
+    def getParameterInfo(self):
+        with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
+            import datetime
+            f.write('DemandTool.getParameterInfo: %s\n' % datetime.datetime.now())
+        return super(DemandTool, self).getParameterInfo()
+
+    def updateParameters(self, parameters):
+        with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
+            import datetime
+            f.write('DemandTool.updateParameters: %s\n' % datetime.datetime.now())
+            for parameter in parameters:
+                f.write('- %s: %s (%s)\n' % (parameter.name, parameter.value, parameter.altered))
+        return super(DemandTool, self).updateParameters(parameters)
+
 
     def override_parameter_info(self, parameter_info, parameter):
         """Override this method if you need to use a non-default ArcGIS parameter handling"""

--- a/cea/interfaces/arcgis/test.pyt
+++ b/cea/interfaces/arcgis/test.pyt
@@ -11,11 +11,6 @@ from cea.interfaces.arcgis.arcgishelper import *
 
 from cea.interfaces.arcgis.modules import arcpy
 
-# with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
-#     import datetime
-#
-#     f.write('\n\nDemandTool.RELOAD: %s\n' % datetime.datetime.now())
-
 class Toolbox(object):
     """List the tools to show in the toolbox."""
 
@@ -34,26 +29,6 @@ class DemandTool(CeaTool):
         self.description = 'Calculate the Demand'
         self.category = 'Demand forecasting'
         self.canRunInBackground = False
-        # with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
-        #     import datetime
-        #     f.write('DemandTool.__init__: %s\n' % datetime.datetime.now())
-
-    def getParameterInfo(self):
-        with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
-            import datetime
-            f.write('DemandTool.getParameterInfo: %s\n' % datetime.datetime.now())
-        return super(DemandTool, self).getParameterInfo()
-
-    def updateParameters(self, parameters):
-        result = super(DemandTool, self).updateParameters(parameters)
-
-        # with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
-        #     import datetime
-        #     f.write('DemandTool.updateParameters: %s\n' % datetime.datetime.now())
-        #     for parameter in parameters:
-        #         f.write('- %s: %s (%s)\n' % (parameter.name, parameter.value, parameter.hasBeenValidated))
-
-        return result
 
     def override_parameter_info(self, parameter_info, parameter):
         """Override this method if you need to use a non-default ArcGIS parameter handling"""

--- a/cea/interfaces/arcgis/test.pyt
+++ b/cea/interfaces/arcgis/test.pyt
@@ -11,6 +11,11 @@ from cea.interfaces.arcgis.arcgishelper import *
 
 from cea.interfaces.arcgis.modules import arcpy
 
+# with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
+#     import datetime
+#
+#     f.write('\n\nDemandTool.RELOAD: %s\n' % datetime.datetime.now())
+
 class Toolbox(object):
     """List the tools to show in the toolbox."""
 
@@ -29,9 +34,9 @@ class DemandTool(CeaTool):
         self.description = 'Calculate the Demand'
         self.category = 'Demand forecasting'
         self.canRunInBackground = False
-        with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
-            import datetime
-            f.write('DemandTool.__init__: %s\n' % datetime.datetime.now())
+        # with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
+        #     import datetime
+        #     f.write('DemandTool.__init__: %s\n' % datetime.datetime.now())
 
     def getParameterInfo(self):
         with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
@@ -40,13 +45,15 @@ class DemandTool(CeaTool):
         return super(DemandTool, self).getParameterInfo()
 
     def updateParameters(self, parameters):
-        with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
-            import datetime
-            f.write('DemandTool.updateParameters: %s\n' % datetime.datetime.now())
-            for parameter in parameters:
-                f.write('- %s: %s (%s)\n' % (parameter.name, parameter.value, parameter.altered))
-        return super(DemandTool, self).updateParameters(parameters)
+        result = super(DemandTool, self).updateParameters(parameters)
 
+        # with open(r'c:\Users\darthoma\polybox\cea.log', 'a') as f:
+        #     import datetime
+        #     f.write('DemandTool.updateParameters: %s\n' % datetime.datetime.now())
+        #     for parameter in parameters:
+        #         f.write('- %s: %s (%s)\n' % (parameter.name, parameter.value, parameter.hasBeenValidated))
+
+        return result
 
     def override_parameter_info(self, parameter_info, parameter):
         """Override this method if you need to use a non-default ArcGIS parameter handling"""
@@ -54,10 +61,6 @@ class DemandTool(CeaTool):
             # ignore this parameter in the ArcGIS interface
             return None
         return parameter_info
-
-
-if __name__ == '__main__':
-    parameters = list(get_parameters('photovoltaic'))
 
 
 

--- a/cea/interfaces/cli/cli.config
+++ b/cea/interfaces/cli/cli.config
@@ -40,7 +40,7 @@ network-layout = cea.technologies.thermal_network.network_layout.main
 decentralized = cea.optimization.preprocessing.disconnected_building_main
 
 [config]
-demand = general:scenario general:weather general:multiprocessing demand
+demand = general:scenario general:region general:weather general:multiprocessing demand
 data-helper = general:scenario general:region data-helper
 emissions = general:scenario emissions
 embodied-energy = general:scenario embodied-energy

--- a/cea/interfaces/cli/cli.py
+++ b/cea/interfaces/cli/cli.py
@@ -28,10 +28,29 @@ def main(config=None):
     option_list = cli_config.get('config', script_name).split()
     config.apply_command_line_args(args, option_list)
 
+    # save the updates to the configuration file (re-running the same tool will result in the
+    # same parameters being set)
+    config.save(cea.config.CEA_CONFIG)
+
+    print_script_configuration(config, script_name, option_list)
+
     module_path = cli_config.get('scripts', script_name)
     script_module = importlib.import_module(module_path)
     script_module.main(config)
 
+
+def print_script_configuration(config, script_name, option_list):
+    """
+    Print a list of script parameters being used for this run of the tool. Historically, each tool
+    was responsible for printing their own parameters, but that requires manually keeping track of these
+    parameters.
+    """
+    print("Running `cea %(script_name)s` with the following parameters:" % locals())
+    for section, parameter in config.matching_parameters(option_list):
+        section_name = section.name
+        parameter_name = parameter.name
+        parameter_value = parameter.get()
+        print("- %(section_name)s:%(parameter_name)s = %(parameter_value)s" % locals())
 
 def get_cli_config():
     """Return a ConfigParser object for the ``cli.config`` file used to configure the scripts known to the


### PR DESCRIPTION
This fixes a few annoying things that cropped up in the test-run of the executive course. Including:

- saving parameter choices to the config file between invocations of the interface
  - (figuring out how to determine when a user made a change and when the dialog was being shown for the first time was a bit of a challenge btw)
- adding the "region" dropdown to the demand calculation. it was there before, but somehow got removed?