### PR TITLE
Release 2.9.2

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,12 +1,46 @@
 How to Cite
 ===========
 
-The CEA team. City Energy Analyst v 2.91. Zenodo. http://doi.org/10.5281/zenodo.1487867. 2018.
+The CEA team. City Energy Analyst v 2.9.2. Zenodo. FIXME: @JIMENOFONSECA add this!. 2019.
 
 The CEA team
 ============
 Starting from version 2.9.1 the credits are structured alphabetically (surname) and split into the categories of developers,
 scrum master, project owner, project sponsor and collaborators.
+
+
+  - Version 2.9.1 - December 2018
+
+    Developers:
+    * [Amr Elesawy](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/amr-elesawy.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+    * [Gabriel Happle](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/gabriel-happle.html)
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+    * [Martín Mosteiro Romero](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/martin-mosteiro-romero.html)
+    * [Zhongming Shi](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/zhongming-shi.html)
+    * [Bhargava Krishna Sreepathi ](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/sreepathi-bhargava-krishna.html)
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Scrum master:
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+
+    Project owner:
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+
+    Project sponsor:
+    * [Arno Schlueter](http://www.systems.arch.ethz.ch/about-us/team/arno-schlueter.html)
+
+    Collaborators:
+    * Jose Bello
+    * Kian Wee Chen
+    * Jack Hawthorne
+    * Fazel Khayatian
+    * Victor Marty
+    * Paul Neitzel
+    * Thuy-An Nguyen
+    * Lennart Rogenhofer
+    * Bo Lie Ong
+    * Tim Vollrath
 
   - Version 2.9.1 - December 2018
   

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.1"
+__version__ = "2.9.2a1"
 
 
 class ConfigError(Exception):

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.9.2a1"
+__version__ = "2.9.2"
 
 
 class ConfigError(Exception):

--- a/cea/config.py
+++ b/cea/config.py
@@ -640,6 +640,10 @@ class ScenarioNameParameter(ChoiceParameter):
             return self._choices[0]
         return str(value)
 
+    def decode(self, value):
+        # allow scenario name to be non-existing folder when reading from config file...
+        return str(value)
+
     @property
     def _choices(self):
         # set the `._choices` attribute to the list of scenarios in the project

--- a/cea/datamanagement/data_helper.py
+++ b/cea/datamanagement/data_helper.py
@@ -63,7 +63,7 @@ def data_helper(locator, config, prop_architecture_flag, prop_hvac_flag, prop_co
     # get occupant densities from archetypes schedules
     occupant_densities = {}
     for use in list_uses:
-        archetypes_schedules = pd.read_excel(locator.get_archetypes_schedules(config.region), use).T
+        archetypes_schedules = pd.read_excel(locator.get_archetypes_schedules(config.region), use, index_col=0).T
         area_per_occupant = archetypes_schedules['density'].values[:1][0]
         if area_per_occupant > 0:
             occupant_densities[use] = 1 / area_per_occupant

--- a/cea/interfaces/arcgis/arcgishelper.py
+++ b/cea/interfaces/arcgis/arcgishelper.py
@@ -458,6 +458,13 @@ class PathParameterInfoBuilder(ParameterInfoBuilder):
         return parameter
 
 
+class ScenarioParameterInfoBuilder(ParameterInfoBuilder):
+    def get_parameter_info(self):
+        parameter = super(ScenarioParameterInfoBuilder, self).get_parameter_info()
+        parameter.datatype = 'DEFolder'
+        return parameter
+
+
 class ChoiceParameterInfoBuilder(ParameterInfoBuilder):
     def get_parameter_info(self):
         parameter = super(ChoiceParameterInfoBuilder, self).get_parameter_info()
@@ -779,6 +786,7 @@ def list_buildings(scenario):
 
 
 BUILDERS = {  # dict[cea.config.Parameter, ParameterInfoBuilder]
+    cea.config.ScenarioParameter: ScenarioParameterInfoBuilder,
     cea.config.PathParameter: PathParameterInfoBuilder,
     cea.config.StringParameter: StringParameterInfoBuilder,
     cea.config.BooleanParameter: ScalarParameterInfoBuilder,

--- a/cea/scripts.yml
+++ b/cea/scripts.yml
@@ -160,7 +160,7 @@ Sensitivity analysis:
   interfaces: [cli, arcgis, dashboard]
   module: cea.analysis.sensitivity.sensitivity_demand_samples
   parameters: ['general:scenario', 'sensitivity-demand:num-samples', 'sensitivity-demand:samples-folder',
-               'sensitivity-demand:method', 'sensitivity-demand:calc-second-order', 'sensitivity-demand:grid-jump',
+               'sensitivity-demand:method', 'sensitivity-demand:calc-second-order',
                'sensitivity-demand:num-levels', 'sensitivity-demand:variable-groups']
 
 - name: sensitivity-demand-simulate

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('README.rst', 'r') as f:
     LONG_DESCRIPTION = f.read()
 
 INSTALL_REQUIRES = ['setuptools', 'doit==0.29.0', 'py4design', 'requests', 'xlrd', 'utm', 'pyyaml', 'sphinx', 'twine',
-                    'ipython', 'pymc3', 'seaborn', 'SALib', 'xlwt', 'jupyter', 'plotly', 'mock']
+                    'ipython', 'pymc3', 'seaborn', 'SALib', 'xlwt', 'jupyter', 'plotly', 'mock', 'pysal']
 
 # For building the documentation on readthedocs, exclude some of the packages, as they create build errors...
 if os.environ.get('READTHEDOCS') == 'True':

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('README.rst', 'r') as f:
     LONG_DESCRIPTION = f.read()
 
 INSTALL_REQUIRES = ['setuptools', 'doit==0.29.0', 'py4design', 'requests', 'xlrd', 'utm', 'pyyaml', 'sphinx', 'twine',
-                    'ipython', 'pymc3', 'seaborn', 'SALib', 'xlwt', 'jupyter', 'plotly']
+                    'ipython', 'pymc3', 'seaborn', 'SALib', 'xlwt', 'jupyter', 'plotly', 'mock']
 
 # For building the documentation on readthedocs, exclude some of the packages, as they create build errors...
 if os.environ.get('READTHEDOCS') == 'True':


### PR DESCRIPTION
implements #1710 (Make release 2.9.1) but also includes some fixes:

- #1755 (cea unusable if C:\reference-case-open\baseline doesn't exist))
- #1771 cea env needs to include mock (to test: new environment, run `cd docs; make html`)
