### PR TITLE
753 remove low hanging fruit global variables

### DIFF
--- a/cea/demand/metamodel/nn_generator/input_matrix.py
+++ b/cea/demand/metamodel/nn_generator/input_matrix.py
@@ -374,7 +374,6 @@ def get_array_HVAC_variables(building):
 
 
 def main(config):
-    gv = cea.globalvar.GlobalVariables()
     locator = cea.inputlocator.InputLocator(scenario=config.scenario)
     building_name = 'B001'
     settings = config.demand

--- a/cea/demand/metamodel/nn_generator/input_prepare.py
+++ b/cea/demand/metamodel/nn_generator/input_prepare.py
@@ -100,7 +100,6 @@ def input_prepare_main(list_building_names, locator, target_parameters, nn_delay
 
 
 def main(config):
-    gv = cea.globalvar.GlobalVariables()
     settings = config.demand
     use_daysim_radiation = settings.use_daysim_radiation
     weather_data = epwreader.epw_reader(config.weather)[['year', 'drybulb_C', 'wetbulb_C',

--- a/cea/inputlocator.py
+++ b/cea/inputlocator.py
@@ -805,7 +805,7 @@ class InputLocator(object):
 
     def get_sensitivity_plots_file(self, parameter):
         """scenario/outputs/plots/sensitivity/${PARAMETER}.pdf"""
-        return os.path.join(self.scenario, 'outputs', 'plots', 'sensitivity', '%s.pdf' % parameter)
+        return os.path.join(self._ensure_folder(self.scenario, 'outputs', 'plots', 'sensitivity'), '%s.pdf' % parameter)
 
     ## POTENTIALS #FIXME: find better placement for these two locators
 

--- a/cea/optimization/master/normalization.py
+++ b/cea/optimization/master/normalization.py
@@ -147,18 +147,18 @@ def normalize_epsIndicator(locator, generation):
 
 
 
-def decentralizeCosts(individual, locator, gV):
+def decentralizeCosts(individual, locator, gv):
     """
     :param individual: list of all parameters corresponding to an individual configuration
     :param locator: locator set to the scenario
-    :param gV: global variables
+    :param gv: global variables
     :type individual: list
     :type locator: string
-    :type gV: class
+    :type gv: class
     :return: costsDisc
     :rtype: float
     """
-    indCombi = sFn.individual_to_barcode(individual, gV)
+    indCombi = sFn.individual_to_barcode(individual, gv)
     buildList = sFn.extract_building_names_from_csv(locator.pathRaw + "/Total.csv")
     costsDisc = 0
 

--- a/cea/optimization/slave/seasonal_storage/design_operation.py
+++ b/cea/optimization/slave/seasonal_storage/design_operation.py
@@ -32,7 +32,6 @@ def Storage_Design(CSV_NAME, SOLCOL_TYPE, T_storage_old_K, Q_in_storage_old_W, l
     :param STORE_DATA:
     :param master_to_slave_vars:
     :param P_HP_max_W:
-    :param gV:
     :type CSV_NAME:
     :type SOLCOL_TYPE:
     :type T_storage_old_K:

--- a/cea/optimization/slave_data.py
+++ b/cea/optimization/slave_data.py
@@ -52,7 +52,7 @@ class SlaveData(object):
 
         # Furnace
         self.Furnace_Q_max_W = 0.0
-        self.Furn_Moist_type = "wet"  # gV.Furn_Moist_type # set the moisture content of wood chips, either "dry" or "wet"
+        self.Furn_Moist_type = "wet"  # set the moisture content of wood chips, either "dry" or "wet"
 
         # GAS TURBINE VARIABLES
         # self.gt_size = 1.0E6 # in Watt

--- a/cea/optimization/supportFn.py
+++ b/cea/optimization/supportFn.py
@@ -48,10 +48,8 @@ def calcQmax(file_name, path):
     Calculates the peak heating power in fName file
     :param file_name: name of the csv file
     :param path: path to the file
-    :param gV: global variables
     :type file_name: string
     :type path: string
-    :type gV: class
     :return: Qmax: maximum heating power [W]
     :rtype: float
     """
@@ -66,9 +64,7 @@ def individual_to_barcode(individual, building_list):
     Reads the 0-1 combination of connected/disconnected buildings
     and creates a list of strings type barcode i.e. ("12311111123012")
     :param individual: list containing the combination of connected/disconnected buildings
-    :param gV: global variables
     :type individual: list
-    :type gV: class
     :return: indCombi: list of strings
     :rtype: list
     """

--- a/cea/plots/old/graphs_optimization.py
+++ b/cea/plots/old/graphs_optimization.py
@@ -431,7 +431,6 @@ def test_graphs_optimization(config):
     # print "Network Optimization \n"
     # finalDir = CodePath + "distribution/"
     # ntwFeat = ntwM.ntwMain2(matlabDir, finalDir, header)
-    # gV = glob.globalVariables()
     # print "Compute electricity needs for all buildings"
     # elecCosts, elecCO2, elecPrim = elecMain.elecOp(pathX, gV)
     # print elecCosts, elecCO2, elecPrim, "elecCosts, elecCO2, elecPrim \n"

--- a/cea/plots/old/sensitivity_demand_graphs.py
+++ b/cea/plots/old/sensitivity_demand_graphs.py
@@ -10,6 +10,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.collections import EllipseCollection
 from matplotlib.backends.backend_pdf import PdfPages
+import cea.config
+import cea.inputlocator
 
 
 __author__ = "Jimeno A. Fonseca"
@@ -84,16 +86,14 @@ def graph(locator, parameters, method, samples):
         plt.clf()
         pdf.close()
 
-def run_as_script():
-    import cea.globalvar
-    import cea.inputlocator as inputlocator
-    gv = cea.globalvar.GlobalVariables()
-    scenario_path = gv.scenario_reference
-    locator = inputlocator.InputLocator(scenario=scenario_path)
+
+def main(config):
+    locator = cea.inputlocator.InputLocator(scenario=config.scenario)
     output_parameters = ['QHf_MWhyr', 'QCf_MWhyr', 'Ef_MWhyr', 'QEf_MWhyr']
     method = 'sobol' # method
     samples = 1000
     graph(locator, output_parameters, method, samples)
 
+
 if __name__ == '__main__':
-    run_as_script()
+    main(cea.config.Configuration())

--- a/cea/resources/natural_gas.py
+++ b/cea/resources/natural_gas.py
@@ -16,13 +16,13 @@ __status__ = "Production"
 
 # investment and maintenance costs
 
-def calc_Cinv_gas(PnomGas, gV):
+def calc_Cinv_gas(PnomGas, gv):
     """
     Calculate investment cost of natural gas connections.
 
     :param PnomGas: peak natural gas supply in [W]
     :type PnomGas: float
-    :param gV: globalvar.py
+    :param gv: globalvar.py
 
     :returns InvCa:
     :rtype InvCa:
@@ -30,6 +30,6 @@ def calc_Cinv_gas(PnomGas, gV):
     """
 
     InvCa = 0
-    InvCa = gV.GasConnectionCost * PnomGas # from Energie360 - Zurich
+    InvCa = gv.GasConnectionCost * PnomGas # from Energie360 - Zurich
 
     return InvCa

--- a/cea/technologies/boiler.py
+++ b/cea/technologies/boiler.py
@@ -84,8 +84,6 @@ def cond_boiler_op_cost(Q_therm_W, Q_design_W, T_return_to_boiler_K, BoilerFuelT
     :type T_return_to_boiler_K : float
     :param T_return_to_boiler_K: return temperature to Boiler (from DH network)
 
-    :param gV: globalvar.py
-
     :rtype C_boil_therm : float
     :returns C_boil_therm: Total generation cost for required load (per hour) in CHF
 
@@ -178,8 +176,6 @@ def calc_Cinv_boiler(Q_design_W, locator, config, technology_type):
 
     :type Q_design_W : float
     :param Q_design_W: Design Load of Boiler in [W]
-
-    :param gV: globalvar.py
 
     :rtype InvCa : float
     :returns InvCa: Annualized investment costs in CHF/a including Maintenance Cost

--- a/cea/technologies/burner.py
+++ b/cea/technologies/burner.py
@@ -51,7 +51,6 @@ def burner_op_cost(Q_load_W, Q_design_W, FuelType, ElectricityType, lca, prices)
     :param Q_design_W: Design Load of Boiler
     :type T_return_to_boiler_K : float
     :param T_return_to_boiler_K: return temperature to Boiler (from DH network)
-    :param gV: globalvar.py
     :rtype C_boil_therm : float
     :returns C_boil_therm: Total generation cost for required load (per hour) in CHF
     :rtype C_boil_per_Wh : float
@@ -92,7 +91,6 @@ def calc_Cinv_burner(Q_design_W, locator, config, technology_type):
     Assume the same cost as gas boilers.
     :type Q_design_W : float
     :param Q_design_W: Design Load of Boiler in [W]
-    :param gV: globalvar.py
     :rtype InvCa : float
     :returns InvCa: Annualized investment costs in CHF/a including Maintenance Cost
     """

--- a/cea/technologies/chiller_absorption.py
+++ b/cea/technologies/chiller_absorption.py
@@ -166,7 +166,6 @@ def calc_Cinv_ACH(qcold_W, locator, ACH_type, config):
     Annualized investment costs for the vapor compressor chiller
     :type qcold_W : float
     :param qcold_W: peak cooling demand in [W]
-    :param gV: globalvar.py
     :returns InvCa: annualized chiller investment cost in CHF/a
     :rtype InvCa: float
     """

--- a/cea/technologies/chiller_vapor_compression.py
+++ b/cea/technologies/chiller_vapor_compression.py
@@ -103,7 +103,6 @@ def calc_Cinv_VCC(qcold_W, locator, config, technology_type):
 
     :type qcold_W : float
     :param qcold_W: peak cooling demand in [W]
-    :param gV: globalvar.py
 
     :returns InvCa: annualized chiller investment cost in CHF/a
     :rtype InvCa: float

--- a/cea/technologies/direct_expansion_units.py
+++ b/cea/technologies/direct_expansion_units.py
@@ -54,7 +54,6 @@ def calc_Cinv_DX(Q_design_W):
     Assume the same cost as gas boilers.
     :type Q_design_W : float
     :param Q_design_W: Design Load of Boiler in [W]
-    :param gV: globalvar.py
     :rtype InvCa : float
     :returns InvCa: Annualized investment costs in CHF/a including Maintenance Cost
     """

--- a/cea/technologies/furnace.py
+++ b/cea/technologies/furnace.py
@@ -40,8 +40,6 @@ def calc_eta_furnace(Q_load, Q_design, T_return_to_boiler, MOIST_TYPE, gv):
     :type MOIST_TYPE : float
     :param MOIST_TYPE: moisture type of the fuel, set in MasterToSlaveVariables ('wet' or 'dry')
 
-    :param gV: globalvar.py
-
     up to 6MW_therm_out Capacity proven!
     = 8 MW th (burner)
 
@@ -123,8 +121,6 @@ def furnace_op_cost(Q_therm_W, Q_design_W, T_return_to_boiler_K, MOIST_TYPE, lca
 
     :type MOIST_TYPE : float
     :param MOIST_TYPE: moisture type of the fuel, set in MasterToSlaveVariables ('wet' or 'dry')
-
-    :param gV: globalvar.py
 
     :rtype C_furn : float
     :returns C_furn: Total generation cost for required load (per hour) in [CHF], including profits from electricity sold

--- a/cea/technologies/heatpumps.py
+++ b/cea/technologies/heatpumps.py
@@ -37,8 +37,6 @@ def HP_air_air(mdot_cp_WC, t_sup_K, t_re_K, tsource_K):
     :param t_re_K: return temeprature from the minisplit unit (hot)
     :type tsource_K : float
     :param tsource_K: temperature of the source
-    :param gV: globalvar.py
-
     :rtype wdot_el : float
     :returns wdot_el: total electric power requirement for compressor and auxiliary el.
     :rtype qcolddot : float
@@ -88,9 +86,6 @@ def calc_Cop_GHP(ground_temp, mdot_kgpers, T_DH_sup_K, T_re_K):
     :param T_DH_sup_K: supply temperature to the DHN (hot)
     :type T_re_K : float
     :param T_re_K: return temeprature from the DHN (cold)
-    :type tground_K : float
-    :param tground_K: ground temperature
-    :param gV: globalvar.py
 
     :rtype wdot_el : float
     :returns wdot_el: total electric power requirement for compressor and auxiliary el.
@@ -127,9 +122,6 @@ def calc_Cop_GHP(ground_temp, mdot_kgpers, T_DH_sup_K, T_re_K):
 
     qcolddot_W =  qhotdot_W - wdot_W
 
-    #if qcolddot > gV.GHP_CmaxSize:
-    #    raise ModelError
-
     return wdot_el_W, qcolddot_W, qhotdot_missing_W, tsup2_K
 
 def GHP_op_cost(mdot_kgpers, t_sup_K, t_re_K, COP, lca, hour):
@@ -144,8 +136,6 @@ def GHP_op_cost(mdot_kgpers, t_sup_K, t_re_K, COP, lca, hour):
     :param t_re_K: return temeprature from the DHN (cold)
     :type COP: float
     :param COP: coefficient of performance of GSHP
-    :param gV: globalvar.py
-
     :rtype C_GHP_el: float
     :returns C_GHP_el: electricity cost of GSHP operation
 
@@ -178,8 +168,6 @@ def GHP_Op_max(tsup_K, tground_K, nProbes):
     :param tground_K: ground temperature
     :type nProbes: float
     :param nProbes: bumber of probes
-    :param gV: globalvar.py
-
     :rtype qhotdot: float
     :returns qhotdot: heating energy provided from GHSP
     :rtype COP: float
@@ -205,8 +193,6 @@ def HPLake_op_cost(mdot_kgpers, tsup_K, tret_K, tlake, lca, hour):
     :param tret_K: return temeprature from the DHN (cold)
     :type tlake : float
     :param tlake: lake temperature
-    :param gV: globalvar.py
-
     :rtype C_HPL_el: float
     :returns C_HPL_el: electricity cost of Lake HP operation
 
@@ -243,8 +229,6 @@ def HPLake_Op(mdot_kgpers, t_sup_K, t_re_K, t_lake_K):
     :param t_re_K: return temeprature from the DHN (cold)
     :type t_lake_K : float
     :param t_lake_K: lake temperature
-    :param gV: globalvar.py
-
     :rtype wdot_el : float
     :returns wdot_el: total electric power requirement for compressor and auxiliary el.
     :rtype qcolddot : float
@@ -290,8 +274,6 @@ def HPSew_op_cost(mdot_kgpers, t_sup_K, t_re_K, t_sup_sew_K, lca, Q_therm_Sew_W,
     :param t_re_K: return temeprature from the DHN (cold)
     :type t_sup_sew_K : float
     :param t_sup_sew_K: sewage supply temperature
-    :param gV: globalvar.py
-
     :rtype C_HPSew_el_pure: float
     :returns C_HPSew_el_pure: electricity cost of sewage water HP operation
 

--- a/cea/tests/create_unittest_data.py
+++ b/cea/tests/create_unittest_data.py
@@ -16,7 +16,6 @@ import pandas as pd
 
 from cea.demand.thermal_loads import calc_thermal_loads
 from cea.demand.demand_main import properties_and_schedule
-from cea.globalvar import GlobalVariables
 from cea.inputlocator import InputLocator
 from cea.utilities import epwreader
 

--- a/legacy/thermal_networks/thermal_network.py
+++ b/legacy/thermal_networks/thermal_network.py
@@ -20,7 +20,7 @@ __status__ = "Production"
 
 # investment and maintenance costs
 
-def calc_Cinv_network_linear(LengthNetwork, gV):
+def calc_Cinv_network_linear(LengthNetwork, gv):
     """
     calculate annualised network investment cost with a linearized function.
 
@@ -33,8 +33,8 @@ def calc_Cinv_network_linear(LengthNetwork, gV):
     """
 
     InvC = 0
-    InvC = LengthNetwork * gV.PipeCostPerMeterInv
-    InvCa = InvC * gV.PipeInterestRate * (1+ gV.PipeInterestRate) ** gV.PipeLifeTime / ((1+gV.PipeInterestRate) ** gV.PipeLifeTime - 1)
+    InvC = LengthNetwork * gv.PipeCostPerMeterInv
+    InvCa = InvC * gv.PipeInterestRate * (1 + gv.PipeInterestRate) ** gv.PipeLifeTime / ((1 + gv.PipeInterestRate) ** gv.PipeLifeTime - 1)
 
     return InvCa, InvC
 


### PR DESCRIPTION
This PR is a smal step towards resolving #753 - I removed some low hanging fruit like:

- removed all instances of `gv` that were not used (greyed out in PyCharm)
- removed `:param:` mentions of `gv` where the function signature changed (not exhaustive, just those I ran into)
- removed / renamed `gV` to `gv` to make future finding of `gv` easier.

There are still usages. If the Jenkins likes this PR, we can merge it and then do the next step:
I suggest @gabriel-happle addresses the usage of `gv.start_date` in a separate PR based on this one merged to master.