### PR TITLE
Limit number of processes of multiprocessing

### DIFF
--- a/cea/default.config
+++ b/cea/default.config
@@ -16,6 +16,11 @@ multiprocessing = true
 multiprocessing.type = BooleanParameter
 multiprocessing.help = Multiprocessing for quicker calculation, if available.
 
+max-processes = -1
+max-processes.type = IntegerParameter
+max-processes.help = Maximum number of processors to use. Default is total number - 1.
+max-processes.category = Advanced
+
 debug = false
 debug.type = BooleanParameter
 debug.help = Enable debugging-specific behaviors.

--- a/cea/default.config
+++ b/cea/default.config
@@ -16,10 +16,10 @@ multiprocessing = true
 multiprocessing.type = BooleanParameter
 multiprocessing.help = Multiprocessing for quicker calculation, if available.
 
-max-processes = -1
-max-processes.type = IntegerParameter
-max-processes.help = Maximum number of processors to use. Default is total number - 1.
-max-processes.category = Advanced
+number-of-CPUs-to-keep-free = 1
+number-of-CPUs-to-keep-free.type = IntegerParameter
+number-of-CPUs-to-keep-free.help = Limits the ,aximum number of processors to use for multiprocessing. Default keeps one CPU free.
+number-of-CPUs-to-keep-free.category = Advanced
 
 debug = false
 debug.type = BooleanParameter

--- a/cea/demand/demand_main.py
+++ b/cea/demand/demand_main.py
@@ -18,6 +18,7 @@ from cea.demand import thermal_loads
 from cea.demand.building_properties import BuildingProperties
 import demand_writers
 from cea.utilities import epwreader
+from cea.utilities.number_of_processes import get_number_of_processes
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2015, Architecture and Building Systems - ETH Zurich"
@@ -98,11 +99,10 @@ def demand_calculation(locator, gv, config):
 
     # DEMAND CALCULATION
     if multiprocessing and mp.cpu_count() > 1:
-        print("Using %i CPU's" % mp.cpu_count())
         calc_demand_multiprocessing(building_properties, date, gv, locator, list_building_names,
                                     schedules_dict, weather_data, use_dynamic_infiltration, use_stochastic_occupancy,
                                     resolution_output, loads_output, massflows_output, temperatures_output,
-                                    format_output)
+                                    format_output, config)
     else:
         calc_demand_singleprocessing(building_properties, date, gv, locator, list_building_names, schedules_dict,
                                      weather_data, use_dynamic_infiltration, use_stochastic_occupancy,
@@ -157,8 +157,10 @@ def calc_demand_singleprocessing(building_properties, date, gv, locator, list_bu
 
 def calc_demand_multiprocessing(building_properties, date, gv, locator, list_building_names, usage_schedules,
                                 weather_data, use_dynamic_infiltration_calculation, use_stochastic_occupancy,
-                                resolution_outputs, loads_output, massflows_output, temperatures_output, format_output):
-    pool = mp.Pool()
+                                resolution_outputs, loads_output, massflows_output, temperatures_output, format_output, config):
+    number_of_processes = get_number_of_processes(config)
+    print("Using %i CPU's" % number_of_processes)
+    pool = mp.Pool(number_of_processes)
     joblist = []
     num_buildings = len(list_building_names)
     for building in list_building_names:

--- a/cea/technologies/thermal_network/thermal_network_matrix.py
+++ b/cea/technologies/thermal_network/thermal_network_matrix.py
@@ -22,6 +22,7 @@ import random
 import networkx as nx
 from itertools import repeat, izip
 import multiprocessing
+from cea.utilities.number_of_processes import get_number_of_processes
 
 from cea.constants import HEAT_CAPACITY_OF_WATER_JPERKGK, P_WATER_KGPERM3, HOURS_IN_YEAR
 from cea.technologies.constants import ROUGHNESS, NETWORK_DEPTH, REDUCED_TIME_STEPS, MAX_INITIAL_DIAMETER_ITERATIONS, \
@@ -490,8 +491,9 @@ def thermal_network_main(locator, network_type, network_name, file_type, set_dia
 
     ## Start solving hydraulic and thermal equations at each time-step
     if config.multiprocessing and multiprocessing.cpu_count() > 1:
-        print("Using %i CPU's" % multiprocessing.cpu_count())
-        pool = multiprocessing.Pool()
+        number_of_processes = get_number_of_processes(config)
+        print("Using %i CPU's" % number_of_processes)
+        pool = multiprocessing.Pool(number_of_processes)
         hourly_thermal_results = pool.map(hourly_thermal_calculation_wrapper,
                                           izip(range(start_t, stop_t),
                                                repeat(thermal_network, times=(stop_t - start_t))))
@@ -1383,8 +1385,9 @@ def calc_max_edge_flowrate(thermal_network, set_diameter, start_t, stop_t, subst
         nhours = stop_t - start_t
 
         if use_multiprocessing and multiprocessing.cpu_count() > 1:
-            print("Using %i CPU's" % multiprocessing.cpu_count())
-            pool = multiprocessing.Pool()
+            number_of_processes = get_number_of_processes(config)
+            print("Using %i CPU's" % number_of_processes)
+            pool = multiprocessing.Pool(number_of_processes)
             mass_flows = pool.map(hourly_mass_flow_calculation_wrapper,
                                   izip(t, repeat(diameter_guess, nhours), repeat(thermal_network, nhours)))
         else:

--- a/cea/utilities/number_of_processes.py
+++ b/cea/utilities/number_of_processes.py
@@ -16,10 +16,8 @@ def get_number_of_processes(config):
     :param config: Configuration file.
     :return number_of_processes: Number of processes to use.
     '''
-    if multiprocessing.cpu_count() == 1:
+    if multiprocessing.cpu_count() - config.number_of_CPUs_to_keep_free < 1:
         number_of_processes = 1
-    elif config.max_processes < 1:
-        number_of_processes = multiprocessing.cpu_count() + config.max_processes
     else:
-        number_of_processes = config.max_processes
+        number_of_processes = multiprocessing.cpu_count() - config.number_of_CPUs_to_keep_free
     return number_of_processes

--- a/cea/utilities/number_of_processes.py
+++ b/cea/utilities/number_of_processes.py
@@ -1,0 +1,25 @@
+from __future__ import division
+import multiprocessing
+
+__author__ = "Lennart Rogenhofer, Daren Thomas"
+__copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"
+__credits__ = ["Jimeno A. Fonseca"]
+__license__ = "MIT"
+__version__ = "0.1"
+__maintainer__ = "Daren Thomas"
+__email__ = "cea@arch.ethz.ch"
+__status__ = "Production"
+
+def get_number_of_processes(config):
+    '''
+    Returns the number of processes to use for multiprocessing.
+    :param config: Configuration file.
+    :return number_of_processes: Number of processes to use.
+    '''
+    if multiprocessing.cpu_count() == 1:
+        number_of_processes = 1
+    elif config.max_processes < 1:
+        number_of_processes = multiprocessing.cpu_count() + config.max_processes
+    else:
+        number_of_processes = config.max_processes
+    return number_of_processes


### PR DESCRIPTION
Introduces limiting function to the total amount of processes used in multiprocessing, default is set to leave on CPU open. The maximum number of processes is now a user input into the config file.