### PR TITLE
Show default values for tool parameters in cea and cea-config

### DIFF
--- a/cea/interfaces/cli/cli.py
+++ b/cea/interfaces/cli/cli.py
@@ -77,6 +77,7 @@ def main(config=None):
 def print_help(config, remaining_args):
     """Print out the help message for the ``cea`` command line interface"""
     if remaining_args:
+        default_config = cea.config.Configuration(config_file=cea.config.DEFAULT_CONFIG)
         script_name = remaining_args[0]
         try:
             cea_script = cea.scripts.by_name(script_name)
@@ -91,6 +92,7 @@ def print_help(config, remaining_args):
         for _, parameter in config.matching_parameters(cea_script.parameters):
             print("--%s: %s" % (parameter.name, parameter.get()))
             print("    %s" % parameter.help)
+            print("    (default: %s)" % default_config.get(parameter.fqname))
     else:
         print("usage: cea SCRIPT [OPTIONS]")
         print("       to run a specific script")

--- a/cea/scripts.py
+++ b/cea/scripts.py
@@ -23,6 +23,7 @@ class CeaScript(object):
         was responsible for printing their own parameters, but that requires manually keeping track of these
         parameters.
         """
+        default_config = cea.config.Configuration(config_file=cea.config.DEFAULT_CONFIG)
         print('City Energy Analyst version %s' % cea.__version__)
         script_name = self.name
         print("%(verb)s `cea %(script_name)s` with the following parameters:" % locals())
@@ -31,6 +32,7 @@ class CeaScript(object):
             parameter_name = parameter.name
             parameter_value = parameter.get()
             print("- %(section_name)s:%(parameter_name)s = %(parameter_value)s" % locals())
+            print("  (default: %s)" % default_config.get(parameter.fqname))
 
 
 def _get_categories_dict():

--- a/cea/utilities/dbf.py
+++ b/cea/utilities/dbf.py
@@ -7,11 +7,15 @@ A collection of utility functions for working with ``*.DBF`` (dBase database) fi
 
 """
 
-import pysal
 import numpy as np
 import pandas as pd
 import os
 import cea.config
+
+# import PySAL without the warning
+import warnings
+warnings.simplefilter('ignore', np.VisibleDeprecationWarning)
+import pysal
 
 __author__ = "Clayton Miller"
 __copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"


### PR DESCRIPTION
implements #1631. To test, run the commands `cea --help data-helper` or `cea-config data-helper` (or any other script the cea implements).

Also, the default values are shown when running scripts via the `cea` command.