### PR TITLE
I1735 fix full demand reporting

### DIFF
--- a/cea/demand/hourly_procedure_heating_cooling_system_load.py
+++ b/cea/demand/hourly_procedure_heating_cooling_system_load.py
@@ -284,7 +284,7 @@ def calc_heat_loads_central_ac(bpr, t, tsd):
         ta_sup_hs_aru = np.nan
         ta_re_hs_aru = np.nan
         tsd['sys_status_aru'][t] = 'Off'
-        tsd['sys_status_ahu'][t] = 'On - over heating'
+        tsd['sys_status_ahu'][t] = 'On:over heating'
 
     elif 0.0 <= qh_sen_central_ac_load < qh_sen_rc_demand:
 
@@ -416,6 +416,11 @@ def calc_cool_loads_mini_split_ac(bpr, t, tsd):
     q_em_ls_cooling = space_emission_systems.calc_q_em_ls_cooling(bpr, tsd, t)
     tsd['Qcs_em_ls'][t] = q_em_ls_cooling
 
+    # system status
+    tsd['sys_status_aru'][t] = 'On:T'
+    tsd['sys_status_ahu'][t] = 'no system'
+    tsd['sys_status_sen'][t] = 'no system'
+
     # the return is only for the input into the detailed thermal reverse calculations for the dashboard graphs
     return rc_model_temperatures
 
@@ -513,6 +518,11 @@ def calc_cool_loads_central_ac(bpr, t, tsd):
     # TODO: check
     q_em_ls_cooling = space_emission_systems.calc_q_em_ls_cooling(bpr, tsd, t)
     tsd['Qcs_em_ls'][t] = q_em_ls_cooling
+
+    # system status
+    tsd['sys_status_ahu'][t] = 'On'
+    tsd['sys_status_aru'][t] = 'On:T/R'
+    tsd['sys_status_sen'][t] = 'no system'
 
     # the return is only for the input into the detailed thermal reverse calculations for the dashboard graphs
     return rc_model_temperatures
@@ -619,6 +629,11 @@ def calc_cool_loads_3for2(bpr, t, tsd):
 
     q_em_ls_cooling = space_emission_systems.calc_q_em_ls_cooling(bpr, tsd, t)
     tsd['Qcs_em_ls'][t] = q_em_ls_cooling
+
+    # system status
+    tsd['sys_status_ahu'][t] = 'On'
+    tsd['sys_status_aru'][t] = 'On:R'
+    tsd['sys_status_sen'][t] = 'On'
 
     # the return is only for the input into the detailed thermal reverse calculations for the dashboard graphs
     return rc_model_temperatures

--- a/cea/demand/thermal_loads.py
+++ b/cea/demand/thermal_loads.py
@@ -13,7 +13,7 @@ from cea.demand import sensible_loads, electrical_loads, hotwater_loads, refrige
 from cea.demand import ventilation_air_flows_detailed, control_heating_cooling_systems
 from cea.technologies import heatpumps
 
-import cea.utilities
+from cea.utilities import reporting
 
 def calc_thermal_loads(building_name, bpr, weather_data, usage_schedules, date, locator, use_stochastic_occupancy,
                        use_dynamic_infiltration_calculation, resolution_outputs, loads_output, massflows_output,
@@ -179,7 +179,7 @@ def write_results(bpr, building_name, date, format_output, loads_output, locator
 
     # write report & quick visualization
     # (NOTE: uncomment to write full report for debugging purposes)
-    # cea.utilities.reporting.full_report_to_xls(tsd, locator.get_demand_results_folder(), building_name)
+    reporting.full_report_to_xls(tsd, locator.get_demand_results_folder(), building_name)
 
 
 def calc_Qcs_sys(bpr, tsd):

--- a/cea/demand/thermal_loads.py
+++ b/cea/demand/thermal_loads.py
@@ -179,7 +179,7 @@ def write_results(bpr, building_name, date, format_output, loads_output, locator
 
     # write report & quick visualization
     # (NOTE: uncomment to write full report for debugging purposes)
-    reporting.full_report_to_xls(tsd, locator.get_demand_results_folder(), building_name)
+    # reporting.full_report_to_xls(tsd, locator.get_demand_results_folder(), building_name)
 
 
 def calc_Qcs_sys(bpr, tsd):

--- a/cea/utilities/reporting.py
+++ b/cea/utilities/reporting.py
@@ -7,9 +7,7 @@ import os
 from plotly.offline import plot
 import plotly.graph_objs as go
 
-from cea.demand.thermal_loads import TSD_KEYS_HEATING_LOADS, TSD_KEYS_HEATING_TEMP, TSD_KEYS_RC_TEMP, \
-    TSD_KEYS_COOLING_LOADS, TSD_KEYS_MOISTURE, TSD_KEYS_VENTILATION_FLOWS, TSD_KEYS_COOLING_SUPPLY_TEMP, \
-    TSD_KEYS_COOLING_SUPPLY_FLOWS
+
 
 __author__ = "Gabriel Happle"
 __copyright__ = "Copyright 2015, Architecture and Building Systems - ETH Zurich"
@@ -40,18 +38,25 @@ def full_report_to_xls(tsd, output_folder, basename):
     writer.close()
 
     # quick visualization
-    quick_visualization_tsd(tsd, output_folder, basename)
+    # UNCOMMENT THE NEXT LINE TO PRODUCE QUICK VISUALIZATIONS WITH PLOTLY OF THE DEMAND CALCULATION IN BUILDINGS
+    # quick_visualization_tsd(tsd, output_folder, basename)
 
 
 def quick_visualization_tsd(tsd, output_folder, building_name):
 
-    plot_heat_load = False
-    plot_heat_temp = False
+    # import keys
+    from cea.demand.thermal_loads import TSD_KEYS_HEATING_LOADS, TSD_KEYS_HEATING_TEMP, TSD_KEYS_RC_TEMP, \
+        TSD_KEYS_COOLING_LOADS, TSD_KEYS_MOISTURE, TSD_KEYS_VENTILATION_FLOWS, TSD_KEYS_COOLING_SUPPLY_TEMP, \
+        TSD_KEYS_COOLING_SUPPLY_FLOWS
+
+    # set to True to produce plotly graphs of selected variables
+    plot_heat_load = True
+    plot_heat_temp = True
     plot_cool_load = True
     plot_cool_moisture = True
     plot_cool_air = True
     plot_cool_sup = True
-    auto_open = False
+    auto_open = True
 
     if plot_heat_load:
         filename = os.path.join(output_folder, "heat-load-{}.html").format(building_name)


### PR DESCRIPTION
this fixes the full reporting to `.xls` function of the demand calculation.

It can be activated by uncommenting line 182 in `thermal_loads.py`.

Following changes have been made additionally:

- deactivate the quick visualization (plotly) of the demand.
- some reporting `system_status` variables of cooling systems.

Assigning @shanshanhsieh and @BhargavaKrishnaSreepathi to test and merge, since they are currently using this functionality.