### PR TITLE
967 interface and dashboard for the cea

### DIFF
--- a/cea/api.py
+++ b/cea/api.py
@@ -1,0 +1,34 @@
+"""
+Provide access to the scripts exported by the City Energy Analyst.
+"""
+
+from __future__ import print_function
+
+
+def register_scripts():
+    import cea.interfaces.cli.cli
+    import cea.config
+    import importlib
+
+    config = cea.config.Configuration()
+
+    def script_wrapper(script_name):
+        def script_runner(config=config, subprocess=False, **kwargs):
+            print('running script {}'.format(script_name))
+            option_list = cli_config.get('config', script_name).split()
+            module_path = cli_config.get('scripts', script_name)
+            script_module = importlib.import_module(module_path)
+            for section, parameter in config.matching_parameters(option_list):
+                if parameter.name in kwargs:
+                    parameter.set(kwargs[parameter.name])
+            if not subprocess:
+                script_module.main(config)
+        return script_runner
+
+    cli_config = cea.interfaces.cli.cli.get_cli_config()
+    for script_name in sorted(cli_config.options('scripts')):
+        script_py_name = script_name.replace('-', '_')
+        globals()[script_py_name] = script_wrapper(script_name)
+
+
+register_scripts()

--- a/cea/config.py
+++ b/cea/config.py
@@ -539,7 +539,8 @@ class MultiChoiceParameter(ChoiceParameter):
     def encode(self, value):
         assert not isinstance(value, basestring)
         for choice in value:
-            assert str(choice) in self._choices, 'Invalid parameter, choose from: %s' % self._choices
+            assert str(choice) in self._choices, 'Invalid parameter value %s for %s, choose from: %s' % (
+                value, self.name, self._choices)
         return ', '.join(map(str, value))
 
     def decode(self, value):

--- a/cea/plots/life_cycle/main.py
+++ b/cea/plots/life_cycle/main.py
@@ -99,31 +99,31 @@ class Plots():
         title = "Operation Costs" + self.plot_title_tail
         output_path = self.locator.get_timeseries_plots_file(self.plot_output_path_header + '_operation_costs')
         data = self.data_processed
-        operation_costs_district(data, self.analysis_fields_costs, title, output_path)
+        return operation_costs_district(data, self.analysis_fields_costs, title, output_path)
 
     def emissions(self):
         title = "Green House Gas Emissions" + self.plot_title_tail
         output_path = self.locator.get_timeseries_plots_file(self.plot_output_path_header + '_emissions')
         data = self.data_processed_emissions
-        emissions(data, self.analysis_fields_emissions, title, output_path)
+        return emissions(data, self.analysis_fields_emissions, title, output_path)
 
     def emissions_intensity(self):
         title = "Green House Gas Emissions" + self.plot_title_tail
         output_path = self.locator.get_timeseries_plots_file(self.plot_output_path_header + '_emissions_intensity')
         data = self.data_processed_emissions
-        emissions_intensity(data, self.analysis_fields_emissions_m2, title, output_path)
+        return emissions_intensity(data, self.analysis_fields_emissions_m2, title, output_path)
 
     def primary_energy(self):
         title = "Non-Renewable Primary Energy" + self.plot_title_tail
         output_path = self.locator.get_timeseries_plots_file(self.plot_output_path_header + '_primary_energy')
         data = self.data_processed_emissions
-        primary_energy(data, self.analysis_fields_primary_energy, title, output_path)
+        return primary_energy(data, self.analysis_fields_primary_energy, title, output_path)
 
     def primary_energy_intensity(self):
         title = "Non-Renewable Primary Energy" + self.plot_title_tail
         output_path = self.locator.get_timeseries_plots_file(self.plot_output_path_header + '_primary_energy_intensity')
         data = self.data_processed_emissions
-        primary_energy_intensity(data, self.analysis_fields_primary_energy_m2, title, output_path)
+        return primary_energy_intensity(data, self.analysis_fields_primary_energy_m2, title, output_path)
 
 
 def main(config):

--- a/cea/plots/plots.yml
+++ b/cea/plots/plots.yml
@@ -1,0 +1,304 @@
+# category energy-demand
+
+heating-reset-schedule:
+  category: energy-demand
+  preprocessor: cea.plots.demand.main.Plots
+  plot-function: heating_reset_schedule
+  single-building: true
+  parameters: [buildings]
+
+energy-balance:
+  category: energy-demand
+  preprocessor: cea.plots.demand.main.Plots
+  plot-function: energy_balance
+  single-building: true
+  parameters: [buildings]
+
+load-duration-curve:
+  category: energy-demand
+  preprocessor: cea.plots.demand.main.Plots
+  plot-function: load_duration_curve
+  single-building: false
+  has-table: true
+  parameters: [buildings]
+
+load-curve:
+  category: energy-demand
+  preprocessor: cea.plots.demand.main.Plots
+  plot-function: load_curve
+  single-building: false
+  parameters: [buildings]
+
+peak-load:
+  category: energy-demand
+  preprocessor: cea.plots.demand.main.Plots
+  plot-function: peak_load
+  single-building: false
+  parameters: [buildings]
+
+energy-use-intensity:
+  category: energy-demand
+  preprocessor: cea.plots.demand.main.Plots
+  plot-function: energy_use_intensity
+  single-building: false
+  parameters: [buildings]
+
+energy-demand:
+  category: energy-demand
+  preprocessor: cea.plots.demand.main.Plots
+  plot-function: energy_demand
+  single-building: false
+  parameters: [buildings]
+
+# category technology-potentials
+
+pv-district-monthly:
+  category: technology-potentials
+  preprocessor: cea.plots.solar_technology_potentials.main.Plots
+  plot-function: pv_district_monthly
+  single-building: false
+  parameters: [buildings, weather]
+
+pvt-district-monthly:
+  category: technology-potentials
+  preprocessor: cea.plots.solar_technology_potentials.main.Plots
+  plot-function: pvt_district_monthly
+  single-building: false
+  parameters: [buildings, weather]
+
+sc-fp-district-monthly:
+  category: technology-potentials
+  preprocessor: cea.plots.solar_technology_potentials.main.Plots
+  plot-function: sc_fp_district_monthly
+  single-building: false
+  parameters: [buildings, weather]
+
+sc-et-district-monthly:
+  category: technology-potentials
+  preprocessor: cea.plots.solar_technology_potentials.main.Plots
+  plot-function: sc_et_district_monthly
+  single-building: false
+  parameters: [buildings, weather]
+
+all-tech-district-yearly:
+  category: technology-potentials
+  preprocessor: cea.plots.solar_technology_potentials.main.Plots
+  plot-function: all_tech_district_yearly
+  single-building: false
+  parameters: [buildings, weather]
+
+# category life-cycle
+
+operation-costs:
+  category: life-cycle
+  preprocessor: cea.plots.life_cycle.main.Plots
+  plot-function: operation_costs
+  single-building: false
+  parameters: [buildings]
+
+emissions:
+  category: life-cycle
+  preprocessor: cea.plots.life_cycle.main.Plots
+  plot-function: emissions
+  single-building: false
+  parameters: [buildings]
+
+emissions-intensity:
+  category: life-cycle
+  preprocessor: cea.plots.life_cycle.main.Plots
+  plot-function: emissions_intensity
+  single-building: false
+  parameters: [buildings]
+
+primary-energy:
+  category: life-cycle
+  preprocessor: cea.plots.life_cycle.main.Plots
+  plot-function: primary_energy
+  single-building: false
+  parameters: [buildings]
+
+primary-energy-intensity:
+  category: life-cycle
+  preprocessor: cea.plots.life_cycle.main.Plots
+  plot-function: primary_energy_intensity
+  single-building: false
+  parameters: [buildings]
+
+# category comparisons
+
+demand-comparison:
+  category: comparisons
+  preprocessor: cea.plots.comparisons.main.Plots
+  plot-function: demand_comparison
+  single-building: false
+  parameters: [scenarios]
+
+demand-intensity-comparison:
+  category: comparisons
+  preprocessor: cea.plots.comparisons.main.Plots
+  plot-function: demand_intensity_comparison
+  single-building: false
+  parameters: [scenarios]
+
+operation-costs-comparison:
+  category: comparisons
+  preprocessor: cea.plots.comparisons.main.Plots
+  plot-function: operation_costs_comparison
+  single-building: false
+  parameters: [scenarios]
+
+emissions-comparison:
+  category: comparisons
+  preprocessor: cea.plots.comparisons.main.Plots
+  plot-function: emissions_comparison
+  single-building: false
+  parameters: [scenarios]
+
+primary-energy-comparison:
+  category: comparisons
+  preprocessor: cea.plots.comparisons.main.Plots
+  plot-function: primary_energy_comparison
+  single-building: false
+  parameters: [scenarios]
+
+emissions-intensity-comparison:
+  category: comparisons
+  preprocessor: cea.plots.comparisons.main.Plots
+  plot-function: emissions_intensity_comparison
+  single-building: false
+  parameters: [scenarios]
+
+primary-energy-intensity-comparison:
+  category: comparisons
+  preprocessor: cea.plots.comparisons.main.Plots
+  plot-function: primary_energy_intensity_comparison
+  single-building: false
+  parameters: [scenarios]
+
+# category optimization
+
+
+pareto-multiple-generations:
+  category: optimization
+  preprocessor: cea.plots.optimization.main.Plots
+  plot-function: pareto_multiple_generations
+  single-building: false
+  parameters: [individual, generations]
+  
+pareto-final-generation:
+  category: optimization
+  preprocessor: cea.plots.optimization.main.Plots
+  plot-function: pareto_final_generation
+  single-building: false
+  parameters: [individual, generations]
+
+pareto-final-generation-capacity-installed:
+  category: optimization
+  preprocessor: cea.plots.optimization.main.Plots
+  plot-function: pareto_final_generation_capacity_installed
+  single-building: false
+  parameters: [individual, generations]
+
+individual-heating-activation-curve:
+  category: optimization
+  preprocessor: cea.plots.optimization.main.Plots
+  plot-function: individual_heating_activation_curve
+  single-building: false
+  parameters: [individual, generations]
+  
+individual-heating-storage-activation-curve:
+  category: optimization
+  preprocessor: cea.plots.optimization.main.Plots
+  plot-function: individual_heating_storage_activation_curve
+  single-building: false
+  parameters: [individual, generations]
+  
+
+individual-electricity-activation-curve:
+  category: optimization
+  preprocessor: cea.plots.optimization.main.Plots
+  plot-function: individual_electricity_activation_curve
+  single-building: false
+  parameters: [individual, generations]
+    
+    
+individual-cooling-activation-curve:
+  category: optimization
+  preprocessor: cea.plots.optimization.main.Plots
+  plot-function: individual_cooling_activation_curve
+  single-building: false
+  parameters: [individual, generations]
+
+# category thermal-networks
+
+loss-curve:
+  category: thermal-networks
+  preprocessor: cea.plots.thermal_networks.main.Plots
+  plot-function: loss_curve
+  single-building: false
+  parameters: [network_type, network_names]
+
+loss-curve-relative:
+  category: thermal-networks
+  preprocessor: cea.plots.thermal_networks.main.Plots
+  plot-function: loss_curve_relative
+  single-building: false
+  parameters: [network_type, network_names]
+  
+supply_return_ambient_curve:
+  category: thermal-networks
+  preprocessor: cea.plots.thermal_networks.main.Plots
+  plot-function: supply_return_ambient_curve
+  single-building: false
+  parameters: [network_type, network_names]
+
+loss-duration-curve:
+  category: thermal-networks
+  preprocessor: cea.plots.thermal_networks.main.Plots
+  plot-function: loss_duration_curve
+  single-building: false
+  parameters: [network_type, network_names]
+
+heat-network-plot:
+  category: thermal-networks
+  preprocessor: cea.plots.thermal_networks.main.Plots
+  plot-function: heat_network_plot
+  single-building: false
+  parameters: [network_type, network_names]
+  
+pressure-network-plot:
+  category: thermal-networks
+  preprocessor: cea.plots.thermal_networks.main.Plots
+  plot-function: pressure_network_plot
+  single-building: false
+  parameters: [network_type, network_names]
+
+# category solar-potential
+
+solar-radiation-curve:
+  category: solar-potential
+  preprocessor: cea.plots.solar_potential.main.Plots
+  plot-function: solar_radiation_curve
+  single-building: false
+  parameters: [buildings, weather]
+
+solar-radiation-district-monthly:
+  category: solar-potential
+  preprocessor: cea.plots.solar_potential.main.Plots
+  plot-function: solar_radiation_district_monthly
+  single-building: false
+  parameters: [buildings, weather]
+
+solar-radiation-district-monthly:
+  category: solar-potential
+  preprocessor: cea.plots.solar_potential.main.Plots
+  plot-function: solar_radiation_district_monthly
+  single-building: false
+  parameters: [buildings, weather]
+    
+solar-radiation-district:
+  category: solar-potential
+  preprocessor: cea.plots.solar_potential.main.Plots
+  plot-function: solar_radiation_district
+  single-building: false
+  parameters: [buildings, weather]

--- a/cea/plots/thermal_networks/main.py
+++ b/cea/plots/thermal_networks/main.py
@@ -65,12 +65,12 @@ def plots_main(locator, config):
 
 class Plots():
 
-    def __init__(self, locator, network_type, network_name):
+    def __init__(self, locator, network_type, network_names):
         self.locator = locator
         self.demand_analysis_fields = ["Qhsf_kWh",
                                        "Qwwf_kWh",
                                        "Qcsf_kWh"]
-        self.network_name = self.preprocess_network_name(network_name)
+        self.network_name = self.preprocess_network_name(network_names)
         self.network_type = network_type
         self.plot_title_tail = self.preprocess_plot_title()
         self.plot_output_path_header = self.preprocess_plot_outputpath()

--- a/cea/scripts.py
+++ b/cea/scripts.py
@@ -1,0 +1,30 @@
+"""
+Provides the list of scripts known to the CEA - to be used by interfaces built on top of the CEA.
+"""
+import os
+import yaml
+
+
+class CeaScript(object):
+    def __init__(self, name, values):
+        self.name = name
+        self.module = values['module']
+        self.category = values.get('category', 'default')
+        self.description = values.get('description', '')
+        self.interfaces = values.get('interfaces', ['cli'])
+        self.label = values.get('label', self.name)
+
+    def __repr__(self):
+        return '<cea %s>' % self.name
+
+
+def list_scripts():
+    """List all scripts"""
+    scripts_yml = os.path.join(os.path.dirname(__file__), 'scripts.yml')
+    for name, values in yaml.load(open(scripts_yml)).items():
+        yield CeaScript(name, values)
+
+
+def for_interface(interface='cli'):
+    """Return the list of CeaScript instances that are listed for the interface"""
+    return [script for script in list_scripts() if interface in script.interfaces]

--- a/cea/scripts.yml
+++ b/cea/scripts.yml
@@ -1,0 +1,392 @@
+benchmark-graphs:
+  interfaces:
+  - cli
+  label: benchmark-graphs
+  module: cea.analysis.benchmark
+  parameters:
+  - benchmark-graphs
+compile:
+  interfaces:
+  - cli
+  label: compile
+  module: cea.utilities.compile_pyd_files
+  parameters: null
+config-editor:
+  interfaces:
+  - cli
+  label: config-editor
+  module: cea.interfaces.config_editor.config_editor
+  parameters: null
+create-new-project:
+  category: Data Management
+  description: Create a new project and scenario based on a zone Shapefile and terrain
+    DEM
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: New Project
+  module: cea.utilities.create_new_project
+  parameters:
+  - create-new-project
+dashboard:
+  interfaces:
+  - cli
+  label: dashboard
+  module: cea.interfaces.dashboard.dashboard
+  parameters: null
+data-helper:
+  category: Data Management
+  description: Query characteristics of buildings and systems from statistical data
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Data miner
+  module: cea.demand.preprocessing.data_helper
+  parameters:
+  - general:scenario
+  - data-helper
+dbf-to-excel:
+  category: Utilities
+  description: dbf => xls
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: DBF to Excel
+  module: cea.interfaces.cli.dbf_to_excel
+  parameters:
+  - dbf-tools:dbf-file
+  - dbf-tools:excel-file
+demand:
+  category: Demand forecasting
+  description: Calculate the Demand
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Demand
+  module: cea.demand.demand_main
+  parameters:
+  - general:scenario
+  - general:weather
+  - general:multiprocessing
+  - demand
+embodied-energy:
+  category: Life cycle analysis
+  description: Calculate the emissions and primary energy for building construction
+    and decommissioning
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Building construction
+  module: cea.analysis.lca.embodied
+  parameters:
+  - general:scenario
+  - embodied-energy
+emissions:
+  category: Life cycle analysis
+  description: Calculate emissions and primary energy due to building operation
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Building operation
+  module: cea.analysis.lca.operation
+  parameters:
+  - general:scenario
+  - emissions
+excel-to-dbf:
+  category: Utilities
+  description: xls => dbf
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Excel to DBF
+  module: cea.interfaces.cli.excel_to_dbf
+  parameters:
+  - dbf-tools:excel-file
+  - dbf-tools:dbf-file
+excel-to-shapefile:
+  interfaces:
+  - cli
+  label: excel-to-shapefile
+  module: cea.interfaces.cli.excel_to_shapefile
+  parameters:
+  - shapefile-tools
+extract-reference-case:
+  interfaces:
+  - cli
+  label: extract-reference-case
+  module: cea.examples.extract_reference_case
+  parameters:
+  - extract-reference-case
+heatmaps:
+  category: Visualization
+  description: Generate maps representing hot and cold spots of energy consumption
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Heatmaps
+  module: cea.plots.heatmaps
+  parameters:
+  - general:scenario
+  - heatmaps:file-to-analyze
+  - heatmaps:analysis-fields
+install-grasshopper:
+  interfaces:
+  - cli
+  label: install-grasshopper
+  module: cea.interfaces.grasshopper.install_grasshopper
+  parameters: null
+install-toolbox:
+  interfaces:
+  - cli
+  label: install-toolbox
+  module: cea.interfaces.arcgis.install_toolbox
+  parameters: null
+list-demand-graphs-fields:
+  interfaces:
+  - cli
+  label: list-demand-graphs-fields
+  module: cea.interfaces.cli.list_demand_graphs_fields
+  parameters:
+  - general:scenario
+mobility:
+  category: Life cycle analysis
+  description: Calculate emissions and primary energy due to mobility
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Urban mobility
+  module: cea.analysis.lca.mobility
+  parameters:
+  - general:scenario
+operation-costs:
+  category: Cost analysis
+  description: Calculate energy costs due to building operation
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Building operation costs
+  module: cea.analysis.lca.operation_costs
+  parameters:
+  - general:scenario
+  - operation-costs
+optimization:
+  category: Optimization
+  description: Run optimization for the given scenario
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Supply system
+  module: cea.optimization.optimization_main
+  parameters:
+  - general:scenario
+  - optimization
+photovoltaic:
+  category: Energy potentials
+  description: Calculate electricity production from solar photovoltaic technologies
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Photovoltaic panels
+  module: cea.technologies.solar.photovoltaic
+  parameters:
+  - general:scenario
+  - general:weather
+  - solar:date-start
+  - solar:type-pvpanel
+  - solar:panel-on-roof
+  - solar:panel-on-wall
+  - solar:min-radiation
+  - solar:solar-window-solstice
+photovoltaic-thermal:
+  category: Energy potentials
+  description: Calculate electricity & heat production from photovoltaic / thermal
+    technologies
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Photovoltaic-thermal Panels
+  module: cea.technologies.solar.photovoltaic_thermal
+  parameters:
+  - general:scenario
+  - general:weather
+  - solar:date-start
+  - solar:type-pvpanel
+  - solar:type-scpanel
+  - solar:panel-on-roof
+  - solar:panel-on-wall
+  - solar:min-radiation
+  - solar:solar-window-solstice
+  - solar:t-in-pvt
+  - solar:dpl
+  - solar:fcr
+  - solar:ro
+  - solar:eff-pumping
+  - solar:k-msc-max
+radiation:
+  interfaces:
+  - cli
+  label: radiation
+  module: cea.resources.radiation_arcgis.radiation
+  parameters:
+  - general:scenario
+  - general:weather
+  - radiation
+radiation-daysim:
+  category: Energy potentials
+  description: Use Daysim to calculate solar radiation for a scenario
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Solar radiation (Daysim engine)
+  module: cea.resources.radiation_daysim.radiation_main
+  parameters:
+  - general:scenario
+  - general:weather
+  - general:multiprocessing
+  - radiation-daysim
+retrofit-potential:
+  category: Retrofit analysis
+  description: Select buildings according to specific criteria for retrofit
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Building Retrofit Potential
+  module: cea.analysis.retrofit.retrofit_potential
+  parameters:
+  - general:scenario
+  - retrofit-potential
+scenario-plots:
+  interfaces:
+  - cli
+  label: scenario-plots
+  module: cea.plots.scenario_plots
+  parameters:
+  - scenario-plots
+sensitivity-demand-analyze:
+  category: Sensitivity analysis
+  description: Analyze the results in the samples folder and write them out to an
+    Excel file.
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Analysis
+  module: cea.analysis.sensitivity.sensitivity_demand_analyze
+  parameters:
+  - sensitivity-demand:samples-folder
+  - sensitivity-demand:temporal-scale
+sensitivity-demand-samples:
+  category: Sensitivity analysis
+  description: Create samples for sensitivity analysis
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Initializer
+  module: cea.analysis.sensitivity.sensitivity_demand_samples
+  parameters:
+  - sensitivity-demand:num-samples
+  - sensitivity-demand:samples-folder
+  - sensitivity-demand:method
+  - sensitivity-demand:calc-second-order
+  - sensitivity-demand:grid-jump
+  - sensitivity-demand:num-levels
+  - sensitivity-demand:variable-groups
+sensitivity-demand-simulate:
+  category: Sensitivity analysis
+  description: Simulate demand for sensitivity analysis samples
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Sampler
+  module: cea.analysis.sensitivity.sensitivity_demand_simulate
+  parameters:
+  - general:scenario
+  - general:weather
+  - sensitivity-demand:samples-folder
+  - sensitivity-demand:simulation-folder
+  - sensitivity-demand:output-parameters
+  - sensitivity-demand:number-of-simulations
+  - sensitivity-demand:sample-index
+sewage-heat-exchanger:
+  category: Energy potentials
+  description: Calculate the heat extracted from the sewage heat exchanger.
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Sewage heat-pump
+  module: cea.technologies.sewage_heat_exchanger
+  parameters:
+  - general:scenario
+  - sewage
+shapefile-to-excel:
+  interfaces:
+  - cli
+  label: shapefile-to-excel
+  module: cea.interfaces.cli.shapefile_to_excel
+  parameters:
+  - shapefile-tools
+solar-collector:
+  category: Energy potentials
+  description: Calculate heat production from solar collector technologies
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Solar collectors
+  module: cea.technologies.solar.solar_collector
+  parameters:
+  - general:scenario
+  - general:weather
+  - solar:date-start
+  - solar:type-scpanel
+  - solar:panel-on-roof
+  - solar:panel-on-wall
+  - solar:min-radiation
+  - solar:solar-window-solstice
+  - solar:t-in-sc
+  - solar:dpl
+  - solar:fcr
+  - solar:ro
+  - solar:eff-pumping
+  - solar:k-msc-max
+test:
+  category: Utilities
+  description: Run some tests on the CEA
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Test CEA
+  module: cea.tests.dodo
+  parameters:
+  - test
+thermal-network-matrix:
+  category: Thermal networks
+  description: Solve the thermal hydraulic network
+  interfaces:
+  - cli
+  - arcgis
+  - dashboard
+  label: Branched network
+  module: cea.technologies.thermal_network.thermal_network_matrix
+  parameters:
+  - general:scenario
+  - thermal-network

--- a/cea/tests/trace_inputlocator.py
+++ b/cea/tests/trace_inputlocator.py
@@ -1,0 +1,79 @@
+"""
+Trace the InputLocator calls in a vareity of scripts.
+"""
+import sys
+import os
+
+import cea.config
+import cea.api
+import pprint
+from collections import defaultdict
+from datetime import datetime
+from jinja2 import Template
+
+
+def create_trace_function(results_set):
+    """results_set is a set of tuples (locator, filename)"""
+    def trace_function(frame, event, arg):
+        """Trace any calls to the InputLocator"""
+        co = frame.f_code
+        func_name = co.co_name
+        if func_name == 'write':
+            # Ignore write() calls from print statements
+            return
+        line_no = frame.f_lineno
+        filename = co.co_filename
+        if event == 'call':
+            # decend into the stack...
+            return trace_function
+        elif event == 'return':
+            if isinstance(arg, basestring) and 'inputlocator' in filename.lower() and not func_name.startswith('_'):
+                results_set.add((func_name, arg))
+                print('%s => %s' % (func_name, arg))
+        return
+    return trace_function
+
+
+def main(config):
+    # force single-threaded execution, see settrace docs for why
+    config.multiprocessing = False
+    # scripts = ['data-helper', 'demand']
+    scripts = ['data-helper', 'demand', 'embodied-energy', 'emissions', 'mobility',]
+               #'photovoltaic', 'photovoltaic-thermal', 'solar-collector', 'sewage-heat-exchanger',]
+               #'thermal-network-matrix', 'retrofit-potential', 'optimization']
+
+    trace_data = set()  # {(direction, script, locator_method, file)}
+    orig_trace = sys.gettrace()
+    for script_name in scripts:
+        script_start = datetime.now()
+        script_func = getattr(cea.api, script_name.replace('-', '_'))
+        results_set = set()  # {(locator_method, filename)}
+
+        sys.settrace(create_trace_function(results_set))
+        script_func()
+        sys.settrace(orig_trace)
+
+        for locator_method, filename in results_set:
+            if os.path.isdir(filename):
+                continue
+            print("{}, {}".format(locator_method, filename))
+            mtime = datetime.fromtimestamp(os.path.getmtime(filename))
+            relative_filename = os.path.relpath(filename, config.scenario).replace('\\', '/')
+            for i in range(10):
+                # remove "B01", "B02" etc. from filenames -> "BXX"
+                relative_filename = relative_filename.replace('B%02d' % i, 'BXX')
+            if script_start < mtime:
+                trace_data.add(('output', script_name, locator_method, relative_filename))
+            else:
+                trace_data.add(('input', script_name, locator_method, relative_filename))
+
+    template_path = os.path.join(os.path.dirname(__file__), 'trace_inputlocator.template.gv')
+    template = Template(open(template_path, 'r').read())
+    digraph = template.render(trace_data=trace_data, scripts=scripts)
+    digraph = '\n'.join([line for line in digraph.split('\n') if len(line.strip())])
+    print(digraph)
+    with open(os.path.join(os.path.dirname(__file__), 'trace_inputlocator.output.gv'), 'w') as f:
+        f.write(digraph)
+
+if __name__ == '__main__':
+    main(cea.config.Configuration())

--- a/cea/tests/trace_inputlocator.template.gv.txt
+++ b/cea/tests/trace_inputlocator.template.gv.txt
@@ -1,0 +1,16 @@
+digraph trace_inputlocator {
+    rankdir="LR";
+    node [shape=box];
+
+    {% for script in scripts %}
+    "{{script}}"[fillcolor=darkorange];
+    {% endfor %}
+
+    {% for direction, script, locator, file in trace_data %}
+        {% if direction == 'input' %}
+    "{{file}}" -> "{{script}}";
+        {% else %}
+    "{{script}}" -> "{{file}}";
+        {% endif %}
+    {% endfor %}
+}


### PR DESCRIPTION
This pull requests contains the changes necessary to run the dashboard from the new repository [cea-dashboard](https://github.com/architecture-building-systems/cea-dashboard).

It replaces PR #1195

The implementation of the dashboard has been moved to a separate repository to avoid adding a bunch of third party js libraries and stuff to the cea code.

Issues referring to the dashboard will be moved to a separate milestone, but I intend to keep them in the CityEnergyAnalyst repository for now.


To run the dashboard:

- checkout the `cea-dashboard` repository and
- switch to this branch
- using the anaconda prompt used for cea, with the same conda environment, run `python dashboard/dashboard.py`
- open browser to `http://localhost:5050`

### Bonus features in this PR: 

- `trace_inputlocator.py` can be used to monitor files read and written during the execution of a script to figure out all inputs / outputs of the script - _and_ create a GraphViz representation of that!
- `cea.api` is a module that allows scripting of the cea from python - basically, it exposes a high-level interface to the cea scripts
- the `cea.scripts.CeaScript` class and the `scripts.yml` file are the beginning of a better mechanism for defining cea scripts (replacing `cli.config`) but are non-functional right now