### PR TITLE
Plot cache for dashboard

### DIFF
--- a/cea/config.py
+++ b/cea/config.py
@@ -647,8 +647,15 @@ class ScenarioNameParameter(ChoiceParameter):
     @property
     def _choices(self):
         # set the `._choices` attribute to the list of scenarios in the project
-        return [folder for folder in os.listdir(self.config.project)
-                if os.path.isdir(os.path.join(self.config.project, folder))]
+        def is_valid_scenario(folder_name):
+            fodler_path = os.path.join(self.config.project, folder_name)
+            return all([
+                os.path.isdir(fodler_path),  # a scenario must be a valid path
+                not folder_name.startswith('.'), # a scenario can't start with a . like `.config`
+                ])
+
+        return [folder_name for folder_name in os.listdir(self.config.project)
+                if is_valid_scenario(folder_name)]
 
 
 class ScenarioParameter(Parameter):

--- a/cea/interfaces/dashboard/plots/routes.py
+++ b/cea/interfaces/dashboard/plots/routes.py
@@ -35,7 +35,8 @@ def route_dashboard(dashboard_index):
     In case of an out-of-bounds error, show the 0-th dashboard (that is guaranteed to exist)
     """
     cea_config = current_app.cea_config
-    dashboards = cea.plots.read_dashboards(cea_config)
+    plot_cache = current_app.plot_cache
+    dashboards = cea.plots.read_dashboards(cea_config, plot_cache)
     dashboard = dashboards[dashboard_index]
     return render_template('dashboard.html', dashboard_index=dashboard_index, dashboard=dashboard, categories=categories)
 
@@ -46,13 +47,14 @@ def route_new_dashboard():
     Append a dashboard to the list of dashboards and open it for editing.
     """
     cea_config = current_app.cea_config
-    dashboard_index = cea.plots.new_dashboard(cea_config)
+    plot_cache = current_app.plot_cache
+    dashboard_index = cea.plots.new_dashboard(cea_config, plot_cache)
     return redirect(url_for('plots_blueprint.route_dashboard', dashboard_index=dashboard_index))
 
 
 @blueprint.route('/dashboard/rename/<int:dashboard_index>', methods=['POST'])
 def route_rename_dashboard(dashboard_index):
-    dashboards = cea.plots.read_dashboards(current_app.cea_config)
+    dashboards = cea.plots.read_dashboards(current_app.cea_config, current_app.plot_cache)
     dashboard = dashboards[dashboard_index]
     dashboard.name = request.form.get('new-name', dashboard.name)
     cea.plots.write_dashboards(current_app.cea_config, dashboards)
@@ -61,7 +63,7 @@ def route_rename_dashboard(dashboard_index):
 
 @blueprint.route('/dashboard/add-plot/<int:dashboard_index>', methods=['POST'])
 def route_add_plot_to_dashboard(dashboard_index):
-    dashboards = cea.plots.read_dashboards(current_app.cea_config)
+    dashboards = cea.plots.read_dashboards(current_app.cea_config, current_app.plot_cache)
     dashboard = dashboards[dashboard_index]
     category = request.form.get('category', next(iter(categories)))
     plot_id = request.form.get('plot-id', next(iter(categories[category]['plots']))['id'])
@@ -73,7 +75,7 @@ def route_add_plot_to_dashboard(dashboard_index):
 @blueprint.route('/dashboard/remove-plot/<int:dashboard_index>/<int:plot_index>')
 def route_remove_plot_from_dashboard(dashboard_index, plot_index):
     """Remove a plot from a dashboard by index."""
-    dashboards = cea.plots.read_dashboards(current_app.cea_config)
+    dashboards = cea.plots.read_dashboards(current_app.cea_config, current_app.plot_cache)
     dashboard = dashboards[dashboard_index]
     dashboard.remove_plot(plot_index)
     if len(dashboard.plots) == 0:
@@ -86,7 +88,7 @@ def route_remove_plot_from_dashboard(dashboard_index, plot_index):
 def route_move_plot_up(dashboard_index, plot_index):
     """Move a plot up in the dashboard"""
     if plot_index > 0:
-        dashboards = cea.plots.read_dashboards(current_app.cea_config)
+        dashboards = cea.plots.read_dashboards(current_app.cea_config, current_app.plot_cache)
         dashboard = dashboards[dashboard_index]
         if plot_index < len(dashboard.plots):
             swap(dashboard.plots, plot_index - 1, plot_index)
@@ -102,7 +104,7 @@ def swap(lst, i, j):
 def route_move_plot_down(dashboard_index, plot_index):
     """Move a plot down in the dashboard"""
     if plot_index >= 0:
-        dashboards = cea.plots.read_dashboards(current_app.cea_config)
+        dashboards = cea.plots.read_dashboards(current_app.cea_config, current_app.plot_cache)
         dashboard = dashboards[dashboard_index]
         if plot_index < (len(dashboard.plots) - 1):
             swap(dashboard.plots, plot_index, plot_index + 1)
@@ -112,7 +114,7 @@ def route_move_plot_down(dashboard_index, plot_index):
 
 @blueprint.route('/dashboard/plot-parameters/<int:dashboard_index>/<int:plot_index>', methods=['GET'])
 def route_get_plot_parameters(dashboard_index, plot_index):
-    dashboards = cea.plots.read_dashboards(current_app.cea_config)
+    dashboards = cea.plots.read_dashboards(current_app.cea_config, current_app.plot_cache)
     dashboard = dashboards[dashboard_index]
     plot = dashboard.plots[plot_index]
     parameters = []
@@ -126,7 +128,7 @@ def route_get_plot_parameters(dashboard_index, plot_index):
 
 @blueprint.route('/dashboard/plot-parameters/<int:dashboard_index>/<int:plot_index>', methods=['POST'])
 def route_post_plot_parameters(dashboard_index, plot_index):
-    dashboards = cea.plots.read_dashboards(current_app.cea_config)
+    dashboards = cea.plots.read_dashboards(current_app.cea_config, current_app.plot_cache)
     dashboard = dashboards[dashboard_index]
     plot = dashboard.plots[plot_index]
     parameters = []
@@ -169,7 +171,7 @@ def route_div(dashboard_index, plot_index):
 def load_plot(dashboard_index, plot_index):
     """Load a plot from the dashboard_yml"""
     cea_config = current_app.cea_config
-    dashboards = cea.plots.read_dashboards(cea_config)
+    dashboards = cea.plots.read_dashboards(cea_config, current_app.plot_cache)
     dashboard_index = dashboards[dashboard_index]
     plot = dashboard_index.plots[plot_index]
     return plot

--- a/cea/interfaces/dashboard/project/routes.py
+++ b/cea/interfaces/dashboard/project/routes.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, render_template, current_app, request, redirect, jsonify, url_for
 import os
 import cea.inputlocator
+import cea.plots.cache
 
 blueprint = Blueprint(
     'project_blueprint',
@@ -45,6 +46,7 @@ def route_save():
     cea_config.district_heating_network = 'district-heating-network' in request.form
     cea_config.district_cooling_network = 'district-cooling-network' in request.form
     cea_config.save()
+    current_app.plot_cache = cea.plots.cache.PlotCache(cea_config.project)
     return redirect(url_for('project_blueprint.route_show'))
 
 

--- a/cea/plots/__init__.py
+++ b/cea/plots/__init__.py
@@ -30,7 +30,7 @@ __email__ = "cea@arch.ethz.ch"
 __status__ = "Production"
 
 
-def read_dashboards(config):
+def read_dashboards(config, cache):
     """
     Return a list of dashboard configurations for a given project. The dashboard is loaded from the
     dashboard.yml file located in the project_path (parent folder of the scenario). If no such file is
@@ -38,13 +38,13 @@ def read_dashboards(config):
     """
     try:
         with open(dashboard_yml_path(config), 'r') as f:
-            dashboards = [Dashboard(config, dashboard_dict) for dashboard_dict in yaml.load(f)]
+            dashboards = [Dashboard(config, dashboard_dict, cache) for dashboard_dict in yaml.load(f)]
             if not dashboards:
-                dashboards = [default_dashboard(config)]
+                dashboards = [default_dashboard(config, cache)]
             return dashboards
     except (IOError, TypeError):
         # problems reading the dashboard_yml file - instead, create a default set of dashboards.
-        dashboards = [default_dashboard(config)]
+        dashboards = [default_dashboard(config, cache)]
         write_dashboards(config, dashboards)
         return dashboards
 
@@ -61,22 +61,22 @@ def dashboard_yml_path(config):
     return dashboard_yml
 
 
-def default_dashboard(config):
+def default_dashboard(config, cache):
     """Return a default Dashboard"""
     return Dashboard(config, {'name': 'Default Dashboard',
                               'plots': [{'plot': 'energy-balance',
                                          'category': 'demand',
                                          'parameters': {'buildings': [],
-                                                        'scenario-name': config.scenario_name}}]})
+                                                        'scenario-name': config.scenario_name}}]}, cache)
 
 
-def new_dashboard(config):
+def new_dashboard(config, cache):
     """
     Append a new dashboard to the dashboard configuration and write it back to disk.
     Returns the index of the new dashboard in the dashboards list.
     """
     dashboards = read_dashboards(config)
-    dashboards.append(default_dashboard(config))
+    dashboards.append(default_dashboard(config, cache))
     write_dashboards(config, dashboards)
     return len(dashboards) - 1
 
@@ -90,10 +90,11 @@ def delete_dashboard(config, dashboard_index):
 
 class Dashboard(object):
     """Implements a dashboard - an editable collection of configured plots."""
-    def __init__(self, config, dashboard_dict):
+    def __init__(self, config, dashboard_dict, cache):
         self.config = config
         self.name = dashboard_dict['name']
-        self.plots = [load_plot(config.project, plot_dict) for plot_dict in dashboard_dict['plots']]
+        self.cache = cache
+        self.plots = [load_plot(config.project, plot_dict, cache) for plot_dict in dashboard_dict['plots']]
 
     def add_plot(self, category, plot_id):
         """Add a new plot to the dashboard"""
@@ -114,14 +115,14 @@ class Dashboard(object):
                            'parameters': p.parameters} for p in self.plots]}
 
 
-def load_plot(project, plot_definition):
+def load_plot(project, plot_definition, cache):
     """Load a plot based on a plot definition dictionary as used in the dashboard_yml file"""
     print('load_plot', project, plot_definition)
     category_name = plot_definition['category']
     plot_id = plot_definition['plot']
     plot_class = cea.plots.categories.load_plot_by_id(category_name, plot_id)
     parameters = plot_definition['parameters']
-    return plot_class(project, parameters)
+    return plot_class(project, parameters, cache)
 
 
 def main(config):

--- a/cea/plots/__init__.py
+++ b/cea/plots/__init__.py
@@ -100,7 +100,7 @@ class Dashboard(object):
         """Add a new plot to the dashboard"""
         plot_class = cea.plots.categories.load_plot_by_id(category, plot_id)
         parameters = plot_class.get_default_parameters(self.config)
-        plot = plot_class(self.config.project, parameters)
+        plot = plot_class(self.config.project, parameters, self.cache)
         self.plots.append(plot)
 
     def remove_plot(self, plot_index):

--- a/cea/plots/__init__.py
+++ b/cea/plots/__init__.py
@@ -75,7 +75,7 @@ def new_dashboard(config, cache):
     Append a new dashboard to the dashboard configuration and write it back to disk.
     Returns the index of the new dashboard in the dashboards list.
     """
-    dashboards = read_dashboards(config)
+    dashboards = read_dashboards(config, cache)
     dashboards.append(default_dashboard(config, cache))
     write_dashboards(config, dashboards)
     return len(dashboards) - 1
@@ -83,7 +83,8 @@ def new_dashboard(config, cache):
 
 def delete_dashboard(config, dashboard_index):
     """Remove the dashboard with that index from the dashboard configuration file"""
-    dashboards = read_dashboards(config)
+    import cea.plots.cache
+    dashboards = read_dashboards(config, cea.plots.cache.NullPlotCache())
     dashboards.pop(dashboard_index)
     write_dashboards(config, dashboards)
 

--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -99,6 +99,9 @@ class PlotBase(object):
 
     def plot_div(self):
         """Return the plot as an html <div/> for use in the dashboard. Override this method in subclasses"""
+        return self.cache.lookup_plot_div(self, self._plot_div_producer)
+
+    def _plot_div_producer(self):
         fig = plotly.graph_objs.Figure(data=self.calc_graph(), layout=self.layout)
         div = plotly.offline.plot(fig, output_type='div', include_plotlyjs=False, show_link=False)
         return div

--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -33,7 +33,8 @@ class PlotBase(object):
     def id(cls):
         return cls.name.lower().replace(' ', '-')  # use for js/html etc.
 
-    def __init__(self, project, parameters):
+    def __init__(self, project, parameters, cache):
+        self.cache = cache  # a PlotCache implementation for reading cached data
         self.project = project  # full path to the project this plot belongs to
         self.category_path = None  # override this in the __init__.py subclasses for each category (see cea/plots/demand/__init__.py for an example)
         self.data = None  # override this in the plot subclasses! set it to the pandas DataFrame to use as data

--- a/cea/plots/cache.py
+++ b/cea/plots/cache.py
@@ -1,0 +1,68 @@
+"""
+Implements a cache for plot data at the project level. Cached plot data has a "path" (e.g. 'optimization/generations_data')
+and dependencies (a list of files that are used to produce that data) as well as the parameters used in that data.
+The cache object is passed to the `calc_graph` method and the plot is responsible for retrieving data from the cache.
+"""
+
+from __future__ import division
+from __future__ import print_function
+import os
+import time
+import hashlib
+import pandas as pd
+
+
+class NullPlotCache(object):
+    """A dummy cache that doesn't cache anything - for comparing performance of PlotCache"""
+    def lookup(self, _, __, producer):
+        return producer()
+
+
+class PlotCache(object):
+    """A cache for plot data. Use the ``lookup`` method to retrieve data from the cache."""
+    def __init__(self, project):
+        """Initialize the cache from disk"""
+        self.parameter_guard = {}  # data_path => set(parameters.keys()) - just a check for programming errors
+        self.project = project
+
+    def _parameter_hash(self, parameters):
+        return hashlib.md5(repr(sorted(parameters.items()))).hexdigest()
+
+    def _cached_data_file(self, data_path, parameters):
+        return os.path.join(self.project, '.cache', data_path, self._parameter_hash(parameters))
+
+    def lookup(self, data_path, plot, producer):
+        if self.cache_timestamp(data_path, plot.parameters) < self.newest_dependency(plot.input_files):
+            return self.store_cached_value(data_path, plot.parameters, producer)
+        return self.load_cached_value(data_path, plot.parameters)
+
+    def cache_timestamp(self, data_path, parameters):
+        """Return a timestamp (like ``os.path.getmtime``) to compare to. Returns 0 if there is no data in the cache"""
+        data_file = self._cached_data_file(data_path, parameters)
+        if not os.path.exists(data_file):
+            return 0
+        else:
+            return os.path.getmtime(data_file)
+
+    def newest_dependency(self, input_files):
+        """Returns the newest timestamp (``os.path.getmtime`` and ``time.time()``) of the input_files - the idea being,
+        that if the cache is newer than this, then the cache is valid."""
+        try:
+            return max(os.path.getmtime(f) for f in input_files)
+        except:
+            print('Could not read input_files for cache!')
+            return time.time()
+
+    def store_cached_value(self, data_path, parameters, producer):
+        """Store the Dataframe returned from producer and return it."""
+        data = producer()
+        data_folder = os.path.join(self.project, '.cache', data_path)
+        if not os.path.exists(data_folder):
+            os.makedirs(data_folder)
+        data.to_pickle(self._cached_data_file(data_path, parameters))
+        return data
+
+    def load_cached_value(self, data_path, parameters):
+        """Load a Dataframe from disk"""
+        return pd.read_pickle(self.cache_timestamp(data_path, parameters))
+

--- a/cea/plots/cache.py
+++ b/cea/plots/cache.py
@@ -54,6 +54,7 @@ class PlotCache(object):
             with open(div_file, 'w') as div_fp:
                 div_fp.write(plot_div)
         else:
+            print('Loading plot_div from cache: {div_file}'.format(div_file=div_file))
             with open(div_file, 'r') as div_fp:
                 plot_div = div_fp.read()
         return plot_div

--- a/cea/plots/cache.py
+++ b/cea/plots/cache.py
@@ -10,11 +10,12 @@ import os
 import time
 import hashlib
 import pandas as pd
+import cPickle
 
 
 class NullPlotCache(object):
     """A dummy cache that doesn't cache anything - for comparing performance of PlotCache"""
-    def lookup(self, _, __, producer):
+    def lookup(self, data_path, plot, producer):
         return producer()
 
 
@@ -64,5 +65,5 @@ class PlotCache(object):
 
     def load_cached_value(self, data_path, parameters):
         """Load a Dataframe from disk"""
-        return pd.read_pickle(self.cache_timestamp(data_path, parameters))
+        return pd.read_pickle(self._cached_data_file(data_path, parameters))
 

--- a/cea/plots/categories.py
+++ b/cea/plots/categories.py
@@ -11,6 +11,7 @@ import inspect
 import cea.plots
 import cea.config
 import cea.inputlocator
+import cea.plots.cache
 
 __author__ = "Daren Thomas"
 __copyright__ = "Copyright 2018, Architecture and Building Systems - ETH Zurich"
@@ -98,6 +99,7 @@ class PlotCategory(object):
 
 if __name__ == '__main__':
     config = cea.config.Configuration()
+    cache = cea.plots.cache.NullPlotCache()
 
     for category in list_categories():
         print('category:', category.name, ':', category.label)
@@ -106,7 +108,7 @@ if __name__ == '__main__':
             parameters = {
                 k: config.get(v) for k, v in plot_class.expected_parameters.items()
             }
-            plot = plot_class(config.project, parameters=parameters)
+            plot = plot_class(config.project, parameters=parameters, cache=cache)
             assert plot.name, 'plot missing name: %s' % plot
             assert plot.category_name == category.name
             print('plot:', plot.name, '/', plot.id(), '/', plot.title)

--- a/cea/plots/demand/__init__.py
+++ b/cea/plots/demand/__init__.py
@@ -145,7 +145,7 @@ if __name__ == '__main__':
     # run all the plots in this category
     config = cea.config.Configuration()
     from cea.plots.categories import list_categories
-    from cea.plots.cache import NullPlotCache, PlotCache
+    from cea.plots.cache import NullPlotCache, PlotCache, MemoryPlotCache
     import time
 
     def plot_category(cache):
@@ -169,6 +169,7 @@ if __name__ == '__main__':
 
     null_plot_cache = NullPlotCache()
     plot_cache = PlotCache(config.project)
+    memory_plot_cache = MemoryPlotCache(config.project)
 
     # test plots with cache
     t0 = time.time()
@@ -176,11 +177,18 @@ if __name__ == '__main__':
         plot_category(plot_cache)
     time_with_cache = (time.time() - t0) / 3
 
-    # test plots without cache
+    # test plots with memory cache
     t0 = time.time()
     for i in range(3):
-        plot_category(null_plot_cache)
-    time_without_cache = (time.time() - t0) / 3
+        plot_category(memory_plot_cache)
+    time_with_memory_cache = (time.time() - t0) / 3
 
-    print('Average without cache: %.2f seconds' % time_without_cache)
+    # test plots without cache
+    # t0 = time.time()
+    # for i in range(3):
+    #     plot_category(null_plot_cache)
+    # time_without_cache = (time.time() - t0) / 3
+
+    # print('Average without cache: %.2f seconds' % time_without_cache)
     print('Average with cache: %.2f seconds' % time_with_cache)
+    print('Average with memory cache: %.2f seconds' % time_with_memory_cache)

--- a/cea/plots/demand/__init__.py
+++ b/cea/plots/demand/__init__.py
@@ -36,9 +36,6 @@ class DemandPlotBase(cea.plots.PlotBase):
         'scenario-name': 'general:scenario-name',
     }
 
-    # cache hourly_loads results to avoid recalculating it every time
-    _cache = {}
-
     def __init__(self, project, parameters, cache):
         super(DemandPlotBase, self).__init__(project, parameters, cache)
 
@@ -94,35 +91,25 @@ class DemandPlotBase(cea.plots.PlotBase):
                                        'E_cs_kWh',
                                        'E_cdata_kWh',
                                        'E_cre_kWh']
+        self.input_files = [self.locator.get_total_demand()]  # all these scripts depend on demand
 
     @property
     def hourly_loads(self):
         """
-        Returns the hourly loads, summed up for all the builidngs being considered by the plot.
-        Stores the result in ``self._cache`` since the reduce operation takes a lot of time.
+        Returns the hourly loads, summed up for all the builidngs being considered by the plot. Uses the PlotCache
+        to speed up ``self._calculate_hourly_loads()``
         """
-        m_time = os.path.getmtime(self.locator.get_total_demand())  # when was demand script last run?
-        buildings_key = ','.join(self.buildings)  # key for looking up in the cache
-        if buildings_key in self._cache:
-            # only load hourly_loads once, based on {buildings, mtime}
-            cache_mtime, result = self._cache[buildings_key]
-            if m_time == cache_mtime:
-                # cached result is still up-to-date!
-                return result
+        return self.cache.lookup(data_path=os.path.join(label, 'hourly_loads'),
+                                 plot=self, producer=self._calculate_hourly_loads)
 
-        # no cached result - calculate from scratch and cache for further use
-        print('no cache found for', buildings_key, m_time)
+    def _calculate_hourly_loads(self):
         def add_fields(df1, df2):
             """Add the demand analysis fields together - use this in reduce to sum up the summable parts of the dfs"""
             df1[self.demand_analysis_fields] += df2[self.demand_analysis_fields]
             return df1
-
-        # cache these results for later
-        result = functools.reduce(add_fields,
-                                 (pd.read_csv(self.locator.get_demand_results_file(building)) for building in
-                                  self.buildings)).set_index('DATE')
-        self._cache[buildings_key] = (m_time, result)
-        return result
+        return functools.reduce(add_fields,
+                                (pd.read_csv(self.locator.get_demand_results_file(building)) for building in
+                                 self.buildings)).set_index('DATE')
 
     @property
     def yearly_loads(self):
@@ -152,3 +139,48 @@ class DemandPlotBase(cea.plots.PlotBase):
             prefix = 'District'
         fname = "%s_%s" % (prefix, self.name.lower().replace(' ', '_'))
         return self.locator.get_timeseries_plots_file(fname, self.category_path)
+
+
+if __name__ == '__main__':
+    # run all the plots in this category
+    config = cea.config.Configuration()
+    from cea.plots.categories import list_categories
+    from cea.plots.cache import NullPlotCache, PlotCache
+    import time
+
+    def plot_category(cache):
+        for category in list_categories():
+            if category.label != label:
+                continue
+            print('category:', category.name, ':', category.label)
+            for plot_class in category.plots:
+                print('plot_class:', plot_class)
+                parameters = {
+                    k: config.get(v) for k, v in plot_class.expected_parameters.items()
+                }
+                plot = plot_class(config.project, parameters=parameters, cache=cache)
+                assert plot.name, 'plot missing name: %s' % plot
+                assert plot.category_name == category.name
+                print('plot:', plot.name, '/', plot.id(), '/', plot.title)
+
+                # plot the plot!
+                plot.plot()
+
+
+    null_plot_cache = NullPlotCache()
+    plot_cache = PlotCache(config.project)
+
+    # test plots with cache
+    t0 = time.time()
+    for i in range(3):
+        plot_category(plot_cache)
+    time_with_cache = (time.time() - t0) / 3
+
+    # test plots without cache
+    t0 = time.time()
+    for i in range(3):
+        plot_category(null_plot_cache)
+    time_without_cache = (time.time() - t0) / 3
+
+    print('Average without cache: %.2f seconds' % time_without_cache)
+    print('Average with cache: %.2f seconds' % time_with_cache)

--- a/cea/plots/demand/__init__.py
+++ b/cea/plots/demand/__init__.py
@@ -39,8 +39,8 @@ class DemandPlotBase(cea.plots.PlotBase):
     # cache hourly_loads results to avoid recalculating it every time
     _cache = {}
 
-    def __init__(self, project, parameters):
-        super(DemandPlotBase, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(DemandPlotBase, self).__init__(project, parameters, cache)
 
         self.category_path = os.path.join('new_basic', 'demand')
 

--- a/cea/plots/demand/__init__.py
+++ b/cea/plots/demand/__init__.py
@@ -99,7 +99,7 @@ class DemandPlotBase(cea.plots.PlotBase):
         Returns the hourly loads, summed up for all the builidngs being considered by the plot. Uses the PlotCache
         to speed up ``self._calculate_hourly_loads()``
         """
-        return self.cache.lookup(data_path=os.path.join(label, 'hourly_loads'),
+        return self.cache.lookup(data_path=os.path.join(self.category_name, 'hourly_loads'),
                                  plot=self, producer=self._calculate_hourly_loads)
 
     def _calculate_hourly_loads(self):

--- a/cea/plots/demand/comfort_chart.py
+++ b/cea/plots/demand/comfort_chart.py
@@ -38,8 +38,8 @@ class ComfortChartPlot(cea.plots.demand.DemandPlotBase):
     expected_parameters = dict(cea.plots.demand.DemandPlotBase.expected_parameters,
                                region='general:region')
 
-    def __init__(self, project, parameters):
-        super(ComfortChartPlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(ComfortChartPlot, self).__init__(project, parameters, cache)
         if len(self.buildings) > 1:
             self.buildings = [self.buildings[0]]
         self.data = self.hourly_loads[self.hourly_loads['Name'].isin(self.buildings)]

--- a/cea/plots/demand/energy_balance.py
+++ b/cea/plots/demand/energy_balance.py
@@ -23,8 +23,8 @@ __status__ = "Production"
 class EnergyBalancePlot(cea.plots.demand.DemandPlotBase):
     name = "Energy balance"
 
-    def __init__(self, project, parameters):
-        super(EnergyBalancePlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(EnergyBalancePlot, self).__init__(project, parameters, cache)
         if len(self.buildings) > 1:
             self.buildings = [self.buildings[0]]
         self.analysis_fields = ['I_sol_kWh',

--- a/cea/plots/demand/energy_demand.py
+++ b/cea/plots/demand/energy_demand.py
@@ -21,8 +21,8 @@ class EnergyDemandDistrictPlot(cea.plots.demand.DemandPlotBase):
     """Implement the energy-use plot"""
     name = "Energy Demand"
 
-    def __init__(self, project, parameters):
-        super(EnergyDemandDistrictPlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(EnergyDemandDistrictPlot, self).__init__(project, parameters, cache)
         self.analysis_fields = ["E_sys_MWhyr",
                                 "Qhs_sys_MWhyr", "Qww_sys_MWhyr",
                                 "Qcs_sys_MWhyr", 'Qcdata_sys_MWhyr', 'Qcre_sys_MWhyr']

--- a/cea/plots/demand/energy_supply.py
+++ b/cea/plots/demand/energy_supply.py
@@ -14,8 +14,8 @@ class EnergySupplyPlot(cea.plots.demand.DemandPlotBase):
     """Implement the energy-supply plot"""
     name = "Energy Supply"
 
-    def __init__(self, project, parameters):
-        super(EnergySupplyPlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(EnergySupplyPlot, self).__init__(project, parameters, cache)
         self.analysis_fields = ["DH_hs_MWhyr", "DH_ww_MWhyr", 'SOLAR_ww_MWhyr', 'SOLAR_hs_MWhyr', "DC_cs_MWhyr",
                                 'DC_cdata_MWhyr', 'DC_cre_MWhyr', 'PV_MWhyr', 'GRID_MWhyr', 'NG_hs_MWhyr',
                                 'COAL_hs_MWhyr', 'OIL_hs_MWhyr', 'WOOD_hs_MWhyr', 'NG_ww_MWhyr', 'COAL_ww_MWhyr',

--- a/cea/plots/demand/energy_supply_intensity.py
+++ b/cea/plots/demand/energy_supply_intensity.py
@@ -9,8 +9,8 @@ from cea.plots.variable_naming import LOGO, COLOR, NAMING
 class EnergySupplyIntensityPlot(cea.plots.demand.DemandPlotBase):
     name = "Energy Supply Intensity"
 
-    def __init__(self, project, parameters):
-        super(EnergySupplyIntensityPlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(EnergySupplyIntensityPlot, self).__init__(project, parameters, cache)
         self.data = self.yearly_loads[self.yearly_loads['Name'].isin(self.buildings)]
         self.analysis_fields = self.remove_unused_fields(self.data, ["DH_hs_MWhyr", "DH_ww_MWhyr", 'SOLAR_ww_MWhyr',
                                                                      'SOLAR_hs_MWhyr', "DC_cs_MWhyr", 'DC_cdata_MWhyr',

--- a/cea/plots/demand/energy_use_intensity.py
+++ b/cea/plots/demand/energy_use_intensity.py
@@ -19,8 +19,8 @@ __status__ = "Production"
 class EnergyUseIntensityPlot(cea.plots.demand.DemandPlotBase):
     name = "Energy Use Intensity"
 
-    def __init__(self, project, parameters):
-        super(EnergyUseIntensityPlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(EnergyUseIntensityPlot, self).__init__(project, parameters, cache)
         self.data = self.yearly_loads[self.yearly_loads['Name'].isin(self.buildings)]
         self.analysis_fields = ["E_sys_MWhyr",
                                 "Qhs_sys_MWhyr", "Qww_sys_MWhyr",

--- a/cea/plots/demand/heating_reset_schedule.py
+++ b/cea/plots/demand/heating_reset_schedule.py
@@ -20,8 +20,8 @@ __status__ = "Production"
 class HeatingResetSchedulePlot(cea.plots.demand.DemandPlotBase):
     name = "Heating Reset Schedule"
 
-    def __init__(self, project, parameters):
-        super(HeatingResetSchedulePlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(HeatingResetSchedulePlot, self).__init__(project, parameters, cache)
         if len(self.buildings) > 1:
             self.buildings = [self.buildings[0]]
         self.data = self.hourly_loads[self.hourly_loads['Name'].isin(self.buildings)]

--- a/cea/plots/demand/load_curve.py
+++ b/cea/plots/demand/load_curve.py
@@ -19,8 +19,8 @@ __status__ = "Production"
 class LoadCurvePlot(cea.plots.demand.DemandPlotBase):
     name = "Load Curve"
 
-    def __init__(self, project, parameters):
-        super(LoadCurvePlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(LoadCurvePlot, self).__init__(project, parameters, cache)
         self.data = self.hourly_loads
         self.analysis_fields = ["E_sys_kWh",
                                 "Qhs_sys_kWh", "Qww_sys_kWh",

--- a/cea/plots/demand/load_curve_supply.py
+++ b/cea/plots/demand/load_curve_supply.py
@@ -14,8 +14,8 @@ class LoadCurveSupplyPlot(cea.plots.demand.DemandPlotBase):
     """Implement the load-curve-supply plot"""
     name = "Load Curve Supply"
 
-    def __init__(self, project, parameters):
-        super(LoadCurveSupplyPlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(LoadCurveSupplyPlot, self).__init__(project, parameters, cache)
         self.data = self.hourly_loads[self.hourly_loads['Name'].isin(self.buildings)]
         self.analysis_fields = self.remove_unused_fields(self.data,
                                                          ["DH_hs_kWh", "DH_ww_kWh",

--- a/cea/plots/demand/load_duration_curve.py
+++ b/cea/plots/demand/load_duration_curve.py
@@ -19,8 +19,8 @@ __status__ = "Production"
 class LoadDurationCurvePlot(cea.plots.demand.DemandPlotBase):
     name = "Load Duration Curve"
 
-    def __init__(self, project, parameters):
-        super(LoadDurationCurvePlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(LoadDurationCurvePlot, self).__init__(project, parameters, cache)
         self.data = self.hourly_loads
         self.analysis_fields = ["E_sys_kWh",
                                 "Qhs_sys_kWh", "Qww_sys_kWh",

--- a/cea/plots/demand/load_duration_curve_supply.py
+++ b/cea/plots/demand/load_duration_curve_supply.py
@@ -14,8 +14,8 @@ class LoadDurationCurveSupplyPlot(cea.plots.demand.DemandPlotBase):
     """Implement the load-duration-curve-supply plot"""
     name = "Load Duration Curve Supply"
 
-    def __init__(self, project, parameters):
-        super(LoadDurationCurveSupplyPlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(LoadDurationCurveSupplyPlot, self).__init__(project, parameters, cache)
         self.data = self.hourly_loads[self.hourly_loads['Name'].isin(self.buildings)]
         self.analysis_fields = self.remove_unused_fields(self.data,
                                                          ["DH_hs_kWh", "DH_ww_kWh", 'SOLAR_ww_kWh', 'SOLAR_hs_kWh',

--- a/cea/plots/demand/peak_load.py
+++ b/cea/plots/demand/peak_load.py
@@ -10,8 +10,8 @@ import cea.plots.demand
 class PeakLoadCurvePlot(cea.plots.demand.DemandPlotBase):
     name = "Peak Load"
 
-    def __init__(self, project, parameters):
-        super(PeakLoadCurvePlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(PeakLoadCurvePlot, self).__init__(project, parameters, cache)
         self.data = self.yearly_loads
         self.data = self.data[self.data['Name'].isin(self.buildings)]
         self.analysis_fields = ["E_sys0_kW",

--- a/cea/plots/demand/peak_load_supply.py
+++ b/cea/plots/demand/peak_load_supply.py
@@ -9,8 +9,8 @@ import cea.plots.demand
 class PeakLoadSupplyPlot(cea.plots.demand.DemandPlotBase):
     name = "Peak Load Supply"
 
-    def __init__(self, project, parameters):
-        super(PeakLoadSupplyPlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(PeakLoadSupplyPlot, self).__init__(project, parameters, cache)
         self.data = self.yearly_loads[self.yearly_loads['Name'].isin(self.buildings)]
         self.analysis_fields = self.remove_unused_fields(self.data,
                                                          ["DH_hs0_kW", "DH_ww0_kW", 'SOLAR_ww0_kW', 'SOLAR_hs0_kW',

--- a/cea/plots/optimization/__init__.py
+++ b/cea/plots/optimization/__init__.py
@@ -45,8 +45,8 @@ class OptimizationOverviewPlotBase(cea.plots.PlotBase):
         'detailed-electricity-pricing': 'general:detailed-electricity-pricing'
     }
 
-    def __init__(self, project, parameters):
-        super(OptimizationOverviewPlotBase, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(OptimizationOverviewPlotBase, self).__init__(project, parameters, cache)
         self.category_path = os.path.join('testing', 'optimization-overview')
         self.generation = self.parameters['generation']
         self.network_type = self.parameters['network-type']

--- a/cea/plots/optimization/__init__.py
+++ b/cea/plots/optimization/__init__.py
@@ -80,7 +80,7 @@ class OptimizationOverviewPlotBase(cea.plots.PlotBase):
         return data_processed
 
     def preprocessing_final_generation_data_cost_centralized(self):
-        return self.cache.lookup(data_path=os.path.join(label, 'preprocessing_final_generation_data_cost_centralized'),
+        return self.cache.lookup(data_path=os.path.join(self.category_name, 'preprocessing_final_generation_data_cost_centralized'),
                                  plot=self, producer=self._preprocessing_final_generation_data_cost_centralized)
 
     def _preprocessing_final_generation_data_cost_centralized(self):
@@ -445,7 +445,7 @@ class OptimizationOverviewPlotBase(cea.plots.PlotBase):
         return data_processed
 
     def preprocessing_multi_criteria_data(self):
-        return self.cache.lookup(data_path=os.path.join(label, 'preprocessing_multi_criteria_data'),
+        return self.cache.lookup(data_path=os.path.join(self.category_name, 'preprocessing_multi_criteria_data'),
                                  plot=self, producer=self._preprocessing_multi_criteria_data)
 
     def _preprocessing_multi_criteria_data(self):
@@ -457,7 +457,7 @@ class OptimizationOverviewPlotBase(cea.plots.PlotBase):
         return data_multi_criteria
 
     def preprocessing_capacities_data(self):
-        return self.cache.lookup(data_path=os.path.join(label, 'preprocessing_capacities_data'),
+        return self.cache.lookup(data_path=os.path.join(self.category_name, 'preprocessing_capacities_data'),
                                  plot=self, producer=self._preprocessing_capacities_data)
 
     def _preprocessing_capacities_data(self):

--- a/cea/plots/optimization/__init__.py
+++ b/cea/plots/optimization/__init__.py
@@ -501,7 +501,7 @@ if __name__ == '__main__':
     from cea.plots.cache import NullPlotCache, PlotCache
     import time
 
-    def plot_optimization_category(cache):
+    def plot_category(cache):
         for category in list_categories():
             if category.label != label:
                 continue
@@ -526,13 +526,13 @@ if __name__ == '__main__':
     # test plots with cache
     t0 = time.time()
     for i in range(3):
-        plot_optimization_category(plot_cache)
+        plot_category(plot_cache)
     time_with_cache = (time.time() - t0) / 3
 
     # test plots without cache
     t0 = time.time()
     for i in range(3):
-        plot_optimization_category(null_plot_cache)
+        plot_category(null_plot_cache)
     time_without_cache = (time.time() - t0) / 3
 
     print('Average without cache: %.2f seconds' % time_without_cache)

--- a/cea/plots/optimization/__init__.py
+++ b/cea/plots/optimization/__init__.py
@@ -5,8 +5,8 @@ import numpy as np
 import pandas as pd
 import os
 import json
-import cea.plots
 import cea.config
+import cea.plots
 from cea.analysis.multicriteria.optimization_post_processing.individual_configuration import supply_system_configuration
 from cea.optimization.lca_calculations import LcaCalculations
 from cea.analysis.multicriteria.optimization_post_processing.locating_individuals_in_generation_script import \
@@ -46,6 +46,12 @@ class OptimizationOverviewPlotBase(cea.plots.PlotBase):
     }
 
     def __init__(self, project, parameters, cache):
+        """
+
+        :param project: The project to base plots on (some plots span scenarios)
+        :param parameters: The plot parameters as, e.g., per the dashboard.yml file
+        :param cea.plots.PlotCache cache: a PlotCache instance for speeding up plotting
+        """
         super(OptimizationOverviewPlotBase, self).__init__(project, parameters, cache)
         self.category_path = os.path.join('testing', 'optimization-overview')
         self.generation = self.parameters['generation']
@@ -74,6 +80,10 @@ class OptimizationOverviewPlotBase(cea.plots.PlotBase):
         return data_processed
 
     def preprocessing_final_generation_data_cost_centralized(self):
+        return self.cache.lookup(data_path=os.path.join(label, 'preprocessing_final_generation_data_cost_centralized'),
+                                 plot=self, producer=self._preprocessing_final_generation_data_cost_centralized)
+
+    def _preprocessing_final_generation_data_cost_centralized(self):
         data_raw = self.preprocessing_generations_data()
         total_demand = pd.read_csv(self.locator.get_total_demand())
         building_names = total_demand.Name.values
@@ -435,6 +445,10 @@ class OptimizationOverviewPlotBase(cea.plots.PlotBase):
         return data_processed
 
     def preprocessing_multi_criteria_data(self):
+        return self.cache.lookup(data_path=os.path.join(label, 'preprocessing_multi_criteria_data'),
+                                 plot=self, producer=self._preprocessing_multi_criteria_data)
+
+    def _preprocessing_multi_criteria_data(self):
         try:
             data_multi_criteria = pd.read_csv(self.locator.get_multi_criteria_analysis(self.generation))
         except IOError:
@@ -443,6 +457,10 @@ class OptimizationOverviewPlotBase(cea.plots.PlotBase):
         return data_multi_criteria
 
     def preprocessing_capacities_data(self):
+        return self.cache.lookup(data_path=os.path.join(label, 'preprocessing_capacities_data'),
+                                 plot=self, producer=self._preprocessing_capacities_data)
+
+    def _preprocessing_capacities_data(self):
         data_generation = self.preprocessing_generations_data()
         column_names = ['Lake_kW', 'VCC_LT_kW', 'VCC_HT_kW', 'single_effect_ACH_LT_kW',
                         'single_effect_ACH_HT_kW', 'DX_kW', 'CHP_CCGT_thermal_kW',
@@ -480,20 +498,42 @@ if __name__ == '__main__':
     # run all the plots in this category
     config = cea.config.Configuration()
     from cea.plots.categories import list_categories
+    from cea.plots.cache import NullPlotCache, PlotCache
+    import time
 
-    for category in list_categories():
-        if category.label != label:
-            continue
-        print('category:', category.name, ':', category.label)
-        for plot_class in category.plots:
-            print('plot_class:', plot_class)
-            parameters = {
-                k: config.get(v) for k, v in plot_class.expected_parameters.items()
-            }
-            plot = plot_class(config.project, parameters=parameters)
-            assert plot.name, 'plot missing name: %s' % plot
-            assert plot.category_name == category.name
-            print('plot:', plot.name, '/', plot.id(), '/', plot.title)
+    def plot_optimization_category(cache):
+        for category in list_categories():
+            if category.label != label:
+                continue
+            print('category:', category.name, ':', category.label)
+            for plot_class in category.plots:
+                print('plot_class:', plot_class)
+                parameters = {
+                    k: config.get(v) for k, v in plot_class.expected_parameters.items()
+                }
+                plot = plot_class(config.project, parameters=parameters, cache=cache)
+                assert plot.name, 'plot missing name: %s' % plot
+                assert plot.category_name == category.name
+                print('plot:', plot.name, '/', plot.id(), '/', plot.title)
 
-            # plot the plot!
-            plot.plot()
+                # plot the plot!
+                plot.plot()
+
+
+    null_plot_cache = NullPlotCache()
+    plot_cache = PlotCache(config.project)
+
+    # test plots with cache
+    t0 = time.time()
+    for i in range(3):
+        plot_optimization_category(plot_cache)
+    time_with_cache = (time.time() - t0) / 3
+
+    # test plots without cache
+    t0 = time.time()
+    for i in range(3):
+        plot_optimization_category(null_plot_cache)
+    time_without_cache = (time.time() - t0) / 3
+
+    print('Average without cache: %.2f seconds' % time_without_cache)
+    print('Average with cache: %.2f seconds' % time_with_cache)

--- a/cea/plots/optimization/centralized_costs_per_generation_unit.py
+++ b/cea/plots/optimization/centralized_costs_per_generation_unit.py
@@ -25,7 +25,6 @@ class CentralizedCostsPerGenerationUnitPlot(cea.plots.optimization.OptimizationO
 
     def __init__(self, project, parameters, cache):
         super(CentralizedCostsPerGenerationUnitPlot, self).__init__(project, parameters, cache)
-        self.data = self.preprocessing_final_generation_data_cost_centralized()
         self.layout = go.Layout(title=self.title, barmode='relative',
                        yaxis=dict(title='Cost [USD$(2015)/year]', domain=[0.0, 1.0]))
 
@@ -66,6 +65,9 @@ class CentralizedCostsPerGenerationUnitPlot(cea.plots.optimization.OptimizationO
                                                          "Electricity_Costs_USD"]
         self.analysis_fields = (self.analysis_fields_cost_heating_centralized if self.network_type == 'DH'
                                 else self.analysis_fields_cost_cooling_centralized)
+        self.input_files = [self.locator.get_total_demand(),
+                            self.locator.get_preprocessing_costs(),
+                            self.locator.get_optimization_checkpoint(self.generation)]
 
     @property
     def title(self):
@@ -80,14 +82,14 @@ class CentralizedCostsPerGenerationUnitPlot(cea.plots.optimization.OptimizationO
             self.category_name)
 
     def calc_graph(self):
+        data = self.preprocessing_final_generation_data_cost_centralized()
         graph = []
         for field in self.analysis_fields:
-            y = self.data[field].values
+            y = data[field].values
             flag_for_unused_technologies = all(v == 0 for v in y)
             if not flag_for_unused_technologies:
-                trace = go.Bar(x=self.data.index, y=y, name=NAMING[field], marker=dict(color=COLOR[field]))
+                trace = go.Bar(x=data.index, y=y, name=NAMING[field], marker=dict(color=COLOR[field]))
                 graph.append(trace)
-
         return graph
 
 

--- a/cea/plots/optimization/centralized_costs_per_generation_unit.py
+++ b/cea/plots/optimization/centralized_costs_per_generation_unit.py
@@ -23,7 +23,7 @@ class CentralizedCostsPerGenerationUnitPlot(cea.plots.optimization.OptimizationO
 
     name = "Centralized costs per generation unit"
 
-    def __init__(self, project, parameters, cache:
+    def __init__(self, project, parameters, cache):
         super(CentralizedCostsPerGenerationUnitPlot, self).__init__(project, parameters, cache)
         self.data = self.preprocessing_final_generation_data_cost_centralized()
         self.layout = go.Layout(title=self.title, barmode='relative',

--- a/cea/plots/optimization/centralized_costs_per_generation_unit.py
+++ b/cea/plots/optimization/centralized_costs_per_generation_unit.py
@@ -23,8 +23,8 @@ class CentralizedCostsPerGenerationUnitPlot(cea.plots.optimization.OptimizationO
 
     name = "Centralized costs per generation unit"
 
-    def __init__(self, project, parameters):
-        super(CentralizedCostsPerGenerationUnitPlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache:
+        super(CentralizedCostsPerGenerationUnitPlot, self).__init__(project, parameters, cache)
         self.data = self.preprocessing_final_generation_data_cost_centralized()
         self.layout = go.Layout(title=self.title, barmode='relative',
                        yaxis=dict(title='Cost [USD$(2015)/year]', domain=[0.0, 1.0]))

--- a/cea/plots/optimization/cost_analysis_centralized_system.py
+++ b/cea/plots/optimization/cost_analysis_centralized_system.py
@@ -20,8 +20,8 @@ class CostAnalysisCentralizedSystemPlot(cea.plots.optimization.OptimizationOverv
     """Implement the "CAPEX vs. OPEX of centralized system in generation X" plot"""
     name = "Cost analysis of centralized system"
 
-    def __init__(self, project, parameters):
-        super(CostAnalysisCentralizedSystemPlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(CostAnalysisCentralizedSystemPlot, self).__init__(project, parameters, cache)
         self.analysis_fields = ["Capex_Centralized_USD",
                                 "Capex_Decentralized_USD",
                                 "Opex_Centralized_USD",

--- a/cea/plots/optimization/cost_analysis_centralized_system.py
+++ b/cea/plots/optimization/cost_analysis_centralized_system.py
@@ -26,9 +26,11 @@ class CostAnalysisCentralizedSystemPlot(cea.plots.optimization.OptimizationOverv
                                 "Capex_Decentralized_USD",
                                 "Opex_Centralized_USD",
                                 "Opex_Decentralized_USD"]
-        self.data = self.preprocessing_final_generation_data_cost_centralized()
         self.layout = go.Layout(title=self.title, barmode='relative',
                                 yaxis=dict(title='Cost [USD$(2015)/year]', domain=[0.0, 1.0]))
+        self.input_files = [self.locator.get_total_demand(),
+                            self.locator.get_preprocessing_costs(),
+                            self.locator.get_optimization_checkpoint(self.generation)]
 
     @property
     def title(self):
@@ -42,12 +44,13 @@ class CostAnalysisCentralizedSystemPlot(cea.plots.optimization.OptimizationOverv
             self.category_name)
 
     def calc_graph(self):
+        data = self.preprocessing_final_generation_data_cost_centralized()
         graph = []
         for field in self.analysis_fields:
-            y = self.data[field].values
+            y = data[field].values
             flag_for_unused_technologies = all(v == 0 for v in y)
             if not flag_for_unused_technologies:
-                trace = go.Bar(x=self.data.index, y=y, name=NAMING[field], marker=dict(color=COLOR[field]))
+                trace = go.Bar(x=data.index, y=y, name=NAMING[field], marker=dict(color=COLOR[field]))
                 graph.append(trace)
 
         return graph

--- a/cea/plots/optimization/pareto_capacity_installed.py
+++ b/cea/plots/optimization/pareto_capacity_installed.py
@@ -22,7 +22,6 @@ class ParetoCapacityInstalledPlot(cea.plots.optimization.OptimizationOverviewPlo
 
     def __init__(self, project, parameters, cache):
         super(ParetoCapacityInstalledPlot, self).__init__(project, parameters, cache)
-        self.data = self.preprocessing_capacities_data().copy()
         self.analysis_fields_individual_heating = ['Base_boiler_BG_capacity_W', 'Base_boiler_NG_capacity_W',
                                                    'CHP_BG_capacity_W',
                                                    'CHP_NG_capacity_W', 'Furnace_dry_capacity_W',
@@ -39,10 +38,11 @@ class ParetoCapacityInstalledPlot(cea.plots.optimization.OptimizationOverviewPlo
                                                    'Storage_thermal_kW']
         self.analysis_fields = (self.analysis_fields_individual_heating if self.network_type == 'DH'
                                 else self.analysis_fields_individual_cooling)
-        self.analysis_fields = self.remove_unused_fields(self.data, self.analysis_fields)
         self.layout = go.Layout(title=self.title, barmode='stack',
                                 yaxis=dict(title='Power Capacity [kW]', domain=[.35, 1]),
                                 xaxis=dict(title='Point in the Pareto Curve'))
+        self.input_files = [self.locator.get_optimization_all_individuals(),
+                            ]
 
     @property
     def title(self):
@@ -58,8 +58,8 @@ class ParetoCapacityInstalledPlot(cea.plots.optimization.OptimizationOverviewPlo
     def calc_graph(self):
         # CALCULATE GRAPH FOR CONNECTED BUILDINGS
         graph = []
-        data = self.data
-        analysis_fields = self.analysis_fields
+        data = self.preprocessing_capacities_data()
+        analysis_fields = self.remove_unused_fields(data, self.analysis_fields)
         data['total'] = data[analysis_fields].sum(axis=1)
         data['Name'] = data.index.values
         data = data.sort_values(by='total', ascending=False)  # this will get the maximum value to the left

--- a/cea/plots/optimization/pareto_capacity_installed.py
+++ b/cea/plots/optimization/pareto_capacity_installed.py
@@ -20,8 +20,8 @@ class ParetoCapacityInstalledPlot(cea.plots.optimization.OptimizationOverviewPlo
     """Show a pareto curve installed capacity for a generation"""
     name = "Capacity installed in a generation"
 
-    def __init__(self, project, parameters):
-        super(ParetoCapacityInstalledPlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(ParetoCapacityInstalledPlot, self).__init__(project, parameters, cache)
         self.data = self.preprocessing_capacities_data().copy()
         self.analysis_fields_individual_heating = ['Base_boiler_BG_capacity_W', 'Base_boiler_NG_capacity_W',
                                                    'CHP_BG_capacity_W',

--- a/cea/plots/optimization/pareto_curve.py
+++ b/cea/plots/optimization/pareto_curve.py
@@ -33,7 +33,7 @@ class ParetoCurveForOneGenerationPlot(cea.plots.optimization.OptimizationOvervie
                                 'Capex_total_Mio',
                                 'Opex_total_Mio']
         self.objectives = ['TAC_Mio', 'total_emissions_kiloton', 'total_prim_energy_TJ']
-        self.data = self.preprocessing_multi_criteria_data()
+        self.input_files = [self.locator.get_multi_criteria_analysis(self.generation)]
         # NOTE: self.layout is set during the call to calc_graph
 
     @property
@@ -47,10 +47,11 @@ class ParetoCurveForOneGenerationPlot(cea.plots.optimization.OptimizationOvervie
                                                       self.category_name)
 
     def calc_graph(self):
-        xs = self.data[self.objectives[0]].values
-        ys = self.data[self.objectives[1]].values
-        zs = self.data[self.objectives[2]].values
-        individual_names = self.data['individual'].values
+        data = self.preprocessing_multi_criteria_data()
+        xs = data[self.objectives[0]].values
+        ys = data[self.objectives[1]].values
+        zs = data[self.objectives[2]].values
+        individual_names = data['individual'].values
 
         xmin = min(xs)
         ymin = min(ys)
@@ -69,7 +70,7 @@ class ParetoCurveForOneGenerationPlot(cea.plots.optimization.OptimizationOvervie
         graph.append(trace)
 
         # Insert scatter points of MCDA assessment.
-        _, table = calc_table(self.data, self.analysis_fields)
+        _, table = calc_table(data, self.analysis_fields)
         xs = table[self.objectives[0]].values
         ys = table[self.objectives[1]].values
         name = table["Attribute"].values

--- a/cea/plots/optimization/pareto_curve.py
+++ b/cea/plots/optimization/pareto_curve.py
@@ -23,8 +23,8 @@ class ParetoCurveForOneGenerationPlot(cea.plots.optimization.OptimizationOvervie
     """Show a pareto curve for a single generation"""
     name = "Pareto curve for a generation"
 
-    def __init__(self, project, parameters):
-        super(ParetoCurveForOneGenerationPlot, self).__init__(project, parameters)
+    def __init__(self, project, parameters, cache):
+        super(ParetoCurveForOneGenerationPlot, self).__init__(project, parameters, cache)
         self.analysis_fields = ['individual',
                                 'TAC_Mio',
                                 'total_emissions_kiloton',


### PR DESCRIPTION
This pull request implements a caching system for plots and their data (see `cea.plots.cache.PlotCache`)

Data used by plots can be cached using `PlotCache.lookup(...)` to the folder `$project/.cache/<category_name>/<data_or_plot_name>/`. The filename for the cached data is made by using a md5 hash of the sorted parameter dictionary. This guarantees unique names for the same data with different parameters.

Each plot lists it's `input_files` in the `__init__` method. The timestamps of these files are compared with the cached data and if a newer one is found, the data is re-calculated.

The `<div/>` version of the plots are cached using the same mechanism to speed up the display of the dashboard.