### PR TITLE
check to make sure reference-case really got deleted before cea test

### DIFF
--- a/cea/tests/dodo.py
+++ b/cea/tests/dodo.py
@@ -112,7 +112,9 @@ def task_download_reference_cases():
     """Download the (current) state of the reference cases"""
     def download_reference_cases():
         if os.path.exists(REFERENCE_CASE_PATH):
+            print('Removing folder: %s' % REFERENCE_CASE_PATH)
             shutil.rmtree(REFERENCE_CASE_PATH)
+            assert not os.path.exists(REFERENCE_CASE_PATH), 'FAILED to remove folder %s' % REFERENCE_CASE_PATH
         # extract the bundled reference case (we will use this anyways
         import cea.examples
         archive = zipfile.ZipFile(os.path.join(os.path.dirname(cea.examples.__file__), 'reference-case-open.zip'))


### PR DESCRIPTION
this adds a check to make sure the reference case folder in the temp folder really is being deleted. it is.