### PR TITLE
Urgent fix for a h5py error that just showed up (failing jenkins tests)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -109,6 +109,7 @@ dependencies:
   - docutils==0.14
   - doit==0.29.0
   - flask==1.0.2
+  - h5py==2.7.1
   - htmlPy
   - idna==2.5
   - imagesize==0.7.1

--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
 - gdal=2.2.4
 - geopandas=0.3.0
 - hdf4=4.2.12=vc9_0
-- hdf5>=1.8.18
+- hdf5==1.10.1
 - icu=58.1=vc9_1
 - jpeg=9b=vc9_0
 - kealib>=1.4.7


### PR DESCRIPTION
hdf5 1.10.2 seems to be a problem for now... This is a proposed fix to the `environment.yml` file.