### PR TITLE
fixes to run from intermittent generations

### DIFF
--- a/cea/default.config
+++ b/cea/default.config
@@ -674,6 +674,10 @@ isheating = true
 isheating.type = BooleanParameter
 isheating.help = if centralized heating is required in the neighborhood.
 
+recoverycheckpoint = 0
+recoverycheckpoint.type = IntegerParameter
+recoverycheckpoint.help = in case the optimization stops, it can be resumed from this checkpoint.
+
 [plots]
 scenarios = baseline, scenario_A, scenario_B
 scenarios.type = SubfoldersParameter

--- a/cea/optimization/master/master_main.py
+++ b/cea/optimization/master/master_main.py
@@ -36,7 +36,7 @@ __status__ = "Production"
 
 
 def evolutionary_algo_main(locator, building_names, extra_costs, extra_CO2, extra_primary_energy, solar_features,
-                           network_features, gv, config, prices, genCP=00):
+                           network_features, gv, config, prices):
     """
     Evolutionary algorithm to optimize the district energy system's design.
     This algorithm optimizes the size and operation of technologies for a district heating network.
@@ -75,6 +75,7 @@ def evolutionary_algo_main(locator, building_names, extra_costs, extra_CO2, extr
     :rtype: pickled file
     """
     t0 = time.clock()
+    genCP = config.optimization.recoverycheckpoint
 
     # initiating hall of fame size and the function evaluations
     halloffame_size = config.optimization.halloffame
@@ -822,10 +823,11 @@ def evolutionary_algo_main(locator, building_names, extra_costs, extra_CO2, extr
                 for j in xrange(len(pop[i])):
                     pop[i][j] = cp['population'][i][j]
             DHN_network_list = DHN_network_list
+            DCN_network_list = DCN_network_list
             epsInd = cp["epsIndicator"]
 
             for ind in pop:
-                evaluation.checkNtw(ind, DHN_network_list, locator, gv, config, building_names)
+                evaluation.checkNtw(ind, DHN_network_list, DCN_network_list, locator, gv, config, building_names)
 
             for i, ind in enumerate(pop):
                 a = objective_function(i, ind, genCP)


### PR DESCRIPTION
This PR allows running optimization from a checkpoint. This can be used to continue from any stopped checkpoint. The only constraint is that it needs have the same initial individuals as the checkpoint.