### PR TITLE
I1534 read supply system configuration of each individual

### DIFF
--- a/cea/optimization/master/cost_model.py
+++ b/cea/optimization/master/cost_model.py
@@ -442,8 +442,8 @@ def addCosts(DHN_barcode, DCN_barcode, buildList, locator, master_to_slave_vars,
 
         # Solar technologies
 
-        PV_peak_kW = master_to_slave_vars.SOLAR_PART_PV * solarFeat.A_PV_m2 * N_PV #kW
-        Capex_a_PV, Opex_fixed_PV = pv.calc_Cinv_pv(PV_peak_kW, locator, config)
+        PV_installed_area_m2 = master_to_slave_vars.SOLAR_PART_PV * solarFeat.A_PV_m2 #kW
+        Capex_a_PV, Opex_fixed_PV = pv.calc_Cinv_pv(PV_installed_area_m2, locator, config)
         addcosts_Capex_a += Capex_a_PV
         addcosts_Opex_fixed += Opex_fixed_PV
 

--- a/cea/plots/supply_system/individual_configuration.py
+++ b/cea/plots/supply_system/individual_configuration.py
@@ -1,0 +1,87 @@
+from __future__ import print_function
+from __future__ import division
+from cea.utilities.standarize_coordinates import get_lat_lon_projected_shapefile
+from geopandas import GeoDataFrame as gdf
+import os
+import time
+import numpy as np
+import pandas as pd
+from scipy import interpolate
+import cea.globalvar
+import cea.inputlocator
+from math import *
+from cea.utilities import epwreader
+from cea.utilities import solar_equations
+from cea.technologies.solar import constants
+import cea.config
+
+__author__ = "Shanshan Hsieh"
+__copyright__ = "Copyright 2016, Architecture and Building Systems - ETH Zurich"
+__credits__ = ["Shanshan Hsieh"]
+__license__ = "MIT"
+__version__ = "0.1"
+__maintainer__ = "Daren Thomas"
+__email__ = "cea@arch.ethz.ch"
+__status__ = "Production"
+
+
+def supply_system_configuration(generation, individual, locator, config):
+    # get supply system configuration of a particular individual
+    all_individuals = pd.read_csv(locator.get_optimization_all_individuals())
+    individual_system_configuration = all_individuals.loc[
+        (all_individuals['generation'].isin([generation])) & all_individuals['individual'].isin([individual])]
+
+    if config.optimization.isheating:
+        network_name = 'DHN'
+        centralized_cost_detail_heating = pd.read_csv(
+            locator.get_optimization_slave_investment_cost_detailed(individual, generation))
+    if config.optimization.iscooling:
+        network_name = 'DCN'
+
+        # get supply systems at centralized plants
+        centralized_cost_detail_cooling = pd.read_csv(
+            locator.get_optimization_slave_investment_cost_detailed_cooling(individual, generation))
+        DCN_buildings_list = [item for item in individual_system_configuration.columns if
+                              network_name in item and 'B' in item]
+        DCN_buildings_df = individual_system_configuration[DCN_buildings_list]
+
+        DCN_connected_buildings = DCN_buildings_df[DCN_buildings_df[DCN_buildings_list] > 0.00000].dropna(
+            axis=1).columns
+        DCN_connected_buildings = [x.split()[0] for x in DCN_connected_buildings]
+
+        # get supply systems at decentralized buildings
+        DCN_decentralized_buildings = DCN_buildings_df[DCN_buildings_df[DCN_buildings_list] < 1.00000].dropna(
+            axis=1).columns
+        DCN_decentralized_buildings = [x.split()[0] for x in DCN_decentralized_buildings]
+        bui_best_supply_sys = {}
+        for building in DCN_decentralized_buildings:
+            bui_sys_config = calc_building_supply_system(individual_system_configuration, network_name)
+            bui_results = pd.read_csv(
+                locator.get_optimization_disconnected_folder_building_result_cooling(building, bui_sys_config))
+            bui_best_supply_sys[building] = bui_results[bui_results['Best configuration'] > 0.0]
+
+    return
+
+
+def calc_building_supply_system(individual_system_configuration, network_name):
+    all_configuration_dict = {1: "ARU_SCU", 2: "AHU_SCU", 3: "AHU_ARU", 4: "SCU", 5: "ARU", 6: "AHU", 7: "AHU_ARU_SCU"}
+    unit_configuration_name = network_name + ' unit configuration'
+    unit_configuration = int(individual_system_configuration[unit_configuration_name].values[0])
+    if unit_configuration in all_configuration_dict:
+        decentralized_config = all_configuration_dict[unit_configuration]
+    else:
+        raise ValueError('DCN unit configuration does not exist.')
+    return decentralized_config
+
+
+def main(config):
+    locator = cea.inputlocator.InputLocator(scenario=config.scenario)
+    generation = '0'
+    individual = '0'
+    print('Fetching supply system configuration of... generation: %s, individual: %s' % (generation, individual))
+    supply_system_configuration(generation, individual, locator, config)
+    print('Done!')
+
+
+if __name__ == '__main__':
+    main(cea.config.Configuration())

--- a/cea/plots/supply_system/individual_configuration.py
+++ b/cea/plots/supply_system/individual_configuration.py
@@ -26,6 +26,10 @@ __status__ = "Production"
 
 
 def supply_system_configuration(generation, individual, locator, config):
+    district_supply_sys_columns = ['Lake [W]', 'VCC [W]', 'single effect ACH [W]', 'double effect ACH [W]',
+                                   'DX [W]', 'CCGT_heat [W]', 'SC_FP [m2]', 'SC_ET [m2]', 'PV [m2]', 'Capex_a',
+                                   'Opex_a']
+
     # get supply system configuration of a particular individual
     all_individuals = pd.read_csv(locator.get_optimization_all_individuals())
     individual_system_configuration = all_individuals.loc[
@@ -33,32 +37,95 @@ def supply_system_configuration(generation, individual, locator, config):
 
     if config.optimization.isheating:
         network_name = 'DHN'
+        network_connected_buildings, decentralized_buildings = calc_building_lists(individual_system_configuration,
+                                                                                   network_name)
         centralized_cost_detail_heating = pd.read_csv(
             locator.get_optimization_slave_investment_cost_detailed(individual, generation))
     if config.optimization.iscooling:
         network_name = 'DCN'
+        network_connected_buildings, decentralized_buildings = calc_building_lists(individual_system_configuration,
+                                                                                   network_name)
 
         # get supply systems at centralized plants
-        centralized_cost_detail_cooling = pd.read_csv(
-            locator.get_optimization_slave_investment_cost_detailed_cooling(individual, generation))
-        DCN_buildings_list = [item for item in individual_system_configuration.columns if
-                              network_name in item and 'B' in item]
-        DCN_buildings_df = individual_system_configuration[DCN_buildings_list]
+        # cen_cost_detail_cooling = pd.read_csv(
+        #     locator.get_optimization_slave_investment_cost_detailed_cooling(individual, generation))
+        # cen_cooling_tech_column = ['Lake Cooling Share', 'VCC Cooling Share', 'Absorption Chiller Share',
+        #                            'Storage Share']
+        # cen_cooling_tech_share = individual_system_configuration[cen_cooling_tech_column]
 
-        DCN_connected_buildings = DCN_buildings_df[DCN_buildings_df[DCN_buildings_list] > 0.00000].dropna(
-            axis=1).columns
-        DCN_connected_buildings = [x.split()[0] for x in DCN_connected_buildings]
+        # get centralized system sizes
+        cen_supply_sys_cooling = calc_cen_supply_sys_cooling(generation, individual, locator)
+        cen_supply_sys_electricity = calc_cen_supply_sys_electricity(network_name, generation, individual, locator)
+        # get centralized system cost
+        cen_capex_a_cooling, cen_opex_a_cooling = calc_cen_costs_cooling(generation, individual,
+                                                                         locator)  # FIXME: cost of PV?
 
         # get supply systems at decentralized buildings
-        DCN_decentralized_buildings = DCN_buildings_df[DCN_buildings_df[DCN_buildings_list] < 1.00000].dropna(
-            axis=1).columns
-        DCN_decentralized_buildings = [x.split()[0] for x in DCN_decentralized_buildings]
-        decentralized_tech_list = ['VCC', 'single effect ACH', 'double effect ACH', 'DX', 'SC']
-        bui_supply_sys = {}
-        for building in DCN_decentralized_buildings:
+        bui_supply_sys = []
+        for building in decentralized_buildings:
             bui_sys_config = calc_building_supply_system(individual_system_configuration, network_name)
-            bui_supply_sys[building] = calc_bui_sys_detail(building, bui_sys_config, locator)
+            bui_supply_sys.append(calc_bui_sys_detail(building, bui_sys_config, district_supply_sys_columns, locator))
+        for building in network_connected_buildings:
+            bui_supply_sys[building]
+
     return
+
+
+def calc_cen_costs_cooling(generation, individual, locator):
+    cooling_costs = pd.read_csv(
+        locator.get_optimization_slave_investment_cost_detailed_cooling(individual, generation))
+    capex_a_columns = [item for item in cooling_costs.columns if 'Capex_a' in item]
+    cen_capex_a = cooling_costs[capex_a_columns].sum(axis=1).values[0]
+    opex_a_columns = [item for item in cooling_costs.columns if 'Opex_a' in item]
+    cen_opex_a = cooling_costs[opex_a_columns].sum(axis=1).values[0]
+    return cen_capex_a, cen_opex_a
+
+
+def calc_cen_supply_sys_cooling(generation, individual, locator):
+    cooling_activation_column = ['Q_from_ACH_W', 'Q_from_Lake_W', 'Q_from_VCC_W', 'Q_from_VCC_backup_W',
+                                 'Q_from_storage_tank_W', 'Qc_CT_associated_with_all_chillers_W',
+                                 'Qh_CCGT_associated_with_absorption_chillers_W']
+    cooling_activation_pattern = pd.read_csv(
+        locator.get_optimization_slave_cooling_activation_pattern(individual, generation))
+    cen_cooling_sys = cooling_activation_pattern[cooling_activation_column].max()
+    return cen_cooling_sys
+
+
+def calc_cen_supply_sys_electricity(network_name, generation, individual, locator):
+    if network_name == 'DCN':
+        el_activation_columns = ['Area_PV_m2', 'E_CHP_to_directload_W', 'E_CHP_to_grid_W', 'E_PV_W', 'E_from_grid_W']
+        el_activation_pattern = pd.read_csv(
+            locator.get_optimization_slave_electricity_activation_pattern_cooling(individual, generation))
+        el_sys_activation_pattern = el_activation_pattern[el_activation_columns]
+        el_sys_activation_pattern['E_CHP_W'] = el_activation_pattern['E_CHP_to_directload_W'] + el_activation_pattern[
+            'E_CHP_to_grid_W']
+        el_sys_activation_pattern.drop('E_CHP_to_directload_W', axis=1, inplace=True)
+        el_sys_activation_pattern.drop('E_CHP_to_grid_W', axis=1, inplace=True)
+        cen_el_supply_sys = el_sys_activation_pattern.max()
+    elif network_name == 'DHN':
+        el_activation_columns = ['Area_PV_m2', 'E_CHP_to_directload_W', 'E_CHP_to_grid_W', 'E_PV_W', 'E_from_grid_W']
+        el_activation_pattern = pd.read_csv(
+            locator.get_optimization_slave_electricity_activation_pattern_heating(individual, generation))
+        el_sys_activation_pattern = el_activation_pattern[el_activation_columns]
+        el_sys_activation_pattern['E_CHP_W'] = el_activation_pattern['E_CHP_to_directload_W'] + el_activation_pattern[
+            'E_CHP_to_grid_W']
+        el_sys_activation_pattern.drop('E_CHP_to_directload_W', axis=1, inplace=True)
+        el_sys_activation_pattern.drop('E_CHP_to_grid_W', axis=1, inplace=True)
+        cen_el_supply_sys = el_sys_activation_pattern.max()
+    else:
+        raise ValueError('Wrong network_name')
+
+    return cen_el_supply_sys
+
+
+def calc_building_lists(individual_system_configuration, network_name):
+    buildings_list = [item for item in individual_system_configuration.columns if network_name in item and 'B' in item]
+    buildings_df = individual_system_configuration[buildings_list]
+    network_connected_buildings = buildings_df[buildings_df[buildings_list] > 0.00000].dropna(axis=1).columns
+    network_connected_buildings = [x.split()[0] for x in network_connected_buildings]
+    decentralized_buildings = buildings_df[buildings_df[buildings_list] < 1.00000].dropna(axis=1).columns
+    decentralized_buildings = [x.split()[0] for x in decentralized_buildings]
+    return network_connected_buildings, decentralized_buildings
 
 
 def calc_building_supply_system(individual_system_configuration, network_name):
@@ -72,7 +139,7 @@ def calc_building_supply_system(individual_system_configuration, network_name):
     return decentralized_config
 
 
-def calc_bui_sys_detail(building, bui_sys_config, locator):
+def calc_bui_sys_detail(building, bui_sys_config, district_supply_sys_columns, locator):
     # get nominal power and costs from disconnected calculation
     bui_results = pd.read_csv(
         locator.get_optimization_disconnected_folder_building_result_cooling(building, bui_sys_config))
@@ -83,15 +150,69 @@ def calc_bui_sys_detail(building, bui_sys_config, locator):
     technology_columns.extend(cost_columns)
     bui_results_best = bui_results_best[technology_columns].reset_index(drop=True)
 
-    # get installed area of solar collectors
-    sc_panel_types = ['FP', 'ET']
-    for panel_type in sc_panel_types:
-        columns = [item for item in bui_results_best.columns if panel_type in item]
-        for tech in columns:
-            if not np.isclose(bui_results_best[tech], 0.0):
-                installed_area = pd.read_csv(locator.SC_metadata_results(building, panel_type))[
-                    'area_installed_module_m2'].sum()
-                bui_results_best.loc[0, panel_type] = installed_area
+    # write building system configuration to output
+    bui_sys_detail = pd.DataFrame(columns=district_supply_sys_columns, index=[building])
+    bui_sys_detail = bui_sys_detail.fillna(0.0)
+
+    if not np.isclose(bui_results_best.loc[0, 'Nominal Power DX to AHU_ARU_SCU [W]'], 0.0):
+        bui_sys_detail.loc[building, 'DX [W]'] = bui_results_best.loc[0, 'Nominal Power DX to AHU_ARU_SCU [W]']
+        pv_installed_area = pd.read_csv(locator.PV_metadata_results(building))['area_installed_module_m2'].sum()
+        bui_sys_detail.loc[building, 'PV[m2]'] = pv_installed_area
+
+    elif not np.isclose(bui_results_best.loc[0, 'Nominal Power VCC to AHU_ARU_SCU [W]'], 0.0):
+        bui_sys_detail.loc[building, 'VCC(LT) [W]'] = bui_results_best.loc[0, 'Nominal Power VCC to AHU_ARU_SCU [W]']
+        pv_installed_area = pd.read_csv(locator.PV_metadata_results(building))['area_installed_module_m2'].sum()
+        bui_sys_detail.loc[building, 'PV[m2]'] = pv_installed_area
+
+    elif not np.isclose(bui_results_best.loc[0, 'Nominal Power single effect ACH to AHU_ARU_SCU (FP) [W]'], 0.0):
+        bui_sys_detail.loc[building, 'ACH(LT) [W]'] = bui_results_best.loc[0, 'Nominal Power single effect ACH to AHU_ARU_SCU (FP) [W]']
+        sc_installed_area = pd.read_csv(locator.SC_metadata_results(building, 'FP'))['area_installed_module_m2'].sum()
+        bui_sys_detail.loc[building, 'SC_FP [m2]'] = sc_installed_area
+
+    elif not np.isclose(bui_results_best.loc[0, 'Nominal Power single effect ACH to AHU_ARU_SCU (ET) [W]'], 0.0):
+        bui_sys_detail.loc[building, 'ACH(LT) [W]'] = bui_results_best.loc[0, 'Nominal Power single effect ACH to AHU_ARU_SCU (ET) [W]']
+        sc_installed_area = pd.read_csv(locator.SC_metadata_results(building, 'ET'))['area_installed_module_m2'].sum()
+        bui_sys_detail.loc[building, 'SC_ET [m2]'] = sc_installed_area
+
+    elif not np.isclose(bui_results_best.loc[0, 'Nominal Power VCC to SCU [W]'], 0.0):
+        bui_sys_detail.loc[building, 'VCC(HT) [W]'] = bui_results_best.loc[0, 'Nominal Power VCC to SCU [W]']
+        bui_sys_detail.loc[building, 'VCC(LT) [W]'] = bui_results_best.loc[0, 'Nominal Power VCC to AHU_ARU [W]']
+        pv_installed_area = pd.read_csv(locator.PV_metadata_results(building))['area_installed_module_m2'].sum()
+        bui_sys_detail.loc[building, 'PV[m2]'] = pv_installed_area
+
+    elif not np.isclose(bui_results_best.loc[0, 'Nominal Power single effect ACH to SCU (FP) [W]'], 0.0):
+        bui_sys_detail.loc[building, 'ACH(HT) [W]'] = bui_results_best.loc[0, 'Nominal Power single effect ACH to SCU (FP) [W]']
+        bui_sys_detail.loc[building, 'VCC(LT) [W]'] = bui_results_best.loc[0, 'Nominal Power VCC to AHU_ARU [W]']
+        sc_installed_area = pd.read_csv(locator.SC_metadata_results(building, 'FP'))['area_installed_module_m2'].sum()
+        bui_sys_detail.loc[building, 'SC_FP [m2]'] = sc_installed_area
+
+    else: raise ValueError ('No cooling system is specified for the decentralized building ', building)
+
+    bui_sys_detail.loc[building, 'Opex_a'] = bui_results_best.loc[0, 'Operation Costs [CHF]']
+    bui_sys_detail.loc[building, 'Capex_a'] = bui_results_best.loc[0, 'Annualized Investment Costs [CHF]']
+    #
+    # # get installed area of solar collectors
+    # sc_panel_types = ['FP', 'ET']
+    # for panel_type in sc_panel_types:
+    #     bui_results_best.loc[0, 'SC_' + panel_type + '[m2]'] = 0.0  # initiate a new column
+    #     columns = [item for item in bui_results_best.columns if panel_type in item]
+    #     for tech in columns:
+    #         if not np.isclose(bui_results_best[tech], 0.0):
+    #             sc_installed_area = pd.read_csv(locator.SC_metadata_results(building, panel_type))[
+    #                 'area_installed_module_m2'].sum()
+    #             bui_results_best.loc[0, 'SC_' + panel_type + '[m2]'] = sc_installed_area
+    #
+    # if np.isclose(bui_results_best['SC_FP[m2]'], 0.0) & np.isclose(bui_results_best['SC_ET[m2]'], 0.0):
+    #     pv_installed_area = pd.read_csv(locator.PV_metadata_results(building))['area_installed_module_m2'].sum()
+    #     bui_results_best.loc[0, 'PV[m2]'] = pv_installed_area
+
+    # bui_results_best.rename(columns={'Nominal Power DX to AHU_ARU_SCU [W]': 'DX [W]',
+    #                                  'Nominal Power VCC to AHU_ARU [W]': 'VCC [W]',
+    #                                  'Nominal Power VCC to AHU_ARU_SCU [W]': 'VCC [W]',
+    #                                  'Nominal Power VCC to SCU [W]': 'VCC_high_T [W]',
+    #                                  'Nominal Power single effect ACH to AHU_ARU_SCU (ET) [W]': 'single effect ACH [W]',
+    #                                  'Nominal Power single effect ACH to AHU_ARU_SCU (FP) [W]': 'single effect ACH [W]'},
+    #                         inplace = True)
 
     return bui_results_best
 

--- a/cea/plots/supply_system/individual_configuration.py
+++ b/cea/plots/supply_system/individual_configuration.py
@@ -110,31 +110,31 @@ def calc_cen_supply_sys_cooling(generation, individual, district_supply_sys_colu
     return cen_cooling_sys_detail
 
 
-def calc_cen_supply_sys_electricity(network_name, generation, individual, locator):
-    if network_name == 'DCN':
-        el_activation_columns = ['Area_PV_m2', 'E_CHP_to_directload_W', 'E_CHP_to_grid_W', 'E_PV_W', 'E_from_grid_W']
-        el_activation_pattern = pd.read_csv(
-            locator.get_optimization_slave_electricity_activation_pattern_cooling(individual, generation))
-        el_sys_activation_pattern = el_activation_pattern[el_activation_columns]
-        el_sys_activation_pattern['E_CHP_W'] = el_activation_pattern['E_CHP_to_directload_W'] + el_activation_pattern[
-            'E_CHP_to_grid_W']
-        el_sys_activation_pattern.drop('E_CHP_to_directload_W', axis=1, inplace=True)
-        el_sys_activation_pattern.drop('E_CHP_to_grid_W', axis=1, inplace=True)
-        cen_el_supply_sys = el_sys_activation_pattern.max()
-    elif network_name == 'DHN':
-        el_activation_columns = ['Area_PV_m2', 'E_CHP_to_directload_W', 'E_CHP_to_grid_W', 'E_PV_W', 'E_from_grid_W']
-        el_activation_pattern = pd.read_csv(
-            locator.get_optimization_slave_electricity_activation_pattern_heating(individual, generation))
-        el_sys_activation_pattern = el_activation_pattern[el_activation_columns]
-        el_sys_activation_pattern['E_CHP_W'] = el_activation_pattern['E_CHP_to_directload_W'] + el_activation_pattern[
-            'E_CHP_to_grid_W']
-        el_sys_activation_pattern.drop('E_CHP_to_directload_W', axis=1, inplace=True)
-        el_sys_activation_pattern.drop('E_CHP_to_grid_W', axis=1, inplace=True)
-        cen_el_supply_sys = el_sys_activation_pattern.max()
-    else:
-        raise ValueError('Wrong network_name')
-
-    return cen_el_supply_sys
+# def calc_cen_supply_sys_electricity(network_name, generation, individual, locator):
+#     if network_name == 'DCN':
+#         el_activation_columns = ['Area_PV_m2', 'E_CHP_to_directload_W', 'E_CHP_to_grid_W', 'E_PV_W', 'E_from_grid_W']
+#         el_activation_pattern = pd.read_csv(
+#             locator.get_optimization_slave_electricity_activation_pattern_cooling(individual, generation))
+#         el_sys_activation_pattern = el_activation_pattern[el_activation_columns]
+#         el_sys_activation_pattern['E_CHP_W'] = el_activation_pattern['E_CHP_to_directload_W'] + el_activation_pattern[
+#             'E_CHP_to_grid_W']
+#         el_sys_activation_pattern.drop('E_CHP_to_directload_W', axis=1, inplace=True)
+#         el_sys_activation_pattern.drop('E_CHP_to_grid_W', axis=1, inplace=True)
+#         cen_el_supply_sys = el_sys_activation_pattern.max()
+#     elif network_name == 'DHN':
+#         el_activation_columns = ['Area_PV_m2', 'E_CHP_to_directload_W', 'E_CHP_to_grid_W', 'E_PV_W', 'E_from_grid_W']
+#         el_activation_pattern = pd.read_csv(
+#             locator.get_optimization_slave_electricity_activation_pattern_heating(individual, generation))
+#         el_sys_activation_pattern = el_activation_pattern[el_activation_columns]
+#         el_sys_activation_pattern['E_CHP_W'] = el_activation_pattern['E_CHP_to_directload_W'] + el_activation_pattern[
+#             'E_CHP_to_grid_W']
+#         el_sys_activation_pattern.drop('E_CHP_to_directload_W', axis=1, inplace=True)
+#         el_sys_activation_pattern.drop('E_CHP_to_grid_W', axis=1, inplace=True)
+#         cen_el_supply_sys = el_sys_activation_pattern.max()
+#     else:
+#         raise ValueError('Wrong network_name')
+#
+#     return cen_el_supply_sys
 
 
 def calc_building_lists(individual_system_configuration, network_name):

--- a/cea/technologies/solar/constants.py
+++ b/cea/technologies/solar/constants.py
@@ -21,3 +21,6 @@ Pg = 0.2  # ground reflectance
 T_IN_SC_FP = 75
 T_IN_SC_ET = 100
 T_IN_PVT = 35
+
+# standard testing condition (STC)
+STC_RADIATION_Wperm2 = 1000

--- a/cea/technologies/solar/photovoltaic.py
+++ b/cea/technologies/solar/photovoltaic.py
@@ -684,22 +684,23 @@ def calc_properties_PV_db(database_path, config):
 
 # investment and maintenance costs
 # FIXME: it looks like this function is never used!!! (REMOVE)
-def calc_Cinv_pv(P_peak_kW, locator, config, technology=0):
+def calc_Cinv_pv(total_module_area_m2, locator, config, technology=0):
     """
     To calculate capital cost of PV modules, assuming 20 year system lifetime.
     :param P_peak: installed capacity of PV module [kW]
     :return InvCa: capital cost of the installed PV module [CHF/Y]
     """
-    P_peak = P_peak_kW * 1000  # converting to W from kW
     PV_cost_data = pd.read_excel(locator.get_supply_systems(config.region), sheetname="PV")
     technology_code = list(set(PV_cost_data['code']))
     PV_cost_data[PV_cost_data['code'] == technology_code[technology]]
+    nominal_efficiency = PV_cost_data[PV_cost_data['code'] == technology_code[technology]]['PV_n'].max()
+    P_nominal_W = total_module_area_m2 * (constants.STC_RADIATION_Wperm2 * nominal_efficiency)
     # if the Q_design is below the lowest capacity available for the technology, then it is replaced by the least
     # capacity for the corresponding technology from the database
-    if P_peak < PV_cost_data['cap_min'][0]:
-        P_peak = PV_cost_data['cap_min'][0]
+    if P_nominal_W < PV_cost_data['cap_min'][0]:
+        P_nominal_W = PV_cost_data['cap_min'][0]
     PV_cost_data = PV_cost_data[
-        (PV_cost_data['cap_min'] <= P_peak) & (PV_cost_data['cap_max'] > P_peak)]
+        (PV_cost_data['cap_min'] <= P_nominal_W) & (PV_cost_data['cap_max'] > P_nominal_W)]
     Inv_a = PV_cost_data.iloc[0]['a']
     Inv_b = PV_cost_data.iloc[0]['b']
     Inv_c = PV_cost_data.iloc[0]['c']
@@ -709,7 +710,7 @@ def calc_Cinv_pv(P_peak_kW, locator, config, technology=0):
     Inv_LT = PV_cost_data.iloc[0]['LT_yr']
     Inv_OM = PV_cost_data.iloc[0]['O&M_%'] / 100
 
-    InvC = Inv_a + Inv_b * (P_peak) ** Inv_c + (Inv_d + Inv_e * P_peak) * log(P_peak)
+    InvC = Inv_a + Inv_b * (P_nominal_W) ** Inv_c + (Inv_d + Inv_e * P_nominal_W) * log(P_nominal_W)
 
     Capex_a = InvC * (Inv_IR) * (1 + Inv_IR) ** Inv_LT / ((1 + Inv_IR) ** Inv_LT - 1)
     Opex_fixed = Capex_a * Inv_OM
@@ -728,7 +729,7 @@ def calc_Crem_pv(E_nom):
     :return KEV_obtained_in_RpPerkWh: KEV remuneration [Rp/kWh]
     :rtype KEV_obtained_in_RpPerkWh: float
     """
-
+    # TODO: change input argument to area_installed and then calculate the nominal capacity within this function, see calc_Cinv_pv
     KEV_regime = [0, 0, 20.4, 20.4, 20.4, 20.4, 20.4, 20.4, 19.7, 19.3, 19, 18.9, 18.7, 18.6, 18.5, 18.1, 17.9, 17.8,
                   17.8, 17.7, 17.7, 17.7, 17.6, 17.6]
     P_installed_in_kW = [0, 9.99, 10, 12, 15, 20, 29, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300, 400, 500, 750, 1000,


### PR DESCRIPTION
This PR resolves i1534
1. A new script `individual_configuration.py` is added to `cea/plots/supply_system`
The output of the script is a dataframe containing all technologies installed at building and disctirct levels.
2. Meanwhile, the cost function `calc_Cinv_PV` is also changed, please check the compatibility in the `cost_model.py`

To test:
- [ ] run  `individual_configuration.py`  with any generation and any individual, and check output
- [ ] check optimisation is still running with update 2.
