### PR TITLE
I1542 qcre takes 3 arguments

### DIFF
--- a/cea/demand/refrigeration_loads.py
+++ b/cea/demand/refrigeration_loads.py
@@ -58,7 +58,7 @@ def calc_Qref(locator, bpr, tsd, region):
     # GET SYSTEMS EFFICIENCIES
     data_systems = pd.read_excel(locator.get_life_cycle_inventory_supply_systems(region), "COOLING").set_index('code')
     type_system = bpr.supply['type_cs']
-    energy_source = data_systems.loc[type_system, "SOURCE"]
+    energy_source = data_systems.loc[type_system, 'source_cs']
 
     if energy_source == "GRID":
         if bpr.supply['type_cs'] in {'T2', 'T3'}:

--- a/cea/demand/thermal_loads.py
+++ b/cea/demand/thermal_loads.py
@@ -81,6 +81,15 @@ def calc_thermal_loads(building_name, bpr, weather_data, usage_schedules, date, 
         #CALCULATE ELECTRICITY LOADS
         tsd = electrical_loads.calc_Eal_Epro(tsd, bpr, schedules)
 
+        # CALCULATE REFRIGERATION LOADS
+        if refrigeration_loads.has_refrigeration_load(bpr):
+            tsd = refrigeration_loads.calc_Qcre_sys(bpr, tsd, schedules)
+            tsd = refrigeration_loads.calc_Qref(locator, bpr, tsd, region)
+        else:
+            tsd['DC_cre'] = tsd['Qcre_sys'] = tsd['Qcre'] = np.zeros(8760)
+            tsd['mcpcre_sys'] = tsd['Tcre_sys_re'] = tsd['Tcre_sys_sup'] = np.zeros(8760)
+            tsd['E_cre'] = np.zeros(8760)
+
         #UPDATE ALL VALUES TO 0
         tsd = update_timestep_data_no_conditioned_area(tsd)
 

--- a/cea/demand/thermal_loads.py
+++ b/cea/demand/thermal_loads.py
@@ -91,8 +91,8 @@ def calc_thermal_loads(building_name, bpr, weather_data, usage_schedules, date, 
 
         # CALCULATE REFRIGERATION LOADS
         if refrigeration_loads.has_refrigeration_load(bpr):
-            tsd = refrigeration_loads.calc_Qcre_sys(tsd)
-            tsd = refrigeration_loads.calc_Qref(tsd)
+            tsd = refrigeration_loads.calc_Qcre_sys(bpr, tsd, schedules)
+            tsd = refrigeration_loads.calc_Qref(locator, bpr, tsd, region)
         else:
             tsd['DC_cre'] = tsd['Qcre_sys'] = tsd['Qcre'] = np.zeros(8760)
             tsd['mcpcre_sys'] = tsd['Tcre_sys_re'] = tsd['Tcre_sys_sup'] = np.zeros(8760)

--- a/cea/demand/thermal_loads.py
+++ b/cea/demand/thermal_loads.py
@@ -88,7 +88,7 @@ def calc_thermal_loads(building_name, bpr, weather_data, usage_schedules, date, 
         tsd['mcpcre_sys'] = tsd['Tcre_sys_re'] = tsd['Tcre_sys_sup'] = np.zeros(8760)
         tsd['E_cre'] = np.zeros(8760)
 
-    if bpr.rc_model['Af'] == 0:  # if building does not have conditioned area
+    if np.isclose(bpr.rc_model['Af'], 0.0):  # if building does not have conditioned area
 
         #UPDATE ALL VALUES TO 0
         tsd = update_timestep_data_no_conditioned_area(tsd)

--- a/cea/demand/thermal_loads.py
+++ b/cea/demand/thermal_loads.py
@@ -76,36 +76,24 @@ def calc_thermal_loads(building_name, bpr, weather_data, usage_schedules, date, 
 """
     schedules, tsd = initialize_inputs(bpr, usage_schedules, weather_data, use_stochastic_occupancy)
 
+    # CALCULATE ELECTRICITY LOADS
+    tsd = electrical_loads.calc_Eal_Epro(tsd, bpr, schedules)
+
+    # CALCULATE REFRIGERATION LOADS
+    if refrigeration_loads.has_refrigeration_load(bpr):
+        tsd = refrigeration_loads.calc_Qcre_sys(bpr, tsd, schedules)
+        tsd = refrigeration_loads.calc_Qref(locator, bpr, tsd, region)
+    else:
+        tsd['DC_cre'] = tsd['Qcre_sys'] = tsd['Qcre'] = np.zeros(8760)
+        tsd['mcpcre_sys'] = tsd['Tcre_sys_re'] = tsd['Tcre_sys_sup'] = np.zeros(8760)
+        tsd['E_cre'] = np.zeros(8760)
+
     if bpr.rc_model['Af'] == 0:  # if building does not have conditioned area
-
-        #CALCULATE ELECTRICITY LOADS
-        tsd = electrical_loads.calc_Eal_Epro(tsd, bpr, schedules)
-
-        # CALCULATE REFRIGERATION LOADS
-        if refrigeration_loads.has_refrigeration_load(bpr):
-            tsd = refrigeration_loads.calc_Qcre_sys(bpr, tsd, schedules)
-            tsd = refrigeration_loads.calc_Qref(locator, bpr, tsd, region)
-        else:
-            tsd['DC_cre'] = tsd['Qcre_sys'] = tsd['Qcre'] = np.zeros(8760)
-            tsd['mcpcre_sys'] = tsd['Tcre_sys_re'] = tsd['Tcre_sys_sup'] = np.zeros(8760)
-            tsd['E_cre'] = np.zeros(8760)
 
         #UPDATE ALL VALUES TO 0
         tsd = update_timestep_data_no_conditioned_area(tsd)
 
     else:
-
-        #CALCULATE ELECTRICITY LOADS PART 1/2 INTERNAL LOADS (appliances and lighting)
-        tsd = electrical_loads.calc_Eal_Epro(tsd, bpr, schedules)
-
-        # CALCULATE REFRIGERATION LOADS
-        if refrigeration_loads.has_refrigeration_load(bpr):
-            tsd = refrigeration_loads.calc_Qcre_sys(bpr, tsd, schedules)
-            tsd = refrigeration_loads.calc_Qref(locator, bpr, tsd, region)
-        else:
-            tsd['DC_cre'] = tsd['Qcre_sys'] = tsd['Qcre'] = np.zeros(8760)
-            tsd['mcpcre_sys'] = tsd['Tcre_sys_re'] = tsd['Tcre_sys_sup'] = np.zeros(8760)
-            tsd['E_cre'] = np.zeros(8760)
 
         #CALCULATE PROCESS HEATING
         tsd['Qhpro_sys'][:] = schedules['Qhpro'] * bpr.internal_loads['Qhpro_Wm2']  # in kWh

--- a/cea/demand/thermal_loads.py
+++ b/cea/demand/thermal_loads.py
@@ -95,7 +95,7 @@ def calc_thermal_loads(building_name, bpr, weather_data, usage_schedules, date, 
 
     else:
 
-        #CALCULATE ELECTRICITY LOADS PART 1/2 INTERNAL LOADS (appliances  and lighting
+        #CALCULATE ELECTRICITY LOADS PART 1/2 INTERNAL LOADS (appliances and lighting)
         tsd = electrical_loads.calc_Eal_Epro(tsd, bpr, schedules)
 
         # CALCULATE REFRIGERATION LOADS


### PR DESCRIPTION
This PR solves four different minor issues:
1) since COOLROOM building types have Hs=0, the electricity demand for refrigeration was not calculated for this building type (which is the only type that has refrigeration by default)
2) the wrong number of arguments was passed to the function `refrigeration_loads.calc_Qcre_sys`
3) the wrong number of arguments was passed to the function `refrigeration_loads.calc_Qref`
4) the wrong label was used for a column in the DataFrame `energy_source` in `refrigeration_loads.calc_Qref`