### PR TITLE
Fixed typo that caused the issue

### DIFF
--- a/cea/demand/demand_writers.py
+++ b/cea/demand/demand_writers.py
@@ -89,7 +89,7 @@ class DemandWriter(object):
         else:
             self.temperature_vars = temperatures
 
-        self.OTHER_VARS = ['Name', 'Af_m2', 'Aroof_m2', 'GFA_m2', 'NFA_m2' 'people0']
+        self.OTHER_VARS = ['Name', 'Af_m2', 'Aroof_m2', 'GFA_m2', 'NFA_m2', 'people0']
 
     def results_to_hdf5(self, tsd, bpr, locator, date, building_name):
         columns, hourly_data = self.calc_hourly_dataframe(building_name, date, tsd)


### PR DESCRIPTION
A typo in the demand writer for 'Total_demand' caused the columns 'NFA_m2' and 'people0' to be exported as 'NFA_m2people0', so when the demand files were called up (e.g. for operation costs) the column 'NFA' was missing.
