### PR TITLE
Restrict length of year to 8760 hours

### DIFF
--- a/cea/demand/calibration/subset_calibrator/sus_calibrator.py
+++ b/cea/demand/calibration/subset_calibrator/sus_calibrator.py
@@ -23,6 +23,7 @@ import cea.inputlocator
 import cea.globalvar
 import cea.config
 from cea.utilities import epwreader
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Fazel Khayatian"
 __copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"
@@ -46,7 +47,7 @@ def ss_measurment_loader(locator):
     path_to_measuements=os.path.join(path_to_measuements_pre, "building-metering\yearly")
     building_names_with_measurement=find_buildings_with_measurements(path_to_measuements,suffix=".csv")
     total_building_measured=len(building_names_with_measurement)
-    all_measurements_matrix=np.empty([8760,total_building_measured])
+    all_measurements_matrix=np.empty([HOURS_IN_YEAR,total_building_measured])
     counter=0
     for i in (building_names_with_measurement):
         file_path_measures = os.path.join(path_to_measuements, i + "." + "csv")

--- a/cea/demand/control_heating_cooling_systems.py
+++ b/cea/demand/control_heating_cooling_systems.py
@@ -4,6 +4,7 @@
 from __future__ import division
 import numpy as np
 import datetime
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Gabriel Happle"
 __copyright__ = "Copyright 2016, Architecture and Building Systems - ETH Zurich"
@@ -187,7 +188,7 @@ def cooling_system_is_active(bpr, tsd, t):
 
     :param tsd: a dictionary of time step data mapping variable names to ndarrays for each hour of the year.
     :type tsd: dict
-    :param t: hour of the year, simulation time step [0...8760]
+    :param t: hour of the year, simulation time step [0...HOURS_IN_YEAR]
     :type t: int
     :return: True or False
     :rtype: bool
@@ -208,7 +209,7 @@ def heating_system_is_active(tsd, t):
 
     :param tsd: a dictionary of time step data mapping variable names to ndarrays for each hour of the year.
     :type tsd: dict
-    :param t: hour of the year, simulation time step [0...8760]
+    :param t: hour of the year, simulation time step [0...HOURS_IN_YEAR]
     :type t: int
     :return: True or False
     :rtype: bool
@@ -242,7 +243,7 @@ def is_heating_season(t, bpr):
     """
     checks if time step is part of the heating season for the building
 
-    :param t: hour of the year, simulation time step [0...8760]
+    :param t: hour of the year, simulation time step [0...HOURS_IN_YEAR]
     :type t: int
     :param bpr: BuildingPropertiesRow
     :type bpr: cea.demand.building_properties.BuildingPropertiesRow
@@ -263,7 +264,7 @@ def is_heating_season(t, bpr):
             return True
 
         elif heating_start > heating_end and \
-                (heating_start <= t <= 8760 or 0 <= t <= heating_end):
+                (heating_start <= t <= HOURS_IN_YEAR or 0 <= t <= heating_end):
             # heating season over the year end (north hemisphere)
             return True
 
@@ -280,7 +281,7 @@ def is_cooling_season(t, bpr):
     """
     checks if time step is part of the cooling season for the building
 
-    :param t: hour of the year, simulation time step [0...8760]
+    :param t: hour of the year, simulation time step [0...HOURS_IN_YEAR]
     :type t: int
     :param bpr: BuildingPropertiesRow
     :type bpr: cea.demand.building_properties.BuildingPropertiesRow
@@ -301,7 +302,7 @@ def is_cooling_season(t, bpr):
             return True
 
         elif cooling_start > cooling_end and \
-                (cooling_start <= t <= 8760 or 0 <= t <= cooling_end):
+                (cooling_start <= t <= HOURS_IN_YEAR or 0 <= t <= cooling_end):
             # cooling season around the year end (south hemisphere)
             return True
 
@@ -328,8 +329,8 @@ def calc_simple_temp_control(tsd, bpr, weekday):
     :rtype: dict
     """
 
-    tsd['ta_hs_set'] = np.vectorize(get_heating_system_set_point)(tsd['people'], range(8760), bpr, weekday)
-    tsd['ta_cs_set'] = np.vectorize(get_cooling_system_set_point)(tsd['people'], range(8760), bpr, weekday)
+    tsd['ta_hs_set'] = np.vectorize(get_heating_system_set_point)(tsd['people'], range(HOURS_IN_YEAR), bpr, weekday)
+    tsd['ta_cs_set'] = np.vectorize(get_cooling_system_set_point)(tsd['people'], range(HOURS_IN_YEAR), bpr, weekday)
 
     return tsd
 
@@ -338,7 +339,7 @@ def get_heating_system_set_point(people, t, bpr, weekday):
     """
 
     :param people:
-    :param t: hour of the year, simulation time step [0...8760]
+    :param t: hour of the year, simulation time step [0...HOURS_IN_YEAR]
     :type t: int
     :param bpr: BuildingPropertiesRow
     :type bpr: cea.demand.building_properties.BuildingPropertiesRow
@@ -364,7 +365,7 @@ def get_cooling_system_set_point(people, t, bpr, weekday):
     """
 
     :param people:
-    :param t: hour of the year, simulation time step [0...8760]
+    :param t: hour of the year, simulation time step [0...HOURS_IN_YEAR]
     :type t: int
     :param bpr: BuildingPropertiesRow
     :type bpr: cea.demand.building_properties.BuildingPropertiesRow

--- a/cea/demand/datacenter_loads.py
+++ b/cea/demand/datacenter_loads.py
@@ -6,6 +6,7 @@ from __future__ import division
 import numpy as np
 import pandas as pd
 from cea.technologies import heatpumps
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2016, Architecture and Building Systems - ETH Zurich"
@@ -77,12 +78,12 @@ def calc_Qcdataf(locator, bpr, tsd):
             tsd['E_data'] = np.vectorize(heatpumps.HP_air_air)(tsd['mcpcdata_sys'], (tsd['Tcdata_sys_sup'] + 273),
                                                                 (tsd['Tcdata_sys_re'] + 273), t_source)
             # final to district is zero
-            tsd['DC_cdata'] = np.zeros(8760)
+            tsd['DC_cdata'] = np.zeros(HOURS_IN_YEAR)
     elif energy_source == "DC":
         tsd['DC_cdata'] = tsd['Qcdata_sys']
-        tsd['E_data'] = np.zeros(8760)
+        tsd['E_data'] = np.zeros(HOURS_IN_YEAR)
     else:
-        tsd['E_data'] = np.zeros(8760)
-        tsd['DC_cdata'] = np.zeros(8760)
+        tsd['E_data'] = np.zeros(HOURS_IN_YEAR)
+        tsd['DC_cdata'] = np.zeros(HOURS_IN_YEAR)
     return tsd
 

--- a/cea/demand/demand_main.py
+++ b/cea/demand/demand_main.py
@@ -19,6 +19,8 @@ from cea.demand import thermal_loads
 from cea.demand.building_properties import BuildingProperties
 from cea.utilities import epwreader
 import warnings
+from cea.constants import HOURS_IN_YEAR
+
 warnings.filterwarnings("ignore")
 
 
@@ -127,7 +129,7 @@ def demand_calculation(locator, config):
 def properties_and_schedule(locator, year, use_daysim_radiation, override_variables=False):
     # this script is called from the Neural network please do not mess with it!
 
-    date = pd.date_range(str(year) + '/01/01', periods=8760, freq='H')
+    date = pd.date_range(str(year) + '/01/01', periods=HOURS_IN_YEAR, freq='H')
     # building properties model
 
     building_properties = BuildingProperties(locator, use_daysim_radiation, override_variables)

--- a/cea/demand/electrical_loads.py
+++ b/cea/demand/electrical_loads.py
@@ -9,6 +9,7 @@ from cea.utilities import physics
 from cea.demand import control_heating_cooling_systems, constants
 from cea.demand.hotwater_loads import calc_water_temperature
 import pandas as pd
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca, Gabriel Happle"
 __copyright__ = "Copyright 2016, Architecture and Building Systems - ETH Zurich"
@@ -57,7 +58,7 @@ def calc_Eal_Epro(tsd, bpr, schedules):
     if bpr.internal_loads['Epro_Wm2'] > 0:
         tsd['Epro'] = schedules['Epro'] * bpr.internal_loads['Epro_Wm2']
     else:
-        tsd['Epro'] = np.zeros(8760)
+        tsd['Epro'] = np.zeros(HOURS_IN_YEAR)
 
     return tsd
 
@@ -83,19 +84,19 @@ def calc_Ef(bpr, tsd):
 
     if scale_technology == "BUILDING":
         if energy_source == "SOLAR":
-            tsd['GRID'] = np.zeros(8760)
+            tsd['GRID'] = np.zeros(HOURS_IN_YEAR)
             tsd['PV'] = total_el_demand
         else:
             raise Exception('check potential error in input database of LCA infrastructure / ELECTRICITY')
     elif scale_technology == "CITY":
         if energy_source == "GRID":
             tsd['GRID'] = total_el_demand
-            tsd['PV'] = np.zeros(8760)
+            tsd['PV'] = np.zeros(HOURS_IN_YEAR)
         else:
             raise Exception('check potential error in input database of LCA infrastructure / ELECTRICITY')
     elif scale_technology == "NONE":
-        tsd['GRID'] = np.zeros(8760)
-        tsd['PV'] = np.zeros(8760)
+        tsd['GRID'] = np.zeros(HOURS_IN_YEAR)
+        tsd['PV'] = np.zeros(HOURS_IN_YEAR)
     else:
         raise Exception('check potential error in input database of LCA infrastructure / ELECTRICITY')
 
@@ -119,7 +120,7 @@ def calc_Eaux_fw(tsd, bpr, schedules):
     if nf_ag > 5:  # up to 5th floor no pumping needs
         tsd['Eaux_fw'] = calc_Eauxf_fw(tsd['vfw_m3perh'], nf_ag)
     else:
-        tsd['Eaux_fw'] = np.zeros(8760)
+        tsd['Eaux_fw'] = np.zeros(HOURS_IN_YEAR)
 
     return tsd
 
@@ -216,7 +217,7 @@ def calc_Eaux_Qhs_Qcs(tsd, bpr):
         Eaux_hs_shu = np.vectorize(calc_Eauxf_hs_dis)(Qhs_sys_shu, Qhs_sys_0_shu, deltaP_des, b, Ths_sup_shu, Ths_re_shu)
         tsd['Eaux_hs'] = Eaux_hs_ahu + Eaux_hs_aru + Eaux_hs_shu  # sum up
     else:
-        tsd['Eaux_hs'] = np.zeros(8760)
+        tsd['Eaux_hs'] = np.zeros(HOURS_IN_YEAR)
 
     if control_heating_cooling_systems.has_cooling_system(bpr):
 
@@ -226,7 +227,7 @@ def calc_Eaux_Qhs_Qcs(tsd, bpr):
         Eaux_cs_scu = np.vectorize(calc_Eauxf_cs_dis)(Qcs_sys_scu, Qcs_sys_0_scu, deltaP_des, b, Tcs_sup_scu, Tcs_re_scu)
         tsd['Eaux_cs'] = Eaux_cs_ahu + Eaux_cs_aru + Eaux_cs_scu  # sum up
     else:
-        tsd['Eaux_cs'] = np.zeros(8760)
+        tsd['Eaux_cs'] = np.zeros(HOURS_IN_YEAR)
 
     return tsd
 
@@ -350,7 +351,7 @@ def calc_Eauxf_fw(freshw, nf):
     """
     # TODO: documentation
 
-    Eaux_fw = np.zeros(8760)
+    Eaux_fw = np.zeros(HOURS_IN_YEAR)
     # for domestic freshwater
     # the power of the pump in Watts assuming the best performance of the pump of 0.6 and an accumulation tank
     for day in range(1, 366):

--- a/cea/demand/hotwater_loads.py
+++ b/cea/demand/hotwater_loads.py
@@ -11,6 +11,7 @@ from math import pi
 from cea.demand import constants
 from cea.technologies import storage_tank as storage_tank
 import pandas as pd
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2016, Architecture and Building Systems - ETH Zurich"
@@ -66,9 +67,9 @@ def calc_water_temperature(T_ambient_C, depth_m):
     T_max = max(T_ambient_C) + 273.15  # to K
     T_avg = np.mean(T_ambient_C) + 273.15  # to K
     e = depth_m * math.sqrt(
-        (math.pi * heat_capacity_soil * density_soil) / (8760 * conductivity_soil))  # soil constants
-    Tg = [(T_avg + (T_max - T_avg) * math.exp(-e) * math.cos((2 * math.pi * (i + 1) / 8760) - e)) - 274
-          for i in range(8760)]
+        (math.pi * heat_capacity_soil * density_soil) / (HOURS_IN_YEAR * conductivity_soil))  # soil constants
+    Tg = [(T_avg + (T_max - T_avg) * math.exp(-e) * math.cos((2 * math.pi * (i + 1) / HOURS_IN_YEAR) - e)) - 274
+          for i in range(HOURS_IN_YEAR)]
 
     return Tg  # in C
 
@@ -155,78 +156,78 @@ def calc_Qwwf(bpr, tsd):
     if scale_technology == "BUILDING":
         if energy_source == "GRID":
             tsd['E_ww'] =  tsd['Qww_sys']/ efficiency_average_year
-            tsd['SOLAR_ww'] = np.zeros(8760)
-            tsd['DH_ww'] = np.zeros(8760)
-            tsd['NG_ww'] = np.zeros(8760)
-            tsd['COAL_ww'] = np.zeros(8760)
-            tsd['OIL_ww'] = np.zeros(8760)
-            tsd['WOOD_ww'] = np.zeros(8760)
+            tsd['SOLAR_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['DH_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['NG_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['COAL_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['OIL_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['WOOD_ww'] = np.zeros(HOURS_IN_YEAR)
         elif energy_source == "NATURALGAS":
             tsd['NG_ww'] = tsd['Qww_sys'] / efficiency_average_year
-            tsd['COAL_ww'] = np.zeros(8760)
-            tsd['OIL_ww'] = np.zeros(8760)
-            tsd['WOOD_ww'] = np.zeros(8760)
-            tsd['DH_ww'] = np.zeros(8760)
-            tsd['E_ww'] = np.zeros(8760)
-            tsd['SOLAR_ww'] = np.zeros(8760)
+            tsd['COAL_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['OIL_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['WOOD_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['DH_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['E_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['SOLAR_ww'] = np.zeros(HOURS_IN_YEAR)
         elif energy_source == "OIL":
-            tsd['NG_ww'] = np.zeros(8760)
-            tsd['COAL_ww'] = np.zeros(8760)
+            tsd['NG_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['COAL_ww'] = np.zeros(HOURS_IN_YEAR)
             tsd['OIL_ww'] = tsd['Qww_sys'] / efficiency_average_year
-            tsd['WOOD_ww'] = np.zeros(8760)
-            tsd['DH_ww'] = np.zeros(8760)
-            tsd['E_ww'] = np.zeros(8760)
-            tsd['SOLAR_ww'] = np.zeros(8760)
+            tsd['WOOD_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['DH_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['E_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['SOLAR_ww'] = np.zeros(HOURS_IN_YEAR)
         elif energy_source == "COAL":
-            tsd['NG_ww'] = np.zeros(8760)
+            tsd['NG_ww'] = np.zeros(HOURS_IN_YEAR)
             tsd['COAL_ww'] = tsd['Qww_sys'] / efficiency_average_year
-            tsd['OIL_ww'] = np.zeros(8760)
-            tsd['WOOD_ww'] = np.zeros(8760)
-            tsd['DH_ww'] = np.zeros(8760)
-            tsd['E_ww'] = np.zeros(8760)
-            tsd['SOLAR_ww'] = np.zeros(8760)
+            tsd['OIL_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['WOOD_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['DH_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['E_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['SOLAR_ww'] = np.zeros(HOURS_IN_YEAR)
         elif energy_source == "WOOD":
-            tsd['NG_ww'] = np.zeros(8760)
-            tsd['COAL_ww'] = np.zeros(8760)
-            tsd['OIL_ww'] = np.zeros(8760)
+            tsd['NG_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['COAL_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['OIL_ww'] = np.zeros(HOURS_IN_YEAR)
             tsd['WOOD_ww'] = tsd['Qww_sys'] / efficiency_average_year
-            tsd['DH_ww'] = np.zeros(8760)
-            tsd['E_ww'] = np.zeros(8760)
-            tsd['SOLAR_ww'] = np.zeros(8760)
+            tsd['DH_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['E_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['SOLAR_ww'] = np.zeros(HOURS_IN_YEAR)
         elif energy_source == "SOLAR":
-            tsd['NG_ww'] = np.zeros(8760)
-            tsd['COAL_ww'] = np.zeros(8760)
-            tsd['OIL_ww'] = np.zeros(8760)
-            tsd['WOOD_ww'] = np.zeros(8760)
+            tsd['NG_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['COAL_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['OIL_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['WOOD_ww'] = np.zeros(HOURS_IN_YEAR)
             tsd['SOLAR_ww'] = tsd['Qww_sys'] / efficiency_average_year
-            tsd['DH_ww'] = np.zeros(8760)
-            tsd['E_ww'] = np.zeros(8760)
+            tsd['DH_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['E_ww'] = np.zeros(HOURS_IN_YEAR)
         elif energy_source == "NONE":
-            tsd['NG_ww'] = np.zeros(8760)
-            tsd['COAL_ww'] = np.zeros(8760)
-            tsd['OIL_ww'] = np.zeros(8760)
-            tsd['WOOD_ww'] = np.zeros(8760)
-            tsd['DH_ww'] = np.zeros(8760)
-            tsd['E_ww'] = np.zeros(8760)
-            tsd['SOLAR_ww'] = np.zeros(8760)
+            tsd['NG_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['COAL_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['OIL_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['WOOD_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['DH_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['E_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['SOLAR_ww'] = np.zeros(HOURS_IN_YEAR)
         else:
             raise Exception('check potential error in input database of LCA infrastructure / HOTWATER')
     elif scale_technology == "DISTRICT":
-            tsd['NG_ww'] = np.zeros(8760)
-            tsd['COAL_ww'] = np.zeros(8760)
-            tsd['OIL_ww'] = np.zeros(8760)
-            tsd['WOOD_ww'] = np.zeros(8760)
+            tsd['NG_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['COAL_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['OIL_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['WOOD_ww'] = np.zeros(HOURS_IN_YEAR)
             tsd['DH_ww'] = tsd['Qww_sys'] / efficiency_average_year
-            tsd['E_ww'] = np.zeros(8760)
-            tsd['SOLAR_ww'] = np.zeros(8760)
+            tsd['E_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['SOLAR_ww'] = np.zeros(HOURS_IN_YEAR)
     elif scale_technology == "NONE":
-            tsd['NG_ww'] = np.zeros(8760)
-            tsd['COAL_ww'] = np.zeros(8760)
-            tsd['OIL_ww'] = np.zeros(8760)
-            tsd['WOOD_ww'] = np.zeros(8760)
-            tsd['DH_ww'] = np.zeros(8760)
-            tsd['E_ww'] = np.zeros(8760)
-            tsd['SOLAR_ww'] = np.zeros(8760)
+            tsd['NG_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['COAL_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['OIL_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['WOOD_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['DH_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['E_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['SOLAR_ww'] = np.zeros(HOURS_IN_YEAR)
     else:
         raise Exception('check potential error in input database of LCA infrastructure / HOTWATER')
 
@@ -319,7 +320,7 @@ def calc_disls(tamb, Vww, V, twws, Lsww_dis, Y):
 
 def calc_DH_ww_with_tank_losses(T_ext_C, T_int_C, Qww, Vww, Qww_dis_ls_r, Qww_dis_ls_nr):
     """
-    Calculates the heat flows within a fully mixed water storage tank for 8760 time-steps.
+    Calculates the heat flows within a fully mixed water storage tank for HOURS_IN_YEAR time-steps.
     :param T_ext_C: external temperature in [C]
     :param T_int_C: room temperature in [C]
     :param Qww: hourly DHW demand in [Wh]
@@ -334,16 +335,16 @@ def calc_DH_ww_with_tank_losses(T_ext_C, T_int_C, Qww, Vww, Qww_dis_ls_r, Qww_di
     :type Qww_dis_ls_nr: ndarray
     :return:
     """
-    Qww_sys = np.zeros(8760)
-    Qww_st_ls = np.zeros(8760)
-    Tww_tank_C = np.zeros(8760)
-    Qd = np.zeros(8760)
+    Qww_sys = np.zeros(HOURS_IN_YEAR)
+    Qww_st_ls = np.zeros(HOURS_IN_YEAR)
+    Tww_tank_C = np.zeros(HOURS_IN_YEAR)
+    Qd = np.zeros(HOURS_IN_YEAR)
     # calculate DHW tank size [in m3] based on the peak DHW demand in the building
     V_tank_m3 = Vww.max()  # size the tank with the highest flow rate
     T_tank_start_C = TWW_SETPOINT  # assume the tank temperature at timestep 0 is at the dhw set point
 
     if V_tank_m3 > 0:
-        for k in range(8760):
+        for k in range(HOURS_IN_YEAR):
             area_tank_surface_m2 = storage_tank.calc_tank_surface_area(V_tank_m3)
             Q_tank_discharged_W = Qww[k] + Qww_dis_ls_r[k] + Qww_dis_ls_nr[k]
             Qww_st_ls[k], Qd[k], Qww_sys[k] = storage_tank.calc_dhw_tank_heat_balance(T_int_C[k], T_ext_C[k],
@@ -354,7 +355,7 @@ def calc_DH_ww_with_tank_losses(T_ext_C, T_int_C, Qww, Vww, Qww_dis_ls_r, Qww_di
                                                                'hot_water')
             T_tank_start_C = Tww_tank_C[k]  # update the tank temperature at the beginning of the next time step
     else:
-        for k in range(8760):
+        for k in range(HOURS_IN_YEAR):
             Tww_tank_C[k] = np.nan
     return Tww_tank_C, Qww_sys
 

--- a/cea/demand/metamodel/nn_generator/input_matrix.py
+++ b/cea/demand/metamodel/nn_generator/input_matrix.py
@@ -18,6 +18,7 @@ from cea.demand import control_heating_cooling_systems
 from cea.utilities import epwreader
 from cea.demand.sensible_loads import calc_I_sol
 import numpy as np
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca","Fazel Khayatian"
 __copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"
@@ -188,25 +189,25 @@ def get_array_geometry_variables(building):
     '''
     this function collects building geometry characteristics
     :param building: the intended building dataset
-    :return: array of geometry features * 8760 (array_geom)
+    :return: array of geometry features * HOURS_IN_YEAR (array_geom)
     '''
     #   net air-conditioned floor area
-    array_Af = np.empty(8760)
+    array_Af = np.empty(HOURS_IN_YEAR)
     array_Af.fill(building.rc_model['Af'])
     #   above ground wall area
-    array_OPwall = np.empty(8760)
+    array_OPwall = np.empty(HOURS_IN_YEAR)
     array_OPwall.fill(building.rc_model['Aop_sup'])
     #   basement wall area
-    array_OPwallB = np.empty(8760)
+    array_OPwallB = np.empty(HOURS_IN_YEAR)
     array_OPwallB.fill(building.rc_model['Aop_bel'])
     #   window area
-    array_GLwin = np.empty(8760)
+    array_GLwin = np.empty(HOURS_IN_YEAR)
     array_GLwin.fill(building.rc_model['Aw'])
     #   roof/floor area
-    array_OProof = np.empty(8760)
+    array_OProof = np.empty(HOURS_IN_YEAR)
     array_OProof.fill(building.rc_model['footprint'])
     #   surface to volume ratio
-    array_sv = np.empty(8760)
+    array_sv = np.empty(HOURS_IN_YEAR)
     array_sv.fill(building.rc_model['surface_volume'])
     #   concatenate geometry arrays
     array_geom = np.column_stack((array_Af, array_OPwall, array_OPwallB, array_GLwin, array_OProof, array_sv))
@@ -220,44 +221,44 @@ def get_array_architecture_variables(building, building_name, locator):
     :param building: the intended building dataset
     :param building_name: the intended building name from the list of buildings
     :param locator: points to the variables
-    :return: array of architectural features * 8760(array_arch)
+    :return: array of architectural features * HOURS_IN_YEAR(array_arch)
     '''
     #   pointing to the building dataframe
     data_architecture = dbf_to_dataframe(locator.get_building_architecture())
     data_architecture.set_index('Name', inplace=True)
     #   Window to wall ratio (as an average of all walls)
-    array_wwr = np.empty(8760)
+    array_wwr = np.empty(HOURS_IN_YEAR)
     average_wwr = np.mean([data_architecture.ix[building_name, 'wwr_south'],
                            data_architecture.ix[building_name, 'wwr_north'],
                            data_architecture.ix[building_name, 'wwr_west'],
                            data_architecture.ix[building_name, 'wwr_east']])
     array_wwr.fill(average_wwr)
     #   thermal mass
-    array_cm = np.empty(8760)
+    array_cm = np.empty(HOURS_IN_YEAR)
     array_cm.fill(building.architecture.Cm_Af)
     #   air leakage (infiltration)
-    array_n50 = np.empty(8760)
+    array_n50 = np.empty(HOURS_IN_YEAR)
     array_n50.fill(building.architecture.n50)
     #   roof properties
-    array_Uroof = np.empty(8760)
+    array_Uroof = np.empty(HOURS_IN_YEAR)
     array_Uroof.fill(building.architecture.U_roof)
-    array_aroof = np.empty(8760)
+    array_aroof = np.empty(HOURS_IN_YEAR)
     array_aroof.fill(building.architecture.a_roof)
     #   walls properties
-    array_Uwall = np.empty(8760)
+    array_Uwall = np.empty(HOURS_IN_YEAR)
     array_Uwall.fill(building.architecture.U_wall)
-    array_awall = np.empty(8760)
+    array_awall = np.empty(HOURS_IN_YEAR)
     array_awall.fill(building.architecture.a_wall)
     #   basement properties
-    array_Ubase = np.empty(8760)
+    array_Ubase = np.empty(HOURS_IN_YEAR)
     array_Ubase.fill(building.architecture.U_base)
     #   glazing properties
-    array_Uwin = np.empty(8760)
+    array_Uwin = np.empty(HOURS_IN_YEAR)
     array_Uwin.fill(building.architecture.U_win)
-    array_Gwin = np.empty(8760)
+    array_Gwin = np.empty(HOURS_IN_YEAR)
     array_Gwin.fill(building.architecture.G_win)
     #   shading properties
-    array_rfsh = np.empty(8760)
+    array_rfsh = np.empty(HOURS_IN_YEAR)
     array_rfsh.fill(building.architecture.rf_sh)
     #   concatenate architectural arrays
     array_arch = np.column_stack(
@@ -287,7 +288,7 @@ def get_array_comfort_variables(building, date, schedules_dict, weather_data,use
     array_Thset = tsd['ta_hs_set']
     array_Tcset = tsd['ta_cs_set']
     #   create a single vector of setpoint temperatures
-    array_cmfrt = np.empty((1, 8760))
+    array_cmfrt = np.empty((1, HOURS_IN_YEAR))
     seasonhours = [3216, 6192]
     array_cmfrt[0, :] = array_Thset
     array_cmfrt[0, seasonhours[0] + 1:seasonhours[1]] = array_Tcset[seasonhours[0] + 1:seasonhours[1]]
@@ -296,10 +297,10 @@ def get_array_comfort_variables(building, date, schedules_dict, weather_data,use
     array_HVAC_status=np.where(array_cmfrt > 99, 0,
              (np.where(array_cmfrt < -99, 0, 1)))
     #   an array of HVAC availability during winter
-    array_HVAC_heating = np.empty((1, 8760))
+    array_HVAC_heating = np.empty((1, HOURS_IN_YEAR))
     array_HVAC_heating[0,:] = np.where(array_Thset < -99, 0,1)
     #   an array of HVAC availability during summer
-    array_HVAC_cooling = np.empty((1, 8760))
+    array_HVAC_cooling = np.empty((1, HOURS_IN_YEAR))
     array_HVAC_cooling[0,:] = np.where(array_Tcset > 99, 0, 1)
     #   concatenate comfort arrays
     array_cmfrts=np.concatenate((array_cmfrt,array_HVAC_status),axis=0)
@@ -325,7 +326,7 @@ def get_array_internal_loads_variables(schedules, tsd, building):
     #   latent gains
     array_latent_gain = tsd['w_int']
     #   solar gains
-    for t in range(8760):
+    for t in range(HOURS_IN_YEAR):
         tsd['I_sol_and_I_rad'][t], tsd['I_rad'][t], tsd['I_sol'][t] =calc_I_sol(t, building, tsd)
     array_solar_gain=tsd['I_sol_and_I_rad']
     #   ventilation loss
@@ -342,29 +343,29 @@ def get_array_HVAC_variables(building):
     '''
     this array collects properties of HVAC system
     :param building: the intended building dataset
-    :return: array of HVAC characteristics * 8760(array_hvac)
+    :return: array of HVAC characteristics * HOURS_IN_YEAR(array_hvac)
     '''
     #   heating system
-    array_dThs_C = np.empty(8760)
+    array_dThs_C = np.empty(HOURS_IN_YEAR)
     array_dThs_C.fill(building.hvac['dThs_C'])
     #   cooling system
-    array_dTcs_C = np.empty(8760)
+    array_dTcs_C = np.empty(HOURS_IN_YEAR)
     array_dTcs_C.fill(building.hvac['dTcs_C'])
     #   ventilation (5 properties , converts true/false to Boolean)
-    array_economizer = np.empty(8760)
+    array_economizer = np.empty(HOURS_IN_YEAR)
     array_economizer.fill(int((building.hvac['ECONOMIZER'])=='True'))
-    array_win_vent = np.empty(8760)
+    array_win_vent = np.empty(HOURS_IN_YEAR)
     array_win_vent.fill(int((building.hvac['WIN_VENT'])=='True'))
-    array_mech_vent = np.empty(8760)
+    array_mech_vent = np.empty(HOURS_IN_YEAR)
     array_mech_vent.fill(int((building.hvac['MECH_VENT'])=='True'))
-    array_heat_rec = np.empty(8760)
+    array_heat_rec = np.empty(HOURS_IN_YEAR)
     array_heat_rec.fill(int((building.hvac['HEAT_REC'])=='True'))
-    array_night_flsh = np.empty(8760)
+    array_night_flsh = np.empty(HOURS_IN_YEAR)
     array_night_flsh.fill(int((building.hvac['NIGHT_FLSH'])=='True'))
     #   controller
-    array_ctrl_Qhs = np.empty(8760)
+    array_ctrl_Qhs = np.empty(HOURS_IN_YEAR)
     array_ctrl_Qhs.fill(1 * (building.hvac['dT_Qhs']))
-    array_ctrl_Qcs = np.empty(8760)
+    array_ctrl_Qcs = np.empty(HOURS_IN_YEAR)
     array_ctrl_Qcs.fill(1 * (building.hvac['dT_Qcs']))
     #   concatenate HVAC system arrays
     array_hvac = np.column_stack((array_dThs_C, array_dTcs_C, array_economizer, array_win_vent, array_mech_vent,

--- a/cea/demand/occupancy_model.py
+++ b/cea/demand/occupancy_model.py
@@ -5,6 +5,7 @@ import random
 import cea.inputlocator
 import cea.config
 from cea.utilities import epwreader
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2015, Architecture and Building Systems - ETH Zurich"
@@ -77,7 +78,7 @@ def calc_schedules(list_uses, archetype_schedules, bpr, archetype_values, stocha
         schedules = {}
         # occupant-related schedules are 0 since there are no occupants
         for schedule in ['people', 've', 'Qs', 'X', 'Vww', 'Vw']:
-            schedules[schedule] = np.zeros(8760)
+            schedules[schedule] = np.zeros(HOURS_IN_YEAR)
         # electricity and process schedules may be greater than 0
         for schedule in ['Ea', 'El', 'Qcre', 'Ed', 'Epro', 'Qhpro']:
             codes = {'Ea': 1, 'El': 1, 'Ed': 1, 'Epro': 3, 'Qhpro': 3,'Qcre': 3}
@@ -128,7 +129,7 @@ def calc_deterministic_schedules(archetype_schedules, archetype_values, bpr, lis
     schedules = {}
     normalizing_values = {}
     for schedule in ['people'] + occupant_schedules + electricity_schedules + water_schedules + process_schedules:
-        schedules[schedule] = np.zeros(8760, dtype=float)
+        schedules[schedule] = np.zeros(HOURS_IN_YEAR, dtype=float)
         normalizing_values[schedule] = 0.0
     for num in range(len(list_uses)):
         if bpr.occupancy[list_uses[num]] > 0:
@@ -147,7 +148,7 @@ def calc_deterministic_schedules(archetype_schedules, archetype_values, bpr, lis
 
     for label in occupant_schedules:
         if normalizing_values[label] == 0:
-            schedules[label] = np.zeros(8760)
+            schedules[label] = np.zeros(HOURS_IN_YEAR)
         else:
             schedules[label] = schedules[label] / normalizing_values[label]
 
@@ -210,7 +211,7 @@ def calc_stochastic_schedules(archetype_schedules, archetype_values, bpr, list_u
     schedules = {}
     normalizing_values = {}
     for schedule in ['people'] + occupant_schedules + electricity_schedules + water_schedules + process_schedules:
-        schedules[schedule] = np.zeros(8760)
+        schedules[schedule] = np.zeros(HOURS_IN_YEAR)
         normalizing_values[schedule] = 0.0
 
     # vector of mobility parameters
@@ -219,7 +220,7 @@ def calc_stochastic_schedules(archetype_schedules, archetype_values, bpr, list_u
 
     for num in range(len(list_uses)):
         current_share_of_use = bpr.occupancy[list_uses[num]]
-        current_stochastic_schedule = np.zeros(8760)
+        current_stochastic_schedule = np.zeros(HOURS_IN_YEAR)
         if current_share_of_use > 0:
             occupants_in_current_use = int(
                 archetype_values['people'][num] * current_share_of_use * bpr.rc_model['NFA_m2'])
@@ -274,7 +275,7 @@ def calc_stochastic_schedules(archetype_schedules, archetype_values, bpr, list_u
 
     for label in occupant_schedules + electricity_schedules + process_schedules + water_schedules:
         if normalizing_values[label] == 0:
-            schedules[label] = np.zeros(8760)
+            schedules[label] = np.zeros(HOURS_IN_YEAR)
         else:
             schedules[label] /= normalizing_values[label]
 
@@ -393,7 +394,7 @@ def calc_remaining_schedules_deterministic(archetype_schedules, archetype_values
     :return: normalized schedule for a given occupancy type
     """
 
-    current_schedule = np.zeros(8760)
+    current_schedule = np.zeros(HOURS_IN_YEAR)
     normalizing_value = 0.0
     for num in range(len(list_uses)):
         if archetype_values[num] != 0:  # do not consider when the value is 0
@@ -665,10 +666,10 @@ def main(config):
 
     weather_data = epwreader.epw_reader(config.weather)[['year']]
     year = weather_data['year'][0]
-    date = pd.date_range(str(year) + '/01/01', periods=8760, freq='H')
+    date = pd.date_range(str(year) + '/01/01', periods=HOURS_IN_YEAR, freq='H')
     locator = cea.inputlocator.InputLocator(scenario=config.scenario)
     config.demand.buildings = locator.get_zone_building_names()[0]
-    date = pd.date_range(gv.date_start, periods=8760, freq='H')
+    date = pd.date_range(gv.date_start, periods=HOURS_IN_YEAR, freq='H')
     building_properties = BuildingProperties(locator, True, False)
     bpr = building_properties[locator.get_zone_building_names()[0]]
     list_uses = ['OFFICE', 'INDUSTRIAL']

--- a/cea/demand/refrigeration_loads.py
+++ b/cea/demand/refrigeration_loads.py
@@ -6,6 +6,7 @@ from __future__ import division
 import numpy as np
 import pandas as pd
 from cea.technologies import heatpumps
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2016, Architecture and Building Systems - ETH Zurich"
@@ -71,12 +72,12 @@ def calc_Qref(locator, bpr, tsd):
             tsd['E_cre'] = np.vectorize(heatpumps.HP_air_air)(tsd['mcpcre_sys'], (tsd['Tcre_sys_sup'] + 273),
                                                                 (tsd['Tcre_sys_re'] + 273), t_source)
             # final to district is zero
-            tsd['DC_cre'] = np.zeros(8760)
+            tsd['DC_cre'] = np.zeros(HOURS_IN_YEAR)
     elif energy_source == "DC":
         tsd['DC_cre'] = tsd['Qcre_sys']
-        tsd['E_cre'] = np.zeros(8760)
+        tsd['E_cre'] = np.zeros(HOURS_IN_YEAR)
     else:
-        tsd['E_cre'] = np.zeros(8760)
+        tsd['E_cre'] = np.zeros(HOURS_IN_YEAR)
 
     return tsd
 

--- a/cea/demand/sensible_loads.py
+++ b/cea/demand/sensible_loads.py
@@ -7,6 +7,7 @@ from __future__ import division
 import numpy as np
 from cea.utilities.physics import BOLTZMANN
 from cea.demand import control_heating_cooling_systems, constants
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2016, Architecture and Building Systems - ETH Zurich"
@@ -201,27 +202,27 @@ def calc_temperatures_emission_systems(bpr, tsd):
     if not control_heating_cooling_systems.has_heating_system(bpr):
         # if no heating system
 
-        tsd['Ths_sys_sup_ahu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Ths_sys_re_ahu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcphs_sys_ahu'] = np.zeros(8760)
-        tsd['Ths_sys_sup_aru'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Ths_sys_re_aru'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcphs_sys_aru'] = np.zeros(8760)
-        tsd['Ths_sys_sup_shu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Ths_sys_re_shu'] = np.zeros(8760) * np.nan # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcphs_sys_shu'] = np.zeros(8760)
+        tsd['Ths_sys_sup_ahu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Ths_sys_re_ahu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcphs_sys_ahu'] = np.zeros(HOURS_IN_YEAR)
+        tsd['Ths_sys_sup_aru'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Ths_sys_re_aru'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcphs_sys_aru'] = np.zeros(HOURS_IN_YEAR)
+        tsd['Ths_sys_sup_shu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Ths_sys_re_shu'] = np.zeros(HOURS_IN_YEAR) * np.nan # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcphs_sys_shu'] = np.zeros(HOURS_IN_YEAR)
 
     elif control_heating_cooling_systems.has_radiator_heating_system(bpr):
         # if radiator heating system
         Ta_heating_0 = np.nanmax(tsd['ta_hs_set'])
         Qhs_sys_0 = np.nanmax(tsd['Qhs_sys'])  # in W
 
-        tsd['Ths_sys_sup_ahu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Ths_sys_re_ahu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcphs_sys_ahu'] = np.zeros(8760)
-        tsd['Ths_sys_sup_aru'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Ths_sys_re_aru'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcphs_sys_aru'] = np.zeros(8760)
+        tsd['Ths_sys_sup_ahu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Ths_sys_re_ahu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcphs_sys_ahu'] = np.zeros(HOURS_IN_YEAR)
+        tsd['Ths_sys_sup_aru'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Ths_sys_re_aru'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcphs_sys_aru'] = np.zeros(HOURS_IN_YEAR)
 
         Ths_sup, Ths_re, mcphs = np.vectorize(radiators.calc_radiator)(tsd['Qhs_sys'], tsd['T_int'], Qhs_sys_0, Ta_heating_0,
                                                                        bpr.building_systems['Ths_sup_shu_0'],
@@ -277,20 +278,20 @@ def calc_temperatures_emission_systems(bpr, tsd):
         tsd['mcphs_sys_aru'] = mcphs
 
         # SHU
-        tsd['Ths_sup_shu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Ths_sys_re_shu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcphs_sys_shu'] = np.zeros(8760)
+        tsd['Ths_sup_shu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Ths_sys_re_shu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcphs_sys_shu'] = np.zeros(HOURS_IN_YEAR)
 
     elif control_heating_cooling_systems.has_floor_heating_system(bpr):
 
         Qhs_sys_0 = np.nanmax(tsd['Qhs_sys'])  # in W
 
-        tsd['Ths_sys_sup_ahu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Ths_sys_re_ahu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcphs_sys_ahu'] = np.zeros(8760)
-        tsd['Ths_sys_sup_aru'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Ths_sys_re_aru'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcphs_sys_aru'] = np.zeros(8760)
+        tsd['Ths_sys_sup_ahu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Ths_sys_re_ahu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcphs_sys_ahu'] = np.zeros(HOURS_IN_YEAR)
+        tsd['Ths_sys_sup_aru'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Ths_sys_re_aru'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcphs_sys_aru'] = np.zeros(HOURS_IN_YEAR)
 
         Ths_sup, Ths_re, mcphs = np.vectorize(tabs.calc_floorheating)(tsd['Qhs_sys'], tsd['theta_m'], Qhs_sys_0,
                                                                       bpr.building_systems['Ths_sup_shu_0'],
@@ -310,15 +311,15 @@ def calc_temperatures_emission_systems(bpr, tsd):
     if not control_heating_cooling_systems.has_cooling_system(bpr):
         # if no heating system
 
-        tsd['Tcs_sys_sup_ahu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Tcs_sys_re_ahu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcpcs_sys_ahu'] = np.zeros(8760)
-        tsd['Tcs_sys_sup_aru'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Tcs_sys_re_aru'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcpcs_sys_aru'] = np.zeros(8760)
-        tsd['Tcs_sys_sup_scu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Tcs_sys_re_scu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcpcs_sys_scu'] = np.zeros(8760)
+        tsd['Tcs_sys_sup_ahu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Tcs_sys_re_ahu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcpcs_sys_ahu'] = np.zeros(HOURS_IN_YEAR)
+        tsd['Tcs_sys_sup_aru'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Tcs_sys_re_aru'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcpcs_sys_aru'] = np.zeros(HOURS_IN_YEAR)
+        tsd['Tcs_sys_sup_scu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Tcs_sys_re_scu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcpcs_sys_scu'] = np.zeros(HOURS_IN_YEAR)
 
     elif control_heating_cooling_systems.has_central_ac_cooling_system(bpr):
 
@@ -365,16 +366,16 @@ def calc_temperatures_emission_systems(bpr, tsd):
         tsd['mcpcs_sys_aru'] = mcpcs
 
         # SCU
-        tsd['Tcs_sys_sup_scu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Tcs_sys_re_scu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcpcs_sys_scu'] = np.zeros(8760)
+        tsd['Tcs_sys_sup_scu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Tcs_sys_re_scu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcpcs_sys_scu'] = np.zeros(HOURS_IN_YEAR)
 
     elif control_heating_cooling_systems.has_local_ac_cooling_system(bpr):
 
         # AHU
-        tsd['Tcs_sys_sup_ahu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Tcs_sys_re_ahu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcpcs_sys_ahu'] = np.zeros(8760)
+        tsd['Tcs_sys_sup_ahu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Tcs_sys_re_ahu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcpcs_sys_ahu'] = np.zeros(HOURS_IN_YEAR)
 
         # ARU
         # consider losses according to loads of systems
@@ -400,9 +401,9 @@ def calc_temperatures_emission_systems(bpr, tsd):
         tsd['mcpcs_sys_aru'] = mcpcs
 
         # SCU
-        tsd['Tcs_sys_sup_scu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Tcs_sys_re_scu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcpcs_sys_scu'] = np.zeros(8760)
+        tsd['Tcs_sys_sup_scu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Tcs_sys_re_scu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcpcs_sys_scu'] = np.zeros(HOURS_IN_YEAR)
 
     elif control_heating_cooling_systems.has_3for2_cooling_system(bpr):
 
@@ -489,14 +490,14 @@ def calc_temperatures_emission_systems(bpr, tsd):
         tsd['mcpcs_sys_scu'] = mcpcs
 
         # AHU
-        tsd['Tcs_sys_sup_ahu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Tcs_sys_re_ahu'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcpcs_sys_ahu'] = np.zeros(8760)
+        tsd['Tcs_sys_sup_ahu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Tcs_sys_re_ahu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcpcs_sys_ahu'] = np.zeros(HOURS_IN_YEAR)
 
         # ARU
-        tsd['Tcs_sys_sup_aru'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['Tcs_sys_re_aru'] = np.zeros(8760) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
-        tsd['mcpcs_sys_aru'] = np.zeros(8760)
+        tsd['Tcs_sys_sup_aru'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['Tcs_sys_re_aru'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
+        tsd['mcpcs_sys_aru'] = np.zeros(HOURS_IN_YEAR)
 
     else:
         raise Exception('Cooling system not defined in function: "calc_temperatures_emission_systems"')
@@ -555,7 +556,7 @@ def calc_Qhs_Qcs_loss(bpr, tsd):
         qhs_sen_ahu_incl_em_ls / np.nanmax(qhs_sen_ahu_incl_em_ls)) * (Lv * Y)
 
     else:
-        Qhs_d_ls_ahu = np.zeros(8760)
+        Qhs_d_ls_ahu = np.zeros(HOURS_IN_YEAR)
 
     if np.any(tsd['Qhs_sen_aru'] > 0):
         frac_aru = [aru / sys if sys > 0 else 0 for aru, sys in zip(tsd['Qhs_sen_aru'], tsd['Qhs_sen_sys'])]
@@ -565,7 +566,7 @@ def calc_Qhs_Qcs_loss(bpr, tsd):
         qhs_sen_aru_incl_em_ls / np.nanmax(qhs_sen_aru_incl_em_ls)) * (
                            Lv * Y)
     else:
-        Qhs_d_ls_aru = np.zeros(8760)
+        Qhs_d_ls_aru = np.zeros(HOURS_IN_YEAR)
 
     if np.any(tsd['Qhs_sen_shu'] > 0):
         frac_shu = [shu / sys if sys > 0 else 0 for shu, sys in zip(tsd['Qhs_sen_shu'], tsd['Qhs_sen_sys'])]
@@ -575,7 +576,7 @@ def calc_Qhs_Qcs_loss(bpr, tsd):
         qhs_sen_shu_incl_em_ls / np.nanmax(qhs_sen_shu_incl_em_ls)) * (
                            Lv * Y)
     else:
-        qhs_d_ls_shu = np.zeros(8760)
+        qhs_d_ls_shu = np.zeros(HOURS_IN_YEAR)
 
     if np.any(tsd['Qcs_sen_ahu'] < 0):
         frac_ahu = [ahu / sys if sys < 0 else 0 for ahu, sys in zip(tsd['Qcs_sen_ahu'], tsd['Qcs_sen_sys'])]
@@ -584,7 +585,7 @@ def calc_Qhs_Qcs_loss(bpr, tsd):
         qcs_d_ls_ahu = ((tsc_ahu + trc_ahu) / 2 - tamb) * (qcs_sen_ahu_incl_em_ls / np.nanmin(qcs_sen_ahu_incl_em_ls))\
                        * (Lv * Y)
     else:
-        qcs_d_ls_ahu = np.zeros(8760)
+        qcs_d_ls_ahu = np.zeros(HOURS_IN_YEAR)
 
     if np.any(tsd['Qcs_sen_aru'] < 0):
         frac_aru = [aru / sys if sys < 0 else 0 for aru, sys in zip(tsd['Qcs_sen_aru'], tsd['Qcs_sen_sys'])]
@@ -593,7 +594,7 @@ def calc_Qhs_Qcs_loss(bpr, tsd):
         qcs_d_ls_aru = ((tsc_aru + trc_aru) / 2 - tamb) * (qcs_sen_aru_incl_em_ls / np.nanmin(qcs_sen_aru_incl_em_ls))\
                         * (Lv * Y)
     else:
-        qcs_d_ls_aru = np.zeros(8760)
+        qcs_d_ls_aru = np.zeros(HOURS_IN_YEAR)
 
     if np.any(tsd['Qcs_sen_scu'] < 0):
         frac_scu = [scu / sys if sys < 0 else 0 for scu, sys in zip(tsd['Qcs_sen_scu'], tsd['Qcs_sen_sys'])]
@@ -602,7 +603,7 @@ def calc_Qhs_Qcs_loss(bpr, tsd):
         Qcs_d_ls_scu = ((tsc_scu + trc_scu) / 2 - tamb) * (qcs_sen_scu_incl_em_ls / np.nanmin(qcs_sen_scu_incl_em_ls)) * (
         Lv * Y)
     else:
-        Qcs_d_ls_scu = np.zeros(8760)
+        Qcs_d_ls_scu = np.zeros(HOURS_IN_YEAR)
 
     tsd['Qhs_dis_ls'] = Qhs_d_ls_ahu + Qhs_d_ls_aru + qhs_d_ls_shu
     tsd['Qcs_dis_ls'] = qcs_d_ls_ahu + qcs_d_ls_aru + Qcs_d_ls_scu

--- a/cea/demand/set_point_from_predefined_file.py
+++ b/cea/demand/set_point_from_predefined_file.py
@@ -9,6 +9,7 @@ from cea.demand.control_heating_cooling_systems import get_heating_system_set_po
 from cea.demand.control_heating_cooling_systems import get_cooling_system_set_point
 
 import datetime
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Bhargava Krishna Sreepathi"
 __copyright__ = "Copyright 2019, Architecture and Building Systems - ETH Zurich"
@@ -45,17 +46,21 @@ def calc_set_point_from_predefined_file(tsd, bpr, weekday, building_name, locato
     :rtype: dict
     """
     if os.path.isfile(locator.get_predefined_hourly_setpoints(building_name, type_of_district_network='space-heating')):
-        predefined_set_temperatures_space_heating = pd.read_csv(locator.get_predefined_hourly_setpoints(building_name, type_of_district_network='space-heating'))
+        predefined_set_temperatures_space_heating = pd.read_csv(
+            locator.get_predefined_hourly_setpoints(building_name, type_of_district_network='space-heating'))
         tsd['ta_hs_set'] = predefined_set_temperatures_space_heating['temperature'].values
     else:
-        print ('predefined set points file for space heating is not provided. It is running with the default archetype set points')
-        tsd['ta_hs_set'] = np.vectorize(get_heating_system_set_point)(tsd['people'], range(8760), bpr, weekday)
+        print (
+            'predefined set points file for space heating is not provided. It is running with the default archetype set points')
+        tsd['ta_hs_set'] = np.vectorize(get_heating_system_set_point)(tsd['people'], range(HOURS_IN_YEAR), bpr, weekday)
 
     if os.path.isfile(locator.get_predefined_hourly_setpoints(building_name, type_of_district_network='space-cooling')):
-        predefined_set_temperatures_space_cooling = pd.read_csv(locator.get_predefined_hourly_setpoints(building_name, type_of_district_network='space-cooling'))
+        predefined_set_temperatures_space_cooling = pd.read_csv(
+            locator.get_predefined_hourly_setpoints(building_name, type_of_district_network='space-cooling'))
         tsd['ta_cs_set'] = predefined_set_temperatures_space_cooling['temperature'].values
     else:
-        print ('predefined set points file for space cooling is not provided. It is running with the default archetype set points')
-        tsd['ta_cs_set'] = np.vectorize(get_cooling_system_set_point)(tsd['people'], range(8760), bpr, weekday)
+        print (
+            'predefined set points file for space cooling is not provided. It is running with the default archetype set points')
+        tsd['ta_cs_set'] = np.vectorize(get_cooling_system_set_point)(tsd['people'], range(HOURS_IN_YEAR), bpr, weekday)
 
     return tsd

--- a/cea/demand/thermal_loads.py
+++ b/cea/demand/thermal_loads.py
@@ -3,10 +3,8 @@
 Demand model of thermal loads
 """
 from __future__ import division
-
 import numpy as np
 import pandas as pd
-
 from cea.demand import demand_writers
 from cea.demand import latent_loads
 from cea.demand import occupancy_model, hourly_procedure_heating_cooling_system_load, ventilation_air_flows_simple
@@ -14,8 +12,8 @@ from cea.demand import sensible_loads, electrical_loads, hotwater_loads, refrige
 from cea.demand import ventilation_air_flows_detailed, control_heating_cooling_systems
 from cea.technologies import heatpumps
 from cea.demand.set_point_from_predefined_file import calc_set_point_from_predefined_file
-
 from cea.utilities import reporting
+from cea.constants import HOURS_IN_YEAR
 
 
 def calc_thermal_loads(building_name, bpr, weather_data, usage_schedules, date, locator, use_stochastic_occupancy,
@@ -38,7 +36,7 @@ def calc_thermal_loads(building_name, bpr, weather_data, usage_schedules, date, 
     * each element of the 'list_uses' entry represents a building occupancy type.
     * each element of the 'schedules' entry represents the schedules for a building occupancy type.
     * the schedules for a building occupancy type are a 4-tuple (occupancy, electricity, domestic hot water,
-      probability of use), with each element of the 4-tuple being a list of hourly values (8760 values).
+      probability of use), with each element of the 4-tuple being a list of hourly values (HOURS_IN_YEAR values).
 
 
     Side effect include a number of files in two folders:
@@ -66,7 +64,7 @@ def calc_thermal_loads(building_name, bpr, weather_data, usage_schedules, date, 
     :param usage_schedules: dict containing schedules and function names of buildings.
     :type usage_schedules: dict
 
-    :param date: the dates (hours) of the year (8760)
+    :param date: the dates (hours) of the year (HOURS_IN_YEAR)
     :type date: pandas.tseries.index.DatetimeIndex
 
     :param locator:
@@ -86,9 +84,9 @@ def calc_thermal_loads(building_name, bpr, weather_data, usage_schedules, date, 
         tsd = refrigeration_loads.calc_Qcre_sys(bpr, tsd, schedules)
         tsd = refrigeration_loads.calc_Qref(locator, bpr, tsd)
     else:
-        tsd['DC_cre'] = tsd['Qcre_sys'] = tsd['Qcre'] = np.zeros(8760)
-        tsd['mcpcre_sys'] = tsd['Tcre_sys_re'] = tsd['Tcre_sys_sup'] = np.zeros(8760)
-        tsd['E_cre'] = np.zeros(8760)
+        tsd['DC_cre'] = tsd['Qcre_sys'] = tsd['Qcre'] = np.zeros(HOURS_IN_YEAR)
+        tsd['mcpcre_sys'] = tsd['Tcre_sys_re'] = tsd['Tcre_sys_sup'] = np.zeros(HOURS_IN_YEAR)
+        tsd['E_cre'] = np.zeros(HOURS_IN_YEAR)
 
     if np.isclose(bpr.rc_model['Af'], 0.0):  # if building does not have conditioned area
 
@@ -106,9 +104,9 @@ def calc_thermal_loads(building_name, bpr, weather_data, usage_schedules, date, 
             tsd = datacenter_loads.calc_Qcdata_sys(tsd)  # system need for cooling
             tsd = datacenter_loads.calc_Qcdataf(locator, bpr, tsd)  # final need for cooling
         else:
-            tsd['DC_cdata'] = tsd['Qcdata_sys'] = tsd['Qcdata'] = np.zeros(8760)
-            tsd['mcpcdata_sys'] = tsd['Tcdata_sys_re'] = tsd['Tcdata_sys_sup'] = np.zeros(8760)
-            tsd['Edata'] = tsd['E_cdata'] = np.zeros(8760)
+            tsd['DC_cdata'] = tsd['Qcdata_sys'] = tsd['Qcdata'] = np.zeros(HOURS_IN_YEAR)
+            tsd['mcpcdata_sys'] = tsd['Tcdata_sys_re'] = tsd['Tcdata_sys_sup'] = np.zeros(HOURS_IN_YEAR)
+            tsd['Edata'] = tsd['E_cdata'] = np.zeros(HOURS_IN_YEAR)
 
         #CALCULATE HEATING AND COOLING DEMAND
         tsd = calc_set_points(bpr, date, tsd, building_name, config, locator)  # calculate the setpoints for every hour
@@ -137,11 +135,11 @@ def calc_thermal_loads(building_name, bpr, weather_data, usage_schedules, date, 
             tsd = hotwater_loads.calc_Qwwf(bpr, tsd) #final
         else:
             tsd = electrical_loads.calc_Eaux_fw(tsd, bpr, schedules)
-            tsd['Qww'] = tsd['DH_ww'] = tsd['Qww_sys'] = np.zeros(8760)
-            tsd['mcpww_sys'] = tsd['Tww_sys_re'] = tsd['Tww_sys_sup'] = np.zeros(8760)
-            tsd['Eaux_ww'] = tsd['SOLAR_ww'] = np.zeros(8760)
-            tsd['NG_ww'] = tsd['COAL_ww'] = tsd['OIL_ww'] =  tsd['WOOD_ww'] = np.zeros(8760)
-            tsd['E_ww'] = np.zeros(8760)
+            tsd['Qww'] = tsd['DH_ww'] = tsd['Qww_sys'] = np.zeros(HOURS_IN_YEAR)
+            tsd['mcpww_sys'] = tsd['Tww_sys_re'] = tsd['Tww_sys_sup'] = np.zeros(HOURS_IN_YEAR)
+            tsd['Eaux_ww'] = tsd['SOLAR_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['NG_ww'] = tsd['COAL_ww'] = tsd['OIL_ww'] =  tsd['WOOD_ww'] = np.zeros(HOURS_IN_YEAR)
+            tsd['E_ww'] = np.zeros(HOURS_IN_YEAR)
 
             # CALCULATE SUM OF HEATING AND COOLING LOADS
         tsd = calc_QH_sys_QC_sys(tsd)  # aggregated cooling and heating loads
@@ -217,18 +215,18 @@ def calc_Qcs_sys(bpr, tsd):
                                                                     (tsd['Tcs_sys_re_scu'] + 273), t_source)
                 # sum
                 tsd['E_cs'] = E_for_Qcs_sys_scu + E_for_Qcs_sys_aru + E_for_Qcs_sys_ahu
-                tsd['DC_cs'] = np.zeros(8760)
+                tsd['DC_cs'] = np.zeros(HOURS_IN_YEAR)
         elif energy_source == "NONE":
-            tsd['E_cs'] = np.zeros(8760)
-            tsd['DC_cs'] = np.zeros(8760)
+            tsd['E_cs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['DC_cs'] = np.zeros(HOURS_IN_YEAR)
         else:
             raise Exception('check potential error in input database of LCA infrastructure / COOLING')
     elif scale_technology == "DISTRICT":
         tsd['DC_cs'] = tsd['Qcs_sys'] / efficiency_average_year
-        tsd['E_cs'] = np.zeros(8760)
+        tsd['E_cs'] = np.zeros(HOURS_IN_YEAR)
     elif scale_technology == "NONE":
-        tsd['DC_cs'] = np.zeros(8760)
-        tsd['E_cs'] = np.zeros(8760)
+        tsd['DC_cs'] = np.zeros(HOURS_IN_YEAR)
+        tsd['E_cs'] = np.zeros(HOURS_IN_YEAR)
     else:
         raise Exception('check potential error in input database of LCA infrastructure / COOLING')
     return tsd
@@ -247,78 +245,78 @@ def calc_Qhs_sys(bpr, tsd):
     if scale_technology == "BUILDING":
         if energy_source == "GRID":
             tsd['E_hs'] =  tsd['Qhs_sys']/efficiency_average_year
-            tsd['SOLAR_hs'] = np.zeros(8760)
-            tsd['DH_hs'] = np.zeros(8760)
-            tsd['NG_hs'] = np.zeros(8760)
-            tsd['COAL_hs'] = np.zeros(8760)
-            tsd['OIL_hs'] = np.zeros(8760)
-            tsd['WOOD_hs'] = np.zeros(8760)
+            tsd['SOLAR_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['DH_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['NG_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['COAL_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['OIL_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['WOOD_hs'] = np.zeros(HOURS_IN_YEAR)
         elif energy_source == "NATURALGAS":
             tsd['NG_hs'] = tsd['Qhs_sys']/efficiency_average_year
-            tsd['COAL_hs'] = np.zeros(8760)
-            tsd['OIL_hs'] = np.zeros(8760)
-            tsd['WOOD_hs'] = np.zeros(8760)
-            tsd['DH_hs'] = np.zeros(8760)
-            tsd['E_hs'] = np.zeros(8760)
-            tsd['SOLAR_hs'] = np.zeros(8760)
+            tsd['COAL_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['OIL_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['WOOD_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['DH_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['E_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['SOLAR_hs'] = np.zeros(HOURS_IN_YEAR)
         elif energy_source == "OIL":
-            tsd['NG_hs'] = np.zeros(8760)
-            tsd['COAL_hs'] = np.zeros(8760)
+            tsd['NG_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['COAL_hs'] = np.zeros(HOURS_IN_YEAR)
             tsd['OIL_hs'] = tsd['Qhs_sys']/efficiency_average_year
-            tsd['WOOD_hs'] = np.zeros(8760)
-            tsd['DH_hs'] = np.zeros(8760)
-            tsd['E_hs'] = np.zeros(8760)
-            tsd['SOLAR_hs'] = np.zeros(8760)
+            tsd['WOOD_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['DH_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['E_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['SOLAR_hs'] = np.zeros(HOURS_IN_YEAR)
         elif energy_source == "COAL":
-            tsd['NG_hs'] = np.zeros(8760)
+            tsd['NG_hs'] = np.zeros(HOURS_IN_YEAR)
             tsd['COAL_hs'] = tsd['Qhs_sys']/efficiency_average_year
-            tsd['OIL_hs'] = np.zeros(8760)
-            tsd['WOOD_hs'] = np.zeros(8760)
-            tsd['DH_hs'] = np.zeros(8760)
-            tsd['E_hs'] = np.zeros(8760)
-            tsd['SOLAR_hs'] = np.zeros(8760)
+            tsd['OIL_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['WOOD_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['DH_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['E_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['SOLAR_hs'] = np.zeros(HOURS_IN_YEAR)
         elif energy_source == "WOOD":
-            tsd['NG_hs'] = np.zeros(8760)
-            tsd['COAL_hs'] = np.zeros(8760)
-            tsd['OIL_hs'] = np.zeros(8760)
+            tsd['NG_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['COAL_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['OIL_hs'] = np.zeros(HOURS_IN_YEAR)
             tsd['WOOD_hs'] = tsd['Qhs_sys']/efficiency_average_year
-            tsd['DH_hs'] = np.zeros(8760)
-            tsd['E_hs'] = np.zeros(8760)
-            tsd['SOLAR_hs'] = np.zeros(8760)
+            tsd['DH_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['E_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['SOLAR_hs'] = np.zeros(HOURS_IN_YEAR)
         elif energy_source == "SOLAR":
-            tsd['NG_hs'] = np.zeros(8760)
-            tsd['COAL_hs'] = np.zeros(8760)
-            tsd['OIL_hs'] = np.zeros(8760)
-            tsd['WOOD_hs'] = np.zeros(8760)
+            tsd['NG_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['COAL_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['OIL_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['WOOD_hs'] = np.zeros(HOURS_IN_YEAR)
             tsd['SOLAR_hs'] =  tsd['Qhs_sys']/efficiency_average_year
-            tsd['DH_hs'] = np.zeros(8760)
-            tsd['E_hs'] = np.zeros(8760)
+            tsd['DH_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['E_hs'] = np.zeros(HOURS_IN_YEAR)
         elif energy_source == "NONE":
-            tsd['NG_hs'] = np.zeros(8760)
-            tsd['COAL_hs'] = np.zeros(8760)
-            tsd['OIL_hs'] = np.zeros(8760)
-            tsd['WOOD_hs'] = np.zeros(8760)
-            tsd['DH_hs'] = np.zeros(8760)
-            tsd['E_hs'] = np.zeros(8760)
-            tsd['SOLAR_hs'] = np.zeros(8760)
+            tsd['NG_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['COAL_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['OIL_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['WOOD_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['DH_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['E_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['SOLAR_hs'] = np.zeros(HOURS_IN_YEAR)
         else:
             raise Exception('check potential error in input database of LCA infrastructure / HEATING')
     elif scale_technology == "DISTRICT":
-            tsd['NG_hs'] = np.zeros(8760)
-            tsd['COAL_hs'] = np.zeros(8760)
-            tsd['OIL_hs'] = np.zeros(8760)
-            tsd['WOOD_hs'] = np.zeros(8760)
+            tsd['NG_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['COAL_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['OIL_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['WOOD_hs'] = np.zeros(HOURS_IN_YEAR)
             tsd['DH_hs'] = tsd['Qhs_sys']/efficiency_average_year
-            tsd['E_hs'] = np.zeros(8760)
-            tsd['SOLAR_hs'] = np.zeros(8760)
+            tsd['E_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['SOLAR_hs'] = np.zeros(HOURS_IN_YEAR)
     elif scale_technology == "NONE":
-            tsd['NG_hs'] = np.zeros(8760)
-            tsd['COAL_hs'] = np.zeros(8760)
-            tsd['OIL_hs'] = np.zeros(8760)
-            tsd['WOOD_hs'] = np.zeros(8760)
-            tsd['DH_hs'] = np.zeros(8760)
-            tsd['E_hs'] = np.zeros(8760)
-            tsd['SOLAR_hs'] = np.zeros(8760)
+            tsd['NG_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['COAL_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['OIL_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['WOOD_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['DH_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['E_hs'] = np.zeros(HOURS_IN_YEAR)
+            tsd['SOLAR_hs'] = np.zeros(HOURS_IN_YEAR)
     else:
         raise Exception('check potential error in input database of LCA infrastructure / HEATING')
     return tsd
@@ -501,12 +499,12 @@ def initialize_timestep_data(bpr, weather_data):
     nan_fields.extend(nan_fields_electricity)
     nan_fields.extend(TSD_KEYS_PEOPLE)
 
-    tsd.update(dict((x, np.zeros(8760) * np.nan) for x in nan_fields))
+    tsd.update(dict((x, np.zeros(HOURS_IN_YEAR) * np.nan) for x in nan_fields))
 
     # initialize system status log
-    tsd['sys_status_ahu'] = np.chararray(8760, itemsize=20)
-    tsd['sys_status_aru'] = np.chararray(8760, itemsize=20)
-    tsd['sys_status_sen'] = np.chararray(8760, itemsize=20)
+    tsd['sys_status_ahu'] = np.chararray(HOURS_IN_YEAR, itemsize=20)
+    tsd['sys_status_aru'] = np.chararray(HOURS_IN_YEAR, itemsize=20)
+    tsd['sys_status_sen'] = np.chararray(HOURS_IN_YEAR, itemsize=20)
     tsd['sys_status_ahu'][:] = 'unknown'
     tsd['sys_status_aru'][:] = 'unknown'
     tsd['sys_status_sen'][:] = 'unknown'
@@ -561,14 +559,14 @@ def update_timestep_data_no_conditioned_area(tsd):
                    'Qgain_wind', 'Qgain_vent'
                    'Q_cool_ref', 'q_cs_lat_peop']
 
-    tsd.update(dict((x, np.zeros(8760)) for x in zero_fields))
+    tsd.update(dict((x, np.zeros(HOURS_IN_YEAR)) for x in zero_fields))
 
     tsd['T_int'] = tsd['T_ext'].copy()
 
     return tsd
 
 
-HOURS_IN_YEAR = 8760
+HOURS_IN_YEAR = HOURS_IN_YEAR
 HOURS_PRE_CONDITIONING = 720  # number of hours that the building will be thermally pre-conditioned, the results of these hours will be overwritten
 
 

--- a/cea/demand/ventilation_air_flows_simple.py
+++ b/cea/demand/ventilation_air_flows_simple.py
@@ -5,6 +5,7 @@ from __future__ import division
 import numpy as np
 from cea.demand import control_ventilation_systems, constants, control_heating_cooling_systems
 from cea.utilities import physics
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Gabriel Happle"
 __copyright__ = "Copyright 2016, Architecture and Building Systems - ETH Zurich"
@@ -37,7 +38,7 @@ def calc_air_mass_flow_mechanical_ventilation(bpr, tsd, t):
     :type bpr: cea.demand.thermal_loads.BuildingPropertiesRow
     :param tsd: Timestep data
     :type tsd: Dict[str, numpy.ndarray]
-    :param t: time step [0..8760]
+    :param t: time step [0..HOURS_IN_YEAR]
     :type t: int
     :return: updates tsd
     """
@@ -91,7 +92,7 @@ def calc_air_mass_flow_window_ventilation(bpr, tsd, t):
     :type bpr: cea.demand.thermal_loads.BuildingPropertiesRow
     :param tsd: Timestep data
     :type tsd: Dict[str, numpy.ndarray]
-    :param t: time step [0..8760]
+    :param t: time step [0..HOURS_IN_YEAR]
     :type t: int
     :return: updates tsd
     """
@@ -166,7 +167,7 @@ def calc_theta_ve_mech(bpr, tsd, t):
     :type bpr: cea.demand.thermal_loads.BuildingPropertiesRow
     :param tsd: Timestep data
     :type tsd: Dict[str, numpy.ndarray]
-    :param t: time step [0..8760]
+    :param t: time step [0..HOURS_IN_YEAR]
     :type t: int
     :return: updates tsd
     """
@@ -216,7 +217,7 @@ def calc_m_ve_required(bpr, tsd):
         m_ve_required_min = constants.MIN_VENTILATION_RATE * bpr.rc_model['Af'] * physics.calc_rho_air(tsd['T_ext'][:]) * 0.001  # kg/s
         # we want this not to affect the air flows during the heating season
         m_ve_required = []
-        for t in range(0,8760):
+        for t in range(0, HOURS_IN_YEAR):
             if 0.0 < m_ve_required_people[t] < m_ve_required_min[t] and \
                 control_heating_cooling_systems.is_cooling_season(t, bpr):
                 m_ve_required.append(m_ve_required_min[t])

--- a/cea/optimization/distribution/network_opt_main.py
+++ b/cea/optimization/distribution/network_opt_main.py
@@ -4,6 +4,7 @@ Network optimization
 from __future__ import division
 import pandas as pd
 import numpy as np
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Sreepathi Bhargava Krishna"
 __copyright__ = "Copyright 2015, Architecture and Building Systems - ETH Zurich"
@@ -24,8 +25,8 @@ class network_opt_main(object):
     def __init__(self, config, locator):
         self.pipesCosts_DHN_USD = 0     # USD-2015
         self.pipesCosts_DCN_USD = 0     # USD-2015
-        self.DeltaP_DHN = np.zeros(8760)         # Pa
-        self.DeltaP_DCN = np.zeros(8760)        # Pa
+        self.DeltaP_DHN = np.zeros(HOURS_IN_YEAR)         # Pa
+        self.DeltaP_DCN = np.zeros(HOURS_IN_YEAR)        # Pa
         self.thermallosses_DHN = 0
         self.thermallosses_DCN = 0
 
@@ -37,10 +38,10 @@ class network_opt_main(object):
         for network_name in network_names:
             pressure_drop_Pa = pd.read_csv(locator.get_optimization_network_layout_pressure_drop_file(config.thermal_network.network_type, network_name))
             if config.thermal_network.network_type == 'DH':
-                for i in range(8760):
+                for i in range(HOURS_IN_YEAR):
                     self.DeltaP_DHN[i] = self.DeltaP_DHN[i] + pressure_drop_Pa['pressure_loss_total_Pa'][i]
             if config.thermal_network.network_type == 'DC':
-                for i in range(8760):
+                for i in range(HOURS_IN_YEAR):
                     self.DeltaP_DCN[i] = self.DeltaP_DCN[i] + pressure_drop_Pa['pressure_loss_total_Pa'][i]
 
         for network_name in network_names:

--- a/cea/optimization/flexibility_model/model_building/building_main.py
+++ b/cea/optimization/flexibility_model/model_building/building_main.py
@@ -33,6 +33,7 @@ from cea.optimization.flexibility_model.model_building import building_setup_dis
 from cea.optimization.flexibility_model.model_building import building_write_definitions
 from cea.optimization.flexibility_model.model_building.constants import DELTA_P_DIM, DENSITY_AIR, HEAT_CAPACITY_AIR, HE_E, H_I, \
     PHI_5_MAX, FB, HP_ETA_EX_COOL, HP_AUXRATIO
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Sebastian Troitzsch"
 __copyright__ = "Copyright 2019, Architecture and Building Systems - ETH Zurich"
@@ -183,7 +184,7 @@ def main(locator,
 
     electricity_prices_MWh = pd.read_excel(locator.get_electricity_costs(), "ELECTRICITY")
     electricity_prices_MWh["PRICE ($/MWh)"] = electricity_prices_MWh["cost_kWh"]*1000
-    electricity_prices_MWh["our_datetime"] = pd.date_range(start='1/1/2005', periods=8760)
+    electricity_prices_MWh["our_datetime"] = pd.date_range(start='1/1/2005', periods=HOURS_IN_YEAR)
     electricity_prices_MWh.set_index('our_datetime', inplace=True)
 
     (

--- a/cea/optimization/individual_evaluation/individual_cooling_main.py
+++ b/cea/optimization/individual_evaluation/individual_cooling_main.py
@@ -28,6 +28,7 @@ from cea.optimization.constants import  SIZING_MARGIN, PUMP_ETA, DELTA_U, \
 import cea.technologies.pumps as pumps
 from math import log, ceil
 from cea.optimization.lca_calculations import LcaCalculations
+from cea.constants import HOURS_IN_YEAR
 
 
 __author__ = "Sreepathi Bhargava Krishna"
@@ -104,12 +105,12 @@ def coolingMain(locator, master_to_slave_vars, ntwFeat, prices, config):
     arrayData = np.array(df)
 
     # total cooling requirements based on the Heat Recovery Flag
-    Q_cooling_req_W = np.zeros(8760)
+    Q_cooling_req_W = np.zeros(HOURS_IN_YEAR)
     if master_to_slave_vars.WasteServersHeatRecovery == 0:
-        for hour in range(8760):  # summing cooling loads of space cooling, refrigeration and data center
+        for hour in range(HOURS_IN_YEAR):  # summing cooling loads of space cooling, refrigeration and data center
             Q_cooling_req_W[hour] = Qc_DCN_W[hour][1]
     else:
-        for hour in range(8760):  # only including cooling loads of space cooling and refrigeration
+        for hour in range(HOURS_IN_YEAR):  # only including cooling loads of space cooling and refrigeration
             Q_cooling_req_W[hour] = Qc_DCN_W[hour][0]
 
     ############# Recover the heat already taken from the Lake by the heat pumps
@@ -221,37 +222,37 @@ def coolingMain(locator, master_to_slave_vars, ntwFeat, prices, config):
     nBuild = int(np.shape(arrayData)[0])
     nHour = int(np.shape(DCN_operation_parameters)[0])
 
-    calfactor_buildings = np.zeros(8760)
+    calfactor_buildings = np.zeros(HOURS_IN_YEAR)
     TotalCool = 0
-    Qc_from_Lake_W = np.zeros(8760)
-    Qc_from_VCC_W = np.zeros(8760)
-    Qc_from_ACH_W = np.zeros(8760)
-    Qc_from_storage_tank_W = np.zeros(8760)
-    Qc_from_VCC_backup_W = np.zeros(8760)
+    Qc_from_Lake_W = np.zeros(HOURS_IN_YEAR)
+    Qc_from_VCC_W = np.zeros(HOURS_IN_YEAR)
+    Qc_from_ACH_W = np.zeros(HOURS_IN_YEAR)
+    Qc_from_storage_tank_W = np.zeros(HOURS_IN_YEAR)
+    Qc_from_VCC_backup_W = np.zeros(HOURS_IN_YEAR)
 
-    Qc_req_from_CT_W = np.zeros(8760)
-    Qh_req_from_CCGT_W = np.zeros(8760)
-    Qh_from_CCGT_W = np.zeros(8760)
-    E_gen_CCGT_W = np.zeros(8760)
+    Qc_req_from_CT_W = np.zeros(HOURS_IN_YEAR)
+    Qh_req_from_CCGT_W = np.zeros(HOURS_IN_YEAR)
+    Qh_from_CCGT_W = np.zeros(HOURS_IN_YEAR)
+    E_gen_CCGT_W = np.zeros(HOURS_IN_YEAR)
 
-    opex_var_Lake = np.zeros(8760)
-    opex_var_VCC = np.zeros(8760)
-    opex_var_ACH = np.zeros(8760)
-    opex_var_VCC_backup = np.zeros(8760)
-    opex_var_CCGT = np.zeros(8760)
-    opex_var_CT = np.zeros(8760)
-    co2_Lake = np.zeros(8760)
-    co2_VCC = np.zeros(8760)
-    co2_ACH = np.zeros(8760)
-    co2_VCC_backup = np.zeros(8760)
-    co2_CCGT = np.zeros(8760)
-    co2_CT = np.zeros(8760)
-    prim_energy_Lake = np.zeros(8760)
-    prim_energy_VCC = np.zeros(8760)
-    prim_energy_ACH = np.zeros(8760)
-    prim_energy_VCC_backup = np.zeros(8760)
-    prim_energy_CCGT = np.zeros(8760)
-    prim_energy_CT = np.zeros(8760)
+    opex_var_Lake = np.zeros(HOURS_IN_YEAR)
+    opex_var_VCC = np.zeros(HOURS_IN_YEAR)
+    opex_var_ACH = np.zeros(HOURS_IN_YEAR)
+    opex_var_VCC_backup = np.zeros(HOURS_IN_YEAR)
+    opex_var_CCGT = np.zeros(HOURS_IN_YEAR)
+    opex_var_CT = np.zeros(HOURS_IN_YEAR)
+    co2_Lake = np.zeros(HOURS_IN_YEAR)
+    co2_VCC = np.zeros(HOURS_IN_YEAR)
+    co2_ACH = np.zeros(HOURS_IN_YEAR)
+    co2_VCC_backup = np.zeros(HOURS_IN_YEAR)
+    co2_CCGT = np.zeros(HOURS_IN_YEAR)
+    co2_CT = np.zeros(HOURS_IN_YEAR)
+    prim_energy_Lake = np.zeros(HOURS_IN_YEAR)
+    prim_energy_VCC = np.zeros(HOURS_IN_YEAR)
+    prim_energy_ACH = np.zeros(HOURS_IN_YEAR)
+    prim_energy_VCC_backup = np.zeros(HOURS_IN_YEAR)
+    prim_energy_CCGT = np.zeros(HOURS_IN_YEAR)
+    prim_energy_CT = np.zeros(HOURS_IN_YEAR)
     calfactor_total = 0
 
     # the simulation is for the month of May. This needs to be multiplied to represent the entire year

--- a/cea/optimization/lca_calculations.py
+++ b/cea/optimization/lca_calculations.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 from cea.optimization.constants import *
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Sreepathi Bhargava Krishna"
 __copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"
@@ -144,7 +145,7 @@ class LcaCalculations(object):
         else:
             average_electricity_price = resources_lca[resources_lca['Description'] == 'Electricity'].iloc[0][
                                             'costs_kWh'] / 1000
-            self.ELEC_PRICE = np.ones(8760) * average_electricity_price # in USD_2015 per W
+            self.ELEC_PRICE = np.ones(HOURS_IN_YEAR) * average_electricity_price # in USD_2015 per W
 
         self.EL_TO_OIL_EQ = resources_lca[resources_lca['Description'] == 'Electricity'].iloc[0][
             'PEN']  # MJ_oil / MJ_final
@@ -153,7 +154,7 @@ class LcaCalculations(object):
 
         average_green_electricity_cost = resources_lca[resources_lca['Description'] == 'Solar'].iloc[0][
             'costs_kWh']  # MJ_oil / MJ_final
-        self.ELEC_PRICE_GREEN = np.ones(8760) * average_green_electricity_cost
+        self.ELEC_PRICE_GREEN = np.ones(HOURS_IN_YEAR) * average_green_electricity_cost
         self.EL_TO_OIL_EQ_GREEN = resources_lca[resources_lca['Description'] == 'Solar'].iloc[0][
             'PEN']  # MJ_oil / MJ_final
         self.EL_TO_CO2_GREEN = resources_lca[resources_lca['Description'] == 'Solar'].iloc[0][

--- a/cea/optimization/master/summarize_network.py
+++ b/cea/optimization/master/summarize_network.py
@@ -14,6 +14,7 @@ from cea.optimization.constants import K_DH, ZERO_DEGREES_CELSIUS_IN_KELVIN
 from cea.resources.geothermal import calc_ground_temperature
 from cea.constants import HEAT_CAPACITY_OF_WATER_JPERKGK
 from cea.utilities import epwreader
+from cea.constants import HOURS_IN_YEAR
 
 
 __author__ = "Jimeno A. Fonseca"
@@ -76,21 +77,21 @@ def network_main(locator, total_demand, building_names, config, gv, key):
     # empty vectors
     buildings = []
     substations = []
-    Qcdata_netw_total_kWh = np.zeros(8760)
-    mcpdata_netw_total_kWperC = np.zeros(8760)
-    Electr_netw_total_W = np.zeros(8760)
-    mdot_heat_netw_all_kgpers = np.zeros(8760)
-    mdot_cool_space_cooling_and_refrigeration_netw_all_kgpers = np.zeros(8760)
-    mdot_cool_space_cooling_data_center_and_refrigeration_netw_all_kgpers = np.zeros(8760)
-    Q_DH_building_netw_total_W = np.zeros(8760)
-    Q_DC_building_netw_space_cooling_and_refrigeration_total_W = np.zeros(8760)
-    Q_DC_building_netw_space_cooling_data_center_and_refrigeration_total_W = np.zeros(8760)
-    sum_tret_mdot_heat = np.zeros(8760)
-    sum_tret_mdot_cool_space_cooling_and_refrigeration = np.zeros(8760)
-    sum_tret_mdot_cool_space_cooling_data_center_and_refrigeration = np.zeros(8760)
-    mdot_heat_netw_min_kgpers = np.zeros(8760) + 1E6
-    mdot_cool_space_cooling_and_refrigeration_netw_min_kgpers = np.zeros(8760) + 1E6
-    mdot_cool_space_cooling_data_center_and_refrigeration_netw_min_kgpers = np.zeros(8760) + 1E6
+    Qcdata_netw_total_kWh = np.zeros(HOURS_IN_YEAR)
+    mcpdata_netw_total_kWperC = np.zeros(HOURS_IN_YEAR)
+    Electr_netw_total_W = np.zeros(HOURS_IN_YEAR)
+    mdot_heat_netw_all_kgpers = np.zeros(HOURS_IN_YEAR)
+    mdot_cool_space_cooling_and_refrigeration_netw_all_kgpers = np.zeros(HOURS_IN_YEAR)
+    mdot_cool_space_cooling_data_center_and_refrigeration_netw_all_kgpers = np.zeros(HOURS_IN_YEAR)
+    Q_DH_building_netw_total_W = np.zeros(HOURS_IN_YEAR)
+    Q_DC_building_netw_space_cooling_and_refrigeration_total_W = np.zeros(HOURS_IN_YEAR)
+    Q_DC_building_netw_space_cooling_data_center_and_refrigeration_total_W = np.zeros(HOURS_IN_YEAR)
+    sum_tret_mdot_heat = np.zeros(HOURS_IN_YEAR)
+    sum_tret_mdot_cool_space_cooling_and_refrigeration = np.zeros(HOURS_IN_YEAR)
+    sum_tret_mdot_cool_space_cooling_data_center_and_refrigeration = np.zeros(HOURS_IN_YEAR)
+    mdot_heat_netw_min_kgpers = np.zeros(HOURS_IN_YEAR) + 1E6
+    mdot_cool_space_cooling_and_refrigeration_netw_min_kgpers = np.zeros(HOURS_IN_YEAR) + 1E6
+    mdot_cool_space_cooling_data_center_and_refrigeration_netw_min_kgpers = np.zeros(HOURS_IN_YEAR) + 1E6
     iteration = 0
 
     for building_name in building_names:
@@ -214,11 +215,11 @@ def network_main(locator, total_demand, building_names, config, gv, key):
                                                                                      mdot_cool_space_cooling_data_center_and_refrigeration_netw_all_kgpers,
                                                                                      HEAT_CAPACITY_OF_WATER_JPERKGK, "negative")
 
-    day_of_max_heatmassflow_fin = np.zeros(8760)
+    day_of_max_heatmassflow_fin = np.zeros(HOURS_IN_YEAR)
     day_of_max_heatmassflow = find_index_of_max(mdot_heat_netw_all_kgpers)
     day_of_max_heatmassflow_fin[:] = day_of_max_heatmassflow
 
-    for i in range(8760):
+    for i in range(HOURS_IN_YEAR):
         if T_DCN_space_cooling_data_center_and_refrigeration_sup_K[i] > T_DCN_space_cooling_data_center_and_refrigeration_re_K[i]:
             print (i)
 

--- a/cea/optimization/preprocessing/decentralized_buildings_cooling.py
+++ b/cea/optimization/preprocessing/decentralized_buildings_cooling.py
@@ -25,7 +25,7 @@ from cea.optimization.constants import SIZING_MARGIN, T_GENERATOR_FROM_FP_C, T_G
     Q_LOSS_DISCONNECTED, ACH_TYPE_SINGLE
 from cea.optimization.lca_calculations import LcaCalculations
 from cea.technologies.thermal_network.thermal_network import calculate_ground_temperature
-
+from cea.constants import HOURS_IN_YEAR
 
 def disconnected_buildings_cooling_main(locator, building_names, config, prices, lca):
     """
@@ -227,13 +227,13 @@ def disconnected_buildings_cooling_main(locator, building_names, config, prices,
         # config 3: single-effect ACH with ET to AHU
         result_AHU[3][3] = 1
 
-        q_CT_VCC_to_AHU_W = np.zeros(8760)
-        q_CT_FP_to_single_ACH_to_AHU_W = np.zeros(8760)
-        q_boiler_FP_to_single_ACH_to_AHU_W = np.zeros(8760)
-        q_burner_ET_to_single_ACH_to_AHU_W = np.zeros(8760)
-        q_CT_ET_to_single_ACH_to_AHU_W = np.zeros(8760)
-        T_re_boiler_FP_to_single_ACH_to_AHU_K = np.zeros(8760)
-        T_re_boiler_ET_to_single_ACH_to_AHU_K = np.zeros(8760)
+        q_CT_VCC_to_AHU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_FP_to_single_ACH_to_AHU_W = np.zeros(HOURS_IN_YEAR)
+        q_boiler_FP_to_single_ACH_to_AHU_W = np.zeros(HOURS_IN_YEAR)
+        q_burner_ET_to_single_ACH_to_AHU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_ET_to_single_ACH_to_AHU_W = np.zeros(HOURS_IN_YEAR)
+        T_re_boiler_FP_to_single_ACH_to_AHU_K = np.zeros(HOURS_IN_YEAR)
+        T_re_boiler_ET_to_single_ACH_to_AHU_K = np.zeros(HOURS_IN_YEAR)
 
         VCC_cost_data = pd.read_excel(locator.get_supply_systems(), sheetname="Chiller")
         VCC_cost_data = VCC_cost_data[VCC_cost_data['code'] == 'CH3']
@@ -265,7 +265,7 @@ def disconnected_buildings_cooling_main(locator, building_names, config, prices,
                 number_of_ACH_chillers = int(ceil(Qc_nom_combination_AHU_W / max_ACH_chiller_size))
                 Qnom_ACH_W = Qc_nom_combination_AHU_W / number_of_ACH_chillers
 
-            for hour in range(8760):  # TODO: vectorize
+            for hour in range(HOURS_IN_YEAR):  # TODO: vectorize
                 # modify return temperatures when there is no load
                 T_re_AHU_K[hour] = T_re_AHU_K[hour] if T_re_AHU_K[hour] > 0 else T_sup_AHU_K[hour]
 
@@ -342,13 +342,13 @@ def disconnected_buildings_cooling_main(locator, building_names, config, prices,
         # config 3: single-effect ACH with ET to ARU
         result_ARU[3][3] = 1
 
-        q_CT_VCC_to_ARU_W = np.zeros(8760)
-        q_CT_FP_to_single_ACH_to_ARU_W = np.zeros(8760)
-        q_boiler_FP_to_single_ACH_to_ARU_W = np.zeros(8760)
-        q_burner_ET_to_single_ACH_to_ARU_W = np.zeros(8760)
-        q_CT_ET_to_single_ACH_to_ARU_W = np.zeros(8760)
-        T_re_boiler_FP_to_single_ACH_to_ARU_K = np.zeros(8760)
-        T_re_boiler_ET_to_single_ACH_to_ARU_K = np.zeros(8760)
+        q_CT_VCC_to_ARU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_FP_to_single_ACH_to_ARU_W = np.zeros(HOURS_IN_YEAR)
+        q_boiler_FP_to_single_ACH_to_ARU_W = np.zeros(HOURS_IN_YEAR)
+        q_burner_ET_to_single_ACH_to_ARU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_ET_to_single_ACH_to_ARU_W = np.zeros(HOURS_IN_YEAR)
+        T_re_boiler_FP_to_single_ACH_to_ARU_K = np.zeros(HOURS_IN_YEAR)
+        T_re_boiler_ET_to_single_ACH_to_ARU_K = np.zeros(HOURS_IN_YEAR)
 
         if config.decentralized.aruflag:
             print building_name, ' decentralized building simulation with configuration: ARU'
@@ -368,7 +368,7 @@ def disconnected_buildings_cooling_main(locator, building_names, config, prices,
                 Qnom_ACH_W = Qc_nom_combination_ARU_W / number_of_ACH_chillers
 
             # chiller operations for config 1-5
-            for hour in range(8760):  # TODO: vectorize
+            for hour in range(HOURS_IN_YEAR):  # TODO: vectorize
                 # modify return temperatures when there is no load
                 T_re_ARU_K[hour] = T_re_ARU_K[hour] if T_re_ARU_K[hour] > 0 else T_sup_AHU_K[hour]
 
@@ -447,13 +447,13 @@ def disconnected_buildings_cooling_main(locator, building_names, config, prices,
         # config 3: single-effect ACH with ET to SCU
         result_SCU[3][3] = 1
 
-        q_CT_VCC_to_SCU_W = np.zeros(8760)
-        q_CT_FP_to_single_ACH_to_SCU_W = np.zeros(8760)
-        q_boiler_FP_to_single_ACH_to_SCU_W = np.zeros(8760)
-        q_CT_ET_to_single_ACH_to_SCU_W = np.zeros(8760)
-        q_burner_ET_to_single_ACH_to_SCU_W = np.zeros(8760)
-        T_re_boiler_FP_to_single_ACH_to_SCU_K = np.zeros(8760)
-        T_re_boiler_ET_to_single_ACH_to_SCU_K = np.zeros(8760)
+        q_CT_VCC_to_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_FP_to_single_ACH_to_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_boiler_FP_to_single_ACH_to_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_ET_to_single_ACH_to_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_burner_ET_to_single_ACH_to_SCU_W = np.zeros(HOURS_IN_YEAR)
+        T_re_boiler_FP_to_single_ACH_to_SCU_K = np.zeros(HOURS_IN_YEAR)
+        T_re_boiler_ET_to_single_ACH_to_SCU_K = np.zeros(HOURS_IN_YEAR)
 
         if config.decentralized.scuflag:
             print building_name, ' decentralized building simulation with configuration: SCU'
@@ -473,7 +473,7 @@ def disconnected_buildings_cooling_main(locator, building_names, config, prices,
                 Qnom_ACH_W = Qc_nom_combination_SCU_W / number_of_ACH_chillers
 
             # chiller operations for config 1-5
-            for hour in range(8760):  # TODO: vectorize
+            for hour in range(HOURS_IN_YEAR):  # TODO: vectorize
                 # modify return temperatures when there is no load
                 T_re_SCU_K[hour] = T_re_SCU_K[hour] if T_re_SCU_K[hour] > 0 else T_sup_SCU_K[hour]
 
@@ -552,13 +552,13 @@ def disconnected_buildings_cooling_main(locator, building_names, config, prices,
         # config 3: single-effect ACH with ET to AHU & ARU
         result_AHU_ARU[3][3] = 1
 
-        q_CT_VCC_to_AHU_ARU_W = np.zeros(8760)
-        q_CT_FP_to_single_ACH_to_AHU_ARU_W = np.zeros(8760)
-        q_boiler_FP_to_single_ACH_to_AHU_ARU_W = np.zeros(8760)
-        q_CT_ET_to_single_ACH_to_AHU_ARU_W = np.zeros(8760)
-        q_burner_ET_to_single_ACH_to_AHU_ARU_W = np.zeros(8760)
-        T_re_boiler_FP_to_single_ACH_to_AHU_ARU_K = np.zeros(8760)
-        T_re_boiler_ET_to_single_ACH_to_AHU_ARU_K = np.zeros(8760)
+        q_CT_VCC_to_AHU_ARU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_FP_to_single_ACH_to_AHU_ARU_W = np.zeros(HOURS_IN_YEAR)
+        q_boiler_FP_to_single_ACH_to_AHU_ARU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_ET_to_single_ACH_to_AHU_ARU_W = np.zeros(HOURS_IN_YEAR)
+        q_burner_ET_to_single_ACH_to_AHU_ARU_W = np.zeros(HOURS_IN_YEAR)
+        T_re_boiler_FP_to_single_ACH_to_AHU_ARU_K = np.zeros(HOURS_IN_YEAR)
+        T_re_boiler_ET_to_single_ACH_to_AHU_ARU_K = np.zeros(HOURS_IN_YEAR)
 
         if config.decentralized.ahuaruflag:
             print building_name, ' decentralized building simulation with configuration: AHU + ARU'
@@ -578,7 +578,7 @@ def disconnected_buildings_cooling_main(locator, building_names, config, prices,
                 Qnom_ACH_W = Qc_nom_combination_AHU_ARU_W / number_of_ACH_chillers
 
             # chiller operations for config 1-5
-            for hour in range(8760):  # TODO: vectorize
+            for hour in range(HOURS_IN_YEAR):  # TODO: vectorize
                 # modify return temperatures when there is no load
                 T_re_AHU_ARU_K[hour] = T_re_AHU_ARU_K[hour] if T_re_AHU_ARU_K[hour] > 0 else T_sup_AHU_ARU_K[hour]
 
@@ -663,13 +663,13 @@ def disconnected_buildings_cooling_main(locator, building_names, config, prices,
         # config 3: single-effect ACH with ET to AHU & SCU
         result_AHU_SCU[3][3] = 1
 
-        q_CT_VCC_to_AHU_SCU_W = np.zeros(8760)
-        q_CT_FP_tosingle_ACH_to_AHU_SCU_W = np.zeros(8760)
-        q_boiler_FP_to_single_ACH_to_AHU_SCU_W = np.zeros(8760)
-        q_CT_ET_to_single_ACH_to_AHU_SCU_W = np.zeros(8760)
-        q_burner_ET_to_single_ACH_to_AHU_SCU_W = np.zeros(8760)
-        T_re_boiler_FP_to_single_ACH_to_AHU_SCU_K = np.zeros(8760)
-        T_re_boiler_ET_to_single_ACH_to_AHU_SCU_K = np.zeros(8760)
+        q_CT_VCC_to_AHU_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_FP_tosingle_ACH_to_AHU_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_boiler_FP_to_single_ACH_to_AHU_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_ET_to_single_ACH_to_AHU_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_burner_ET_to_single_ACH_to_AHU_SCU_W = np.zeros(HOURS_IN_YEAR)
+        T_re_boiler_FP_to_single_ACH_to_AHU_SCU_K = np.zeros(HOURS_IN_YEAR)
+        T_re_boiler_ET_to_single_ACH_to_AHU_SCU_K = np.zeros(HOURS_IN_YEAR)
 
         if config.decentralized.ahuscuflag:
             print building_name, ' decentralized building simulation with configuration: AHU + SCU'
@@ -689,7 +689,7 @@ def disconnected_buildings_cooling_main(locator, building_names, config, prices,
                 Qnom_ACH_W = Qc_nom_combination_AHU_SCU_W / number_of_ACH_chillers
 
             # chiller operations for config 1-5
-            for hour in range(8760):  # TODO: vectorize
+            for hour in range(HOURS_IN_YEAR):  # TODO: vectorize
                 # modify return temperatures when there is no load
                 T_re_AHU_SCU_K[hour] = T_re_AHU_SCU_K[hour] if T_re_AHU_SCU_K[hour] > 0 else T_sup_AHU_SCU_K[hour]
 
@@ -774,13 +774,13 @@ def disconnected_buildings_cooling_main(locator, building_names, config, prices,
         # config 3: single-effect ACH with ET to ARU & SCU
         result_ARU_SCU[3][3] = 1
 
-        q_CT_VCC_to_ARU_SCU_W = np.zeros(8760)
-        q_CT_FP_to_single_ACH_to_ARU_SCU_W = np.zeros(8760)
-        q_boiler_FP_to_single_ACH_to_ARU_SCU_W = np.zeros(8760)
-        q_CT_ET_to_single_ACH_to_ARU_SCU_W = np.zeros(8760)
-        q_burner_ET_to_single_ACH_to_ARU_SCU_W = np.zeros(8760)
-        T_re_boiler_FP_to_single_ACH_to_ARU_SCU_K = np.zeros(8760)
-        T_re_boiler_ET_to_single_ACH_to_ARU_SCU_K = np.zeros(8760)
+        q_CT_VCC_to_ARU_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_FP_to_single_ACH_to_ARU_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_boiler_FP_to_single_ACH_to_ARU_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_ET_to_single_ACH_to_ARU_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_burner_ET_to_single_ACH_to_ARU_SCU_W = np.zeros(HOURS_IN_YEAR)
+        T_re_boiler_FP_to_single_ACH_to_ARU_SCU_K = np.zeros(HOURS_IN_YEAR)
+        T_re_boiler_ET_to_single_ACH_to_ARU_SCU_K = np.zeros(HOURS_IN_YEAR)
 
         if config.decentralized.aruscuflag:
             print building_name, ' decentralized building simulation with configuration: ARU + SCU'
@@ -799,7 +799,7 @@ def disconnected_buildings_cooling_main(locator, building_names, config, prices,
                 number_of_ACH_chillers = int(ceil(Qc_nom_combination_ARU_SCU_W / max_ACH_chiller_size))
                 Qnom_ACH_W = Qc_nom_combination_ARU_SCU_W / number_of_ACH_chillers
             # chiller operations for config 1-5
-            for hour in range(8760):  # TODO: vectorize
+            for hour in range(HOURS_IN_YEAR):  # TODO: vectorize
                 # modify return temperatures when there is no load
                 T_re_ARU_SCU_K[hour] = T_re_ARU_SCU_K[hour] if T_re_ARU_SCU_K[hour] > 0 else T_sup_ARU_SCU_K[hour]
 
@@ -889,17 +889,17 @@ def disconnected_buildings_cooling_main(locator, building_names, config, prices,
         result_AHU_ARU_SCU[5][4] = 1
         result_AHU_ARU_SCU[5][6] = 1
 
-        q_CT_VCC_to_AHU_ARU_SCU_W = np.zeros(8760)
-        q_CT_VCC_to_AHU_ARU_and_VCC_to_SCU_W = np.zeros(8760)
-        q_CT_VCC_to_AHU_ARU_and_single_ACH_to_SCU_W = np.zeros(8760)
-        q_CT_FP_to_single_ACH_to_AHU_ARU_SCU_W = np.zeros(8760)
-        q_boiler_FP_to_single_ACH_to_AHU_ARU_SCU_W = np.zeros(8760)
-        q_CT_ET_to_single_ACH_to_AHU_ARU_SCU_W = np.zeros(8760)
-        q_burner_ET_single_ACH_to_AHU_ARU_SCU_W = np.zeros(8760)
-        q_boiler_VCC_to_AHU_ARU_and_FP_to_single_ACH_to_SCU_W = np.zeros(8760)
-        T_re_boiler_FP_to_single_ACH_to_AHU_ARU_SCU_K = np.zeros(8760)
-        T_re_boiler_ET_to_single_ACH_to_AHU_ARU_SCU_K = np.zeros(8760)
-        T_re_boiler_VCC_to_AHU_ARU_and_FP_to_single_ACH_to_SCU_K = np.zeros(8760)
+        q_CT_VCC_to_AHU_ARU_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_VCC_to_AHU_ARU_and_VCC_to_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_VCC_to_AHU_ARU_and_single_ACH_to_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_FP_to_single_ACH_to_AHU_ARU_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_boiler_FP_to_single_ACH_to_AHU_ARU_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_CT_ET_to_single_ACH_to_AHU_ARU_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_burner_ET_single_ACH_to_AHU_ARU_SCU_W = np.zeros(HOURS_IN_YEAR)
+        q_boiler_VCC_to_AHU_ARU_and_FP_to_single_ACH_to_SCU_W = np.zeros(HOURS_IN_YEAR)
+        T_re_boiler_FP_to_single_ACH_to_AHU_ARU_SCU_K = np.zeros(HOURS_IN_YEAR)
+        T_re_boiler_ET_to_single_ACH_to_AHU_ARU_SCU_K = np.zeros(HOURS_IN_YEAR)
+        T_re_boiler_VCC_to_AHU_ARU_and_FP_to_single_ACH_to_SCU_K = np.zeros(HOURS_IN_YEAR)
 
         if True:  # for the case with AHU + ARU + SCU scenario. this should always be present
 
@@ -948,7 +948,7 @@ def disconnected_buildings_cooling_main(locator, building_names, config, prices,
                 Qnom_ACH_AHU_ARU_W = Qc_nom_combination_AHU_ARU_W / number_of_ACH_AHU_ARU_chillers
 
             # chiller operations for config 1-5
-            for hour in range(8760):  # TODO: vectorize
+            for hour in range(HOURS_IN_YEAR):  # TODO: vectorize
                 # modify return temperatures when there is no load
                 T_re_AHU_ARU_SCU_K[hour] = T_re_AHU_ARU_SCU_K[hour] if T_re_AHU_ARU_SCU_K[hour] > 0 else \
                     T_sup_AHU_ARU_SCU_K[hour]
@@ -1140,7 +1140,7 @@ def disconnected_buildings_cooling_main(locator, building_names, config, prices,
 
         boiler_VCC_to_AHU_ARU_and_FP_to_single_ACH_to_SCU_nom_size_W = boiler_FP_to_single_ACH_to_SCU_nom_size_W
 
-        for hour in range(8760):
+        for hour in range(HOURS_IN_YEAR):
             # cooling towers operation
             # AHU
             if config.decentralized.ahuflag:

--- a/cea/optimization/preprocessing/decentralized_buildings_heating.py
+++ b/cea/optimization/preprocessing/decentralized_buildings_heating.py
@@ -16,7 +16,7 @@ from cea.utilities import dbf
 from geopandas import GeoDataFrame as Gdf
 from cea.utilities import epwreader
 import cea.technologies.substation as substation
-
+from cea.constants import HOURS_IN_YEAR
 
 
 def disconnected_buildings_heating_main(locator, building_names, config, prices, lca):
@@ -94,8 +94,7 @@ def disconnected_buildings_heating_main(locator, building_names, config, prices,
         TsupDH = loads["T_supply_DH_result_K"].values
         mdot = loads["mdot_DH_result_kgpers"].values
 
-        for hour in range(8760):
-
+        for hour in range(HOURS_IN_YEAR):
             if Tret[hour] == 0:
                 Tret[hour] = TsupDH[hour]
 

--- a/cea/optimization/preprocessing/preprocessing_main.py
+++ b/cea/optimization/preprocessing/preprocessing_main.py
@@ -17,6 +17,7 @@ from cea.optimization.preprocessing import electricity
 from cea.resources import geothermal
 from cea.utilities import epwreader
 from cea.technologies import substation
+from cea.constants import HOURS_IN_YEAR
 
 
 __author__ = "Jimeno A. Fonseca"
@@ -110,15 +111,15 @@ def preproccessing(locator, total_demand, building_names, weather_file, gv, conf
 
 class SolarFeatures(object):
     def __init__(self, locator, building_names, config):
-        E_PV_gen_kWh = np.zeros(8760)
-        E_PVT_gen_kWh = np.zeros(8760)
-        Q_PVT_gen_kWh = np.zeros(8760)
-        Q_SC_FP_gen_kWh = np.zeros(8760)
-        Q_SC_ET_gen_kWh = np.zeros(8760)
-        A_PV_m2 = np.zeros(8760)
-        A_PVT_m2 = np.zeros(8760)
-        A_SC_FP_m2 = np.zeros(8760)
-        A_SC_ET_m2 = np.zeros(8760)
+        E_PV_gen_kWh = np.zeros(HOURS_IN_YEAR)
+        E_PVT_gen_kWh = np.zeros(HOURS_IN_YEAR)
+        Q_PVT_gen_kWh = np.zeros(HOURS_IN_YEAR)
+        Q_SC_FP_gen_kWh = np.zeros(HOURS_IN_YEAR)
+        Q_SC_ET_gen_kWh = np.zeros(HOURS_IN_YEAR)
+        A_PV_m2 = np.zeros(HOURS_IN_YEAR)
+        A_PVT_m2 = np.zeros(HOURS_IN_YEAR)
+        A_SC_FP_m2 = np.zeros(HOURS_IN_YEAR)
+        A_SC_ET_m2 = np.zeros(HOURS_IN_YEAR)
         if config.district_heating_network:
             for name in building_names:
                 building_PV = pd.read_csv(os.path.join(locator.get_potentials_solar_folder(), name + '_PV.csv'))

--- a/cea/optimization/preprocessing/processheat.py
+++ b/cea/optimization/preprocessing/processheat.py
@@ -10,6 +10,7 @@ from __future__ import division
 import pandas as pd
 from cea.technologies import boiler
 from cea.optimization.constants import BOILER_ETA_HP, SIZING_MARGIN
+from cea.constants import HOURS_IN_YEAR
 
 
 def calc_pareto_Qhp(locator, total_demand, prices, lca, config):
@@ -41,7 +42,7 @@ def calc_pareto_Qhp(locator, total_demand, prices, lca, config):
             Qnom = 0
             Qannual = 0
             # Operation costs / CO2 / Prim
-            for i in range(8760):
+            for i in range(HOURS_IN_YEAR):
                 Qgas = Qhpro_sys[i] * 1E3 / BOILER_ETA_HP # [Wh] Assumed 0.9 efficiency
 
                 if Qgas < Qnom:

--- a/cea/optimization/slave/cooling_main.py
+++ b/cea/optimization/slave/cooling_main.py
@@ -24,7 +24,7 @@ from cea.optimization.constants import SIZING_MARGIN, PUMP_ETA, DELTA_U, \
     ACH_T_IN_FROM_CHP, ACH_TYPE_DOUBLE, T_TANK_FULLY_CHARGED_K, T_TANK_FULLY_DISCHARGED_K, PIPEINTERESTRATE, PIPELIFETIME
 import cea.technologies.pumps as pumps
 from math import log, ceil
-
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Sreepathi Bhargava Krishna"
 __copyright__ = "Copyright 2015, Architecture and Building Systems - ETH Zurich"
@@ -98,12 +98,12 @@ def cooling_calculations_of_DC_buildings(locator, master_to_slave_vars, ntwFeat,
     arrayData = np.array(df)
 
     # total cooling requirements based on the Heat Recovery Flag
-    Q_cooling_req_W = np.zeros(8760)
+    Q_cooling_req_W = np.zeros(HOURS_IN_YEAR)
     if master_to_slave_vars.WasteServersHeatRecovery == 0:
-        for hour in range(8760):  # summing cooling loads of space cooling, refrigeration and data center
+        for hour in range(HOURS_IN_YEAR):  # summing cooling loads of space cooling, refrigeration and data center
             Q_cooling_req_W[hour] = Qc_DCN_W[hour][1]
     else:
-        for hour in range(8760):  # only including cooling loads of space cooling and refrigeration
+        for hour in range(HOURS_IN_YEAR):  # only including cooling loads of space cooling and refrigeration
             Q_cooling_req_W[hour] = Qc_DCN_W[hour][0]
 
     ############# Recover the heat already taken from the Lake by the heat pumps
@@ -221,43 +221,43 @@ def cooling_calculations_of_DC_buildings(locator, master_to_slave_vars, ntwFeat,
         stop_t = 3624
     timesteps = range(start_t, stop_t)
 
-    calfactor_buildings = np.zeros(8760)
+    calfactor_buildings = np.zeros(HOURS_IN_YEAR)
     TotalCool = 0
-    Qc_from_Lake_W = np.zeros(8760)
-    Qc_from_VCC_W = np.zeros(8760)
-    Qc_from_ACH_W = np.zeros(8760)
-    Qc_from_storage_tank_W = np.zeros(8760)
-    Qc_from_VCC_backup_W = np.zeros(8760)
+    Qc_from_Lake_W = np.zeros(HOURS_IN_YEAR)
+    Qc_from_VCC_W = np.zeros(HOURS_IN_YEAR)
+    Qc_from_ACH_W = np.zeros(HOURS_IN_YEAR)
+    Qc_from_storage_tank_W = np.zeros(HOURS_IN_YEAR)
+    Qc_from_VCC_backup_W = np.zeros(HOURS_IN_YEAR)
 
-    Qc_req_from_CT_W = np.zeros(8760)
-    Qh_req_from_CCGT_W = np.zeros(8760)
-    Qh_from_CCGT_W = np.zeros(8760)
-    E_gen_CCGT_W = np.zeros(8760)
+    Qc_req_from_CT_W = np.zeros(HOURS_IN_YEAR)
+    Qh_req_from_CCGT_W = np.zeros(HOURS_IN_YEAR)
+    Qh_from_CCGT_W = np.zeros(HOURS_IN_YEAR)
+    E_gen_CCGT_W = np.zeros(HOURS_IN_YEAR)
 
-    opex_var_Lake_USD = np.zeros(8760)
-    opex_var_VCC_USD = np.zeros(8760)
-    opex_var_ACH_USD = np.zeros(8760)
-    opex_var_VCC_backup_USD = np.zeros(8760)
-    opex_var_CCGT_USD = np.zeros(8760)
-    opex_var_CT_USD = np.zeros(8760)
-    E_used_Lake_W = np.zeros(8760)
-    E_used_VCC_W = np.zeros(8760)
-    E_used_VCC_backup_W = np.zeros(8760)
-    E_used_ACH_W = np.zeros(8760)
-    E_used_CT_W = np.zeros(8760)
-    co2_Lake_kgCO2 = np.zeros(8760)
-    co2_VCC_kgCO2 = np.zeros(8760)
-    co2_ACH_kgCO2 = np.zeros(8760)
-    co2_VCC_backup_kgCO2 = np.zeros(8760)
-    co2_CCGT_kgCO2 = np.zeros(8760)
-    co2_CT_kgCO2 = np.zeros(8760)
-    prim_energy_Lake_MJ = np.zeros(8760)
-    prim_energy_VCC_MJ = np.zeros(8760)
-    prim_energy_ACH_MJ = np.zeros(8760)
-    prim_energy_VCC_backup_MJ = np.zeros(8760)
-    prim_energy_CCGT_MJ = np.zeros(8760)
-    prim_energy_CT_MJ = np.zeros(8760)
-    NG_used_CCGT_W = np.zeros(8760)
+    opex_var_Lake_USD = np.zeros(HOURS_IN_YEAR)
+    opex_var_VCC_USD = np.zeros(HOURS_IN_YEAR)
+    opex_var_ACH_USD = np.zeros(HOURS_IN_YEAR)
+    opex_var_VCC_backup_USD = np.zeros(HOURS_IN_YEAR)
+    opex_var_CCGT_USD = np.zeros(HOURS_IN_YEAR)
+    opex_var_CT_USD = np.zeros(HOURS_IN_YEAR)
+    E_used_Lake_W = np.zeros(HOURS_IN_YEAR)
+    E_used_VCC_W = np.zeros(HOURS_IN_YEAR)
+    E_used_VCC_backup_W = np.zeros(HOURS_IN_YEAR)
+    E_used_ACH_W = np.zeros(HOURS_IN_YEAR)
+    E_used_CT_W = np.zeros(HOURS_IN_YEAR)
+    co2_Lake_kgCO2 = np.zeros(HOURS_IN_YEAR)
+    co2_VCC_kgCO2 = np.zeros(HOURS_IN_YEAR)
+    co2_ACH_kgCO2 = np.zeros(HOURS_IN_YEAR)
+    co2_VCC_backup_kgCO2 = np.zeros(HOURS_IN_YEAR)
+    co2_CCGT_kgCO2 = np.zeros(HOURS_IN_YEAR)
+    co2_CT_kgCO2 = np.zeros(HOURS_IN_YEAR)
+    prim_energy_Lake_MJ = np.zeros(HOURS_IN_YEAR)
+    prim_energy_VCC_MJ = np.zeros(HOURS_IN_YEAR)
+    prim_energy_ACH_MJ = np.zeros(HOURS_IN_YEAR)
+    prim_energy_VCC_backup_MJ = np.zeros(HOURS_IN_YEAR)
+    prim_energy_CCGT_MJ = np.zeros(HOURS_IN_YEAR)
+    prim_energy_CT_MJ = np.zeros(HOURS_IN_YEAR)
+    NG_used_CCGT_W = np.zeros(HOURS_IN_YEAR)
     calfactor_total = 0
 
     for hour in timesteps:  # cooling supply for all buildings excluding cooling loads from data centers
@@ -301,9 +301,9 @@ def cooling_calculations_of_DC_buildings(locator, master_to_slave_vars, ntwFeat,
         reduced_prim_MJ = np.sum(prim_energy_Lake_MJ) + np.sum(prim_energy_VCC_MJ) + np.sum(prim_energy_ACH_MJ) + np.sum(
         prim_energy_VCC_backup_MJ)
 
-        costs_a_USD += reduced_costs_USD*(8760/(stop_t-start_t))
-        CO2_kgCO2 += reduced_CO2_kgCO2*(8760/(stop_t-start_t))
-        prim_MJ += reduced_prim_MJ*(8760/(stop_t-start_t))
+        costs_a_USD += reduced_costs_USD*(HOURS_IN_YEAR/(stop_t-start_t))
+        CO2_kgCO2 += reduced_CO2_kgCO2*(HOURS_IN_YEAR/(stop_t-start_t))
+        prim_MJ += reduced_prim_MJ*(HOURS_IN_YEAR/(stop_t-start_t))
     else:
         costs_a_USD += np.sum(opex_var_Lake_USD) + np.sum(opex_var_VCC_USD) + np.sum(opex_var_ACH_USD) + np.sum(opex_var_VCC_backup_USD)
         CO2_kgCO2 += np.sum(co2_Lake_kgCO2) + np.sum(co2_Lake_kgCO2) + np.sum(co2_ACH_kgCO2) + np.sum(co2_VCC_backup_kgCO2)
@@ -335,9 +335,9 @@ def cooling_calculations_of_DC_buildings(locator, master_to_slave_vars, ntwFeat,
             reduced_CO2_kgCO2 = np.sum(co2_CT_kgCO2)
             reduced_prim_MJ = np.sum(prim_energy_CT_MJ)
 
-            costs_a_USD += reduced_costs_USD * (8760 / (stop_t - start_t))
-            CO2_kgCO2 += reduced_CO2_kgCO2 * (8760 / (stop_t - start_t))
-            prim_MJ += reduced_prim_MJ * (8760 / (stop_t - start_t))
+            costs_a_USD += reduced_costs_USD * (HOURS_IN_YEAR / (stop_t - start_t))
+            CO2_kgCO2 += reduced_CO2_kgCO2 * (HOURS_IN_YEAR / (stop_t - start_t))
+            prim_MJ += reduced_prim_MJ * (HOURS_IN_YEAR / (stop_t - start_t))
         else:
             costs_a_USD += np.sum(opex_var_CT_USD)
             CO2_kgCO2 += np.sum(co2_CT_kgCO2)
@@ -391,9 +391,9 @@ def cooling_calculations_of_DC_buildings(locator, master_to_slave_vars, ntwFeat,
             reduced_CO2_kgCO2 = np.sum(co2_CCGT_kgCO2)
             reduced_prim_MJ = np.sum(prim_energy_CCGT_MJ)
 
-            costs_a_USD += reduced_costs_USD * (8760 / (stop_t - start_t))
-            CO2_kgCO2 += reduced_CO2_kgCO2 * (8760 / (stop_t - start_t))
-            prim_MJ += reduced_prim_MJ * (8760 / (stop_t - start_t))
+            costs_a_USD += reduced_costs_USD * (HOURS_IN_YEAR / (stop_t - start_t))
+            CO2_kgCO2 += reduced_CO2_kgCO2 * (HOURS_IN_YEAR / (stop_t - start_t))
+            prim_MJ += reduced_prim_MJ * (HOURS_IN_YEAR / (stop_t - start_t))
         else:
             costs_a_USD += np.sum(opex_var_CCGT_USD)
             CO2_kgCO2 += np.sum(co2_CCGT_kgCO2)

--- a/cea/optimization/slave/electricity_main.py
+++ b/cea/optimization/slave/electricity_main.py
@@ -12,6 +12,7 @@ import numpy as np
 import cea.config
 import cea.inputlocator
 from cea.constants import WH_TO_J
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Sreepathi Bhargava Krishna"
 __copyright__ = "Copyright 2018, Architecture and Building Systems - ETH Zurich"
@@ -34,13 +35,13 @@ def electricity_calculations_of_all_buildings(DHN_barcode, DCN_barcode, locator,
 
 
     # step 1: Get demand of all the district (tota
-    E_appliances_total_W = np.zeros(8760)
-    E_data_center_total_W = np.zeros(8760)
-    E_industrial_processes_total_W = np.zeros(8760)
-    E_auxiliary_units_total_W = np.zeros(8760)
-    E_hotwater_total_W = np.zeros(8760)
-    E_space_heating_total_W = np.zeros(8760)
-    E_space_cooling_total_W = np.zeros(8760)
+    E_appliances_total_W = np.zeros(HOURS_IN_YEAR)
+    E_data_center_total_W = np.zeros(HOURS_IN_YEAR)
+    E_industrial_processes_total_W = np.zeros(HOURS_IN_YEAR)
+    E_auxiliary_units_total_W = np.zeros(HOURS_IN_YEAR)
+    E_hotwater_total_W = np.zeros(HOURS_IN_YEAR)
+    E_space_heating_total_W = np.zeros(HOURS_IN_YEAR)
+    E_space_cooling_total_W = np.zeros(HOURS_IN_YEAR)
 
     for name in building_names: # adding the electricity demand of
         building_demand = pd.read_csv(locator.get_demand_results_folder() + '//' + name + ".csv",
@@ -111,15 +112,15 @@ def electricity_calculations_of_all_buildings(DHN_barcode, DCN_barcode, locator,
         E_from_PVT_W = E_PVT_gen_W
 
 
-        E_CHP_directload_W = np.zeros(8760)
-        E_CHP_grid_W = np.zeros(8760)
-        E_PV_directload_W = np.zeros(8760)
-        E_PV_grid_W = np.zeros(8760)
-        E_PVT_directload_W = np.zeros(8760)
-        E_PVT_grid_W = np.zeros(8760)
-        E_GRID_directload_W = np.zeros(8760)
+        E_CHP_directload_W = np.zeros(HOURS_IN_YEAR)
+        E_CHP_grid_W = np.zeros(HOURS_IN_YEAR)
+        E_PV_directload_W = np.zeros(HOURS_IN_YEAR)
+        E_PV_grid_W = np.zeros(HOURS_IN_YEAR)
+        E_PVT_directload_W = np.zeros(HOURS_IN_YEAR)
+        E_PVT_grid_W = np.zeros(HOURS_IN_YEAR)
+        E_GRID_directload_W = np.zeros(HOURS_IN_YEAR)
 
-        for hour in range(8760):
+        for hour in range(HOURS_IN_YEAR):
             E_hour_W = total_electricity_demand_W[hour]
             if E_hour_W > 0:
                 if E_from_PV_W[hour] > E_hour_W:
@@ -258,17 +259,17 @@ def electricity_calculations_of_all_buildings(DHN_barcode, DCN_barcode, locator,
         E_from_CHP_W = np.array(data_heating['E_CHP_gen_W'])
         E_from_Furnace_W = np.array(data_heating['E_Furnace_gen_W'])
 
-        E_CHP_directload_W = np.zeros(8760)
-        E_CHP_grid_W = np.zeros(8760)
-        E_PV_directload_W = np.zeros(8760)
-        E_PV_grid_W = np.zeros(8760)
-        E_PVT_directload_W = np.zeros(8760)
-        E_PVT_grid_W = np.zeros(8760)
-        E_Furnace_directload_W = np.zeros(8760)
-        E_Furnace_grid_W = np.zeros(8760)
-        E_GRID_directload_W = np.zeros(8760)
+        E_CHP_directload_W = np.zeros(HOURS_IN_YEAR)
+        E_CHP_grid_W = np.zeros(HOURS_IN_YEAR)
+        E_PV_directload_W = np.zeros(HOURS_IN_YEAR)
+        E_PV_grid_W = np.zeros(HOURS_IN_YEAR)
+        E_PVT_directload_W = np.zeros(HOURS_IN_YEAR)
+        E_PVT_grid_W = np.zeros(HOURS_IN_YEAR)
+        E_Furnace_directload_W = np.zeros(HOURS_IN_YEAR)
+        E_Furnace_grid_W = np.zeros(HOURS_IN_YEAR)
+        E_GRID_directload_W = np.zeros(HOURS_IN_YEAR)
 
-        for hour in range(8760):
+        for hour in range(HOURS_IN_YEAR):
             E_hour_W = total_electricity_demand_W[hour]
             if E_hour_W > 0:
                 if E_from_PV_W[hour] > E_hour_W:
@@ -407,14 +408,14 @@ def electricity_calculations_of_all_buildings(DHN_barcode, DCN_barcode, locator,
         E_from_PV_W = E_PV_gen_W
         E_from_PVT_W = E_PVT_gen_W
 
-        E_PV_directload_W = np.zeros(8760)
-        E_PV_grid_W = np.zeros(8760)
-        E_PVT_directload_W = np.zeros(8760)
-        E_PVT_grid_W = np.zeros(8760)
+        E_PV_directload_W = np.zeros(HOURS_IN_YEAR)
+        E_PV_grid_W = np.zeros(HOURS_IN_YEAR)
+        E_PVT_directload_W = np.zeros(HOURS_IN_YEAR)
+        E_PVT_grid_W = np.zeros(HOURS_IN_YEAR)
 
-        E_GRID_directload_W = np.zeros(8760)
+        E_GRID_directload_W = np.zeros(HOURS_IN_YEAR)
 
-        for hour in range(8760):
+        for hour in range(HOURS_IN_YEAR):
             E_hour_W = total_electricity_demand_W[hour]
             if E_hour_W > 0:
                 if E_from_PV_W[hour] > E_hour_W:
@@ -488,14 +489,14 @@ def electricity_calculations_of_all_buildings(DHN_barcode, DCN_barcode, locator,
         E_from_PV_W = E_PV_gen_W
         E_from_PVT_W = E_PVT_gen_W
 
-        E_PV_directload_W = np.zeros(8760)
-        E_PV_grid_W = np.zeros(8760)
-        E_PVT_directload_W = np.zeros(8760)
-        E_PVT_grid_W = np.zeros(8760)
+        E_PV_directload_W = np.zeros(HOURS_IN_YEAR)
+        E_PV_grid_W = np.zeros(HOURS_IN_YEAR)
+        E_PVT_directload_W = np.zeros(HOURS_IN_YEAR)
+        E_PVT_grid_W = np.zeros(HOURS_IN_YEAR)
 
-        E_GRID_directload_W = np.zeros(8760)
+        E_GRID_directload_W = np.zeros(HOURS_IN_YEAR)
 
-        for hour in range(8760):
+        for hour in range(HOURS_IN_YEAR):
             E_hour_W = total_electricity_demand_W[hour]
             if E_hour_W > 0:
                 if E_from_PV_W[hour] > E_hour_W:

--- a/cea/optimization/slave/heating_main.py
+++ b/cea/optimization/slave/heating_main.py
@@ -14,6 +14,7 @@ from cea.technologies.boiler import cond_boiler_op_cost
 from cea.optimization.slave.heating_resource_activation import heating_source_activator
 from cea.resources.geothermal import calc_ground_temperature
 from cea.utilities import epwreader
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Tim Vollrath"
 __copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"
@@ -90,79 +91,79 @@ def heating_calculations_of_DH_buildings(locator, master_to_slave_vars, gv, conf
         TretsewArray_K = np.array(HPSew_Data['ts_C']) + 273
 
     # Initiation of the variables
-    Opex_var_HP_Sewage_USD = np.zeros(8760)
-    Opex_var_HP_Lake_USD = np.zeros(8760)
-    Opex_var_GHP_USD = np.zeros(8760)
-    Opex_var_CHP_USD = np.zeros(8760)
-    Opex_var_Furnace_USD = np.zeros(8760)
-    Opex_var_BaseBoiler_USD = np.zeros(8760)
-    Opex_var_PeakBoiler_USD = np.zeros(8760)
+    Opex_var_HP_Sewage_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_HP_Lake_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_GHP_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_CHP_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_Furnace_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_BaseBoiler_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_PeakBoiler_USD = np.zeros(HOURS_IN_YEAR)
 
-    source_HP_Sewage = np.zeros(8760)
-    source_HP_Lake = np.zeros(8760)
-    source_GHP = np.zeros(8760)
-    source_CHP = np.zeros(8760)
-    source_Furnace = np.zeros(8760)
-    source_BaseBoiler = np.zeros(8760)
-    source_PeakBoiler = np.zeros(8760)
+    source_HP_Sewage = np.zeros(HOURS_IN_YEAR)
+    source_HP_Lake = np.zeros(HOURS_IN_YEAR)
+    source_GHP = np.zeros(HOURS_IN_YEAR)
+    source_CHP = np.zeros(HOURS_IN_YEAR)
+    source_Furnace = np.zeros(HOURS_IN_YEAR)
+    source_BaseBoiler = np.zeros(HOURS_IN_YEAR)
+    source_PeakBoiler = np.zeros(HOURS_IN_YEAR)
 
-    Q_HPSew_gen_W = np.zeros(8760)
-    Q_HPLake_gen_W = np.zeros(8760)
-    Q_GHP_gen_W = np.zeros(8760)
-    Q_CHP_gen_W = np.zeros(8760)
-    Q_Furnace_gen_W = np.zeros(8760)
-    Q_BaseBoiler_gen_W = np.zeros(8760)
-    Q_PeakBoiler_gen_W = np.zeros(8760)
-    Q_uncovered_W = np.zeros(8760)
+    Q_HPSew_gen_W = np.zeros(HOURS_IN_YEAR)
+    Q_HPLake_gen_W = np.zeros(HOURS_IN_YEAR)
+    Q_GHP_gen_W = np.zeros(HOURS_IN_YEAR)
+    Q_CHP_gen_W = np.zeros(HOURS_IN_YEAR)
+    Q_Furnace_gen_W = np.zeros(HOURS_IN_YEAR)
+    Q_BaseBoiler_gen_W = np.zeros(HOURS_IN_YEAR)
+    Q_PeakBoiler_gen_W = np.zeros(HOURS_IN_YEAR)
+    Q_uncovered_W = np.zeros(HOURS_IN_YEAR)
 
-    E_HPSew_req_W = np.zeros(8760)
-    E_HPLake_req_W = np.zeros(8760)
-    E_GHP_req_W = np.zeros(8760)
-    E_CHP_gen_W = np.zeros(8760)
-    E_Furnace_gen_W = np.zeros(8760)
-    E_BaseBoiler_req_W = np.zeros(8760)
-    E_PeakBoiler_req_W = np.zeros(8760)
+    E_HPSew_req_W = np.zeros(HOURS_IN_YEAR)
+    E_HPLake_req_W = np.zeros(HOURS_IN_YEAR)
+    E_GHP_req_W = np.zeros(HOURS_IN_YEAR)
+    E_CHP_gen_W = np.zeros(HOURS_IN_YEAR)
+    E_Furnace_gen_W = np.zeros(HOURS_IN_YEAR)
+    E_BaseBoiler_req_W = np.zeros(HOURS_IN_YEAR)
+    E_PeakBoiler_req_W = np.zeros(HOURS_IN_YEAR)
 
-    NG_used_HPSew_W = np.zeros(8760)
-    NG_used_HPLake_W = np.zeros(8760)
-    NG_used_GHP_W = np.zeros(8760)
-    NG_used_CHP_W = np.zeros(8760)
-    NG_used_Furnace_W = np.zeros(8760)
-    NG_used_BaseBoiler_W = np.zeros(8760)
-    NG_used_PeakBoiler_W = np.zeros(8760)
-    NG_used_BackupBoiler_W = np.zeros(8760)
+    NG_used_HPSew_W = np.zeros(HOURS_IN_YEAR)
+    NG_used_HPLake_W = np.zeros(HOURS_IN_YEAR)
+    NG_used_GHP_W = np.zeros(HOURS_IN_YEAR)
+    NG_used_CHP_W = np.zeros(HOURS_IN_YEAR)
+    NG_used_Furnace_W = np.zeros(HOURS_IN_YEAR)
+    NG_used_BaseBoiler_W = np.zeros(HOURS_IN_YEAR)
+    NG_used_PeakBoiler_W = np.zeros(HOURS_IN_YEAR)
+    NG_used_BackupBoiler_W = np.zeros(HOURS_IN_YEAR)
 
 
-    BG_used_HPSew_W = np.zeros(8760)
-    BG_used_HPLake_W = np.zeros(8760)
-    BG_used_GHP_W = np.zeros(8760)
-    BG_used_CHP_W = np.zeros(8760)
-    BG_used_Furnace_W = np.zeros(8760)
-    BG_used_BaseBoiler_W = np.zeros(8760)
-    BG_used_PeakBoiler_W = np.zeros(8760)
+    BG_used_HPSew_W = np.zeros(HOURS_IN_YEAR)
+    BG_used_HPLake_W = np.zeros(HOURS_IN_YEAR)
+    BG_used_GHP_W = np.zeros(HOURS_IN_YEAR)
+    BG_used_CHP_W = np.zeros(HOURS_IN_YEAR)
+    BG_used_Furnace_W = np.zeros(HOURS_IN_YEAR)
+    BG_used_BaseBoiler_W = np.zeros(HOURS_IN_YEAR)
+    BG_used_PeakBoiler_W = np.zeros(HOURS_IN_YEAR)
 
-    Wood_used_HPSew_W = np.zeros(8760)
-    Wood_used_HPLake_W = np.zeros(8760)
-    Wood_used_GHP_W = np.zeros(8760)
-    Wood_used_CHP_W = np.zeros(8760)
-    Wood_used_Furnace_W = np.zeros(8760)
-    Wood_used_BaseBoiler_W = np.zeros(8760)
-    Wood_used_PeakBoiler_W = np.zeros(8760)
+    Wood_used_HPSew_W = np.zeros(HOURS_IN_YEAR)
+    Wood_used_HPLake_W = np.zeros(HOURS_IN_YEAR)
+    Wood_used_GHP_W = np.zeros(HOURS_IN_YEAR)
+    Wood_used_CHP_W = np.zeros(HOURS_IN_YEAR)
+    Wood_used_Furnace_W = np.zeros(HOURS_IN_YEAR)
+    Wood_used_BaseBoiler_W = np.zeros(HOURS_IN_YEAR)
+    Wood_used_PeakBoiler_W = np.zeros(HOURS_IN_YEAR)
 
-    Q_coldsource_HPSew_W = np.zeros(8760)
-    Q_coldsource_HPLake_W = np.zeros(8760)
-    Q_coldsource_GHP_W = np.zeros(8760)
-    Q_coldsource_CHP_W = np.zeros(8760)
-    Q_coldsource_Furnace_W = np.zeros(8760)
-    Q_coldsource_BaseBoiler_W = np.zeros(8760)
-    Q_coldsource_PeakBoiler_W = np.zeros(8760)
+    Q_coldsource_HPSew_W = np.zeros(HOURS_IN_YEAR)
+    Q_coldsource_HPLake_W = np.zeros(HOURS_IN_YEAR)
+    Q_coldsource_GHP_W = np.zeros(HOURS_IN_YEAR)
+    Q_coldsource_CHP_W = np.zeros(HOURS_IN_YEAR)
+    Q_coldsource_Furnace_W = np.zeros(HOURS_IN_YEAR)
+    Q_coldsource_BaseBoiler_W = np.zeros(HOURS_IN_YEAR)
+    Q_coldsource_PeakBoiler_W = np.zeros(HOURS_IN_YEAR)
 
-    Q_excess_W = np.zeros(8760)
+    Q_excess_W = np.zeros(HOURS_IN_YEAR)
     weather_data = epwreader.epw_reader(config.weather)[['year', 'drybulb_C', 'wetbulb_C', 'relhum_percent',
                                                          'windspd_ms', 'skytemp_C']]
     ground_temp = calc_ground_temperature(locator, config, weather_data['drybulb_C'], depth_m=10)
 
-    for hour in range(8760):
+    for hour in range(HOURS_IN_YEAR):
         Q_therm_req_W = Q_missing_W[hour]
         # cost_data_centralPlant_op[hour, :], source_info[hour, :], Q_source_data_W[hour, :], E_coldsource_data_W[hour,
         #                                                                                     :], \
@@ -247,27 +248,27 @@ def heating_calculations_of_DH_buildings(locator, master_to_slave_vars, gv, conf
     # sum up the uncovered demand, get average and peak load
     Q_uncovered_design_W = np.amax(Q_uncovered_W)
     Q_uncovered_annual_W = np.sum(Q_uncovered_W)
-    Opex_var_BackupBoiler_USD = np.zeros(8760)
-    Q_BackupBoiler_W = np.zeros(8760)
-    E_BackupBoiler_req_W = np.zeros(8760)
+    Opex_var_BackupBoiler_USD = np.zeros(HOURS_IN_YEAR)
+    Q_BackupBoiler_W = np.zeros(HOURS_IN_YEAR)
+    E_BackupBoiler_req_W = np.zeros(HOURS_IN_YEAR)
 
-    Opex_var_Furnace_wet_USD = np.zeros(8760)
-    Opex_var_Furnace_dry_USD = np.zeros(8760)
-    Opex_var_CHP_NG_USD = np.zeros(8760)
-    Opex_var_CHP_BG_USD = np.zeros(8760)
-    Opex_var_BaseBoiler_NG_USD = np.zeros(8760)
-    Opex_var_BaseBoiler_BG_USD = np.zeros(8760)
-    Opex_var_PeakBoiler_NG_USD = np.zeros(8760)
-    Opex_var_PeakBoiler_BG_USD = np.zeros(8760)
-    Opex_var_BackupBoiler_NG_USD = np.zeros(8760)
-    Opex_var_BackupBoiler_BG_USD = np.zeros(8760)
+    Opex_var_Furnace_wet_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_Furnace_dry_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_CHP_NG_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_CHP_BG_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_BaseBoiler_NG_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_BaseBoiler_BG_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_PeakBoiler_NG_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_PeakBoiler_BG_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_BackupBoiler_NG_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_BackupBoiler_BG_USD = np.zeros(HOURS_IN_YEAR)
 
-    Opex_var_PV_USD = np.zeros(8760)
-    Opex_var_PVT_USD = np.zeros(8760)
-    Opex_var_SC_USD = np.zeros(8760)
+    Opex_var_PV_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_PVT_USD = np.zeros(HOURS_IN_YEAR)
+    Opex_var_SC_USD = np.zeros(HOURS_IN_YEAR)
 
     if Q_uncovered_design_W != 0:
-        for hour in range(8760):
+        for hour in range(HOURS_IN_YEAR):
             tdhret_req_K = tdhret_K[hour]
             BoilerBackup_Cost_Data = cond_boiler_op_cost(Q_uncovered_W[hour], Q_uncovered_design_W, tdhret_req_K, \
                                                          master_to_slave_vars.BoilerBackupType,

--- a/cea/optimization/slave/natural_gas_main.py
+++ b/cea/optimization/slave/natural_gas_main.py
@@ -14,6 +14,7 @@ import pandas as pd
 import numpy as np
 import cea.config
 import cea.inputlocator
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Sreepathi Bhargava Krishna"
 __copyright__ = "Copyright 2018, Architecture and Building Systems - ETH Zurich"
@@ -26,9 +27,9 @@ __status__ = "Production"
 
 def natural_gas_imports(master_to_slave_vars, locator, config):
 
-    NG_total_heating_W = np.zeros(8760)
-    NG_total_cooling_W = np.zeros(8760)
-    NG_total_W = np.zeros(8760)
+    NG_total_heating_W = np.zeros(HOURS_IN_YEAR)
+    NG_total_cooling_W = np.zeros(HOURS_IN_YEAR)
+    NG_total_W = np.zeros(HOURS_IN_YEAR)
     storage_data = pd.read_csv(locator.get_optimization_slave_storage_operation_data(master_to_slave_vars.individual_number, master_to_slave_vars.generation_number))
     date = storage_data.DATE.values
 
@@ -43,7 +44,7 @@ def natural_gas_imports(master_to_slave_vars, locator, config):
         NG_used_PeakBoiler_W = data_heating["NG_used_PeakBoiler_W"]
         NG_used_BackupBoiler_W = data_heating["NG_used_BackupBoiler_W"]
 
-        for hour in range(8760):
+        for hour in range(HOURS_IN_YEAR):
             NG_total_heating_W[hour] = NG_used_HPSew_W[hour] + NG_used_HPLake_W[hour] + NG_used_GHP_W[hour] + \
                                        NG_used_CHP_W[hour] + NG_used_Furnace_W[hour] + NG_used_BaseBoiler_W[hour] + \
                                        NG_used_PeakBoiler_W[hour] + NG_used_BackupBoiler_W[hour]
@@ -55,10 +56,10 @@ def natural_gas_imports(master_to_slave_vars, locator, config):
 
         # Natural Gas supply for the CCGT plant
         NG_used_CCGT_W = data_cooling['NG_used_CCGT_W']
-        for hour in range(8760):
+        for hour in range(HOURS_IN_YEAR):
             NG_total_cooling_W[hour] = NG_used_CCGT_W[hour]
 
-    for hour in range(8760):
+    for hour in range(HOURS_IN_YEAR):
         NG_total_W[hour] = NG_total_heating_W[hour] + NG_total_cooling_W[hour]
 
 

--- a/cea/optimization/slave/seasonal_storage/Import_Network_Data_functions.py
+++ b/cea/optimization/slave/seasonal_storage/Import_Network_Data_functions.py
@@ -8,6 +8,8 @@ Import Network Data:
 """
 import pandas as pd
 import numpy as np
+from cea.constants import HOURS_IN_YEAR
+
 __author__ = "Sreepathi Bhargava Krishna"
 __copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"
 __credits__ = ["Sreepathi Bhargava Krishna", "Thuy-an Ngugen", "Jimeno A. Fonseca"]
@@ -30,28 +32,28 @@ def import_solar_data(fName):
     """
 
     if fName == "PV_total.csv":
-        solar_data = pd.read_csv(fName, nrows=8760)
+        solar_data = pd.read_csv(fName, nrows=HOURS_IN_YEAR)
         PV_import_kWh = np.array(solar_data['E_PV_gen_kWh'])
         PV_kWh = PV_import_kWh
-        PVT_kWh = np.zeros(8760)
-        Solar_Area_m2 = np.zeros(8760)
-        Solar_E_aux_kWh = np.zeros(8760)
-        Solar_Q_th_kWh = np.zeros(8760)
-        Solar_Tscs_th = np.zeros(8760)
-        Solar_Tscr_th_K = np.zeros(8760)
-        Solar_mcp_kWperC = np.zeros(8760)
+        PVT_kWh = np.zeros(HOURS_IN_YEAR)
+        Solar_Area_m2 = np.zeros(HOURS_IN_YEAR)
+        Solar_E_aux_kWh = np.zeros(HOURS_IN_YEAR)
+        Solar_Q_th_kWh = np.zeros(HOURS_IN_YEAR)
+        Solar_Tscs_th = np.zeros(HOURS_IN_YEAR)
+        Solar_Tscr_th_K = np.zeros(HOURS_IN_YEAR)
+        Solar_mcp_kWperC = np.zeros(HOURS_IN_YEAR)
         #print "PV"
     
     elif fName == "PVT_total.csv":
-        solar_data = pd.read_csv(fName, nrows=8760)
-        PV_kWh = np.zeros(8760)
+        solar_data = pd.read_csv(fName, nrows=HOURS_IN_YEAR)
+        PV_kWh = np.zeros(HOURS_IN_YEAR)
         PV_PVT_import_kWh = np.array(solar_data['E_PVT_gen_kWh'])
         PVT_kWh = PV_PVT_import_kWh
         Solar_Area_Array = np.array(solar_data['Area_PVT_m2'])
         Solar_Area_m2 = Solar_Area_Array[0]
         Solar_E_aux_kWh = np.array(solar_data['Eaux_PVT_kWh'])
         Solar_Q_th_kWh = np.array(solar_data['Q_PVT_gen_kWh']) + 0.0
-        Solar_Tscs_th = np.zeros(8760)
+        Solar_Tscs_th = np.zeros(HOURS_IN_YEAR)
         Solar_Tscr_th_K = np.array(solar_data['T_PVT_re_C']) + 273.0
         Solar_mcp_kWperC = np.array(solar_data['mcp_PVT_kWperC'])
         #print "PVT 35"
@@ -59,7 +61,7 @@ def import_solar_data(fName):
         # Replace by 0 if negative values
         Tscs = np.array( pd.read_csv( fName, usecols=["T_PVT_sup_C"], nrows=1 ) ) [0][0]
         
-        for i in range(8760):
+        for i in range(HOURS_IN_YEAR):
             if Solar_Q_th_kWh[i] < 0:
                 Solar_Q_th_kWh[i] = 0
                 Solar_E_aux_kWh[i] = 0
@@ -67,22 +69,22 @@ def import_solar_data(fName):
                 Solar_mcp_kWperC[i] = 0
     
     else:
-        solar_data = pd.read_csv(fName, nrows=8760)
+        solar_data = pd.read_csv(fName, nrows=HOURS_IN_YEAR)
         Solar_Area_Array = np.array(solar_data['Area_SC_m2'])
         Solar_Area_m2 = Solar_Area_Array[0]
         Solar_E_aux_kWh = np.array(solar_data['Eaux_SC_kWh'])
         Solar_Q_th_kWh = np.array(solar_data['Q_SC_gen_kWh']) + 0.0
         Solar_Tscr_th_K = np.array(solar_data['T_SC_re_C']) + 273.0
-        Solar_Tscs_th = np.zeros(8760)
+        Solar_Tscs_th = np.zeros(HOURS_IN_YEAR)
 
         Solar_mcp_kWperC = np.array(solar_data['mcp_SC_kWperC'])
-        PV_kWh = np.zeros(8760)
-        PVT_kWh = np.zeros(8760)
+        PV_kWh = np.zeros(HOURS_IN_YEAR)
+        PVT_kWh = np.zeros(HOURS_IN_YEAR)
 
         # Replace by 0 if negative values
         Tscs = np.array( pd.read_csv( fName, usecols=["T_SC_sup_C"], nrows=1 ) ) [0][0]
         
-        for i in range(8760):
+        for i in range(HOURS_IN_YEAR):
             if Solar_Q_th_kWh[i] < 0:
                 Solar_Q_th_kWh[i] = 0
                 Solar_E_aux_kWh[i] = 0

--- a/cea/optimization/slave/seasonal_storage/design_operation.py
+++ b/cea/optimization/slave/seasonal_storage/design_operation.py
@@ -18,6 +18,7 @@ from cea.optimization.constants import *
 from cea.technologies.constants import DT_HEAT
 from cea.resources.geothermal import calc_ground_temperature
 from cea.utilities import epwreader
+from cea.constants import HOURS_IN_YEAR
 
 def Storage_Design(CSV_NAME, SOLCOL_TYPE, T_storage_old_K, Q_in_storage_old_W, locator,
                    STORAGE_SIZE_m3, STORE_DATA, master_to_slave_vars, P_HP_max_W, config):
@@ -57,9 +58,9 @@ def Storage_Design(CSV_NAME, SOLCOL_TYPE, T_storage_old_K, Q_in_storage_old_W, l
     T_DH_supply_array_K = Network_Data['T_DHNf_sup_K'].values
     Q_wasteheatServer_kWh =  Network_Data['Qcdata_netw_total_kWh'].values
     
-    Solar_Data_SC = np.zeros((8760, 7))
-    Solar_Data_PVT = np.zeros((8760, 7))
-    Solar_Data_PV = np.zeros((8760, 7))
+    Solar_Data_SC = np.zeros((HOURS_IN_YEAR, 7))
+    Solar_Data_PVT = np.zeros((HOURS_IN_YEAR, 7))
+    Solar_Data_PV = np.zeros((HOURS_IN_YEAR, 7))
     
     Solar_Tscr_th_SC_K = Solar_Data_SC[:,6]
     Solar_E_aux_SC_req_kWh = Solar_Data_SC[:,1]
@@ -106,7 +107,7 @@ def Storage_Design(CSV_NAME, SOLCOL_TYPE, T_storage_old_K, Q_in_storage_old_W, l
     Q_SC_ET_gen_Wh = Solar_Q_th_SC_ET_kWh * 1000 * master_to_slave_vars.SOLAR_PART_SC_ET
     Q_SC_FP_gen_Wh = Solar_Q_th_SC_FP_kWh * 1000 * master_to_slave_vars.SOLAR_PART_SC_FP
     Q_PVT_gen_Wh = Solar_Q_th_PVT_kW * 1000 * master_to_slave_vars.SOLAR_PART_PVT
-    Q_SCandPVT_gen_Wh = np.zeros(8760)
+    Q_SCandPVT_gen_Wh = np.zeros(HOURS_IN_YEAR)
     weather_data = epwreader.epw_reader(config.weather)[['year', 'drybulb_C', 'wetbulb_C','relhum_percent',
                                                               'windspd_ms', 'skytemp_C']]
     ground_temp = calc_ground_temperature(locator, config, weather_data['drybulb_C'], depth_m=10)
@@ -119,44 +120,44 @@ def Storage_Design(CSV_NAME, SOLCOL_TYPE, T_storage_old_K, Q_in_storage_old_W, l
     E_PVT_Wh = PVT_kWh * 1000  * master_to_slave_vars.SOLAR_PART_PVT
 
     HOUR = 0
-    Q_to_storage_avail_W = np.zeros(8760)
-    Q_from_storage_W = np.zeros(8760)
-    to_storage = np.zeros(8760)
-    Q_storage_content_fin_W = np.zeros(8760)
-    Q_server_to_directload_W = np.zeros(8760)
-    Q_server_to_storage_W = np.zeros(8760)
-    Q_compair_to_directload_W = np.zeros(8760)
-    Q_compair_to_storage_W = np.zeros(8760)
-    Q_PVT_to_directload_W = np.zeros(8760)
-    Q_PVT_to_storage_W = np.zeros(8760)
-    Q_SC_ET_to_directload_W = np.zeros(8760)
-    Q_SC_ET_to_storage_W = np.zeros(8760)
-    Q_SC_FP_to_directload_W = np.zeros(8760)
-    Q_SC_FP_to_storage_W = np.zeros(8760)
-    T_storage_fin_K = np.zeros(8760)
-    Q_from_storage_fin_W = np.zeros(8760)
-    Q_to_storage_fin_W = np.zeros(8760)
-    E_aux_ch_fin_W = np.zeros(8760)
-    E_aux_dech_fin_W = np.zeros(8760)
-    #E_PV_Wh_fin = np.zeros(8760)
-    E_aux_solar_W = np.zeros(8760)
-    Q_missing_fin_W = np.zeros(8760)
-    Q_from_storage_used_fin_W = np.zeros(8760)
-    Q_rejected_fin_W = np.zeros(8760)
-    mdot_DH_fin_kgpers = np.zeros(8760)
-    Q_uncontrollable_fin_Wh = np.zeros(8760)
-    E_aux_solar_and_heat_recovery_Wh = np.zeros(8760)
-    HPServerHeatDesignArray_kWh = np.zeros(8760)
-    HPpvt_designArray_Wh = np.zeros(8760)
-    HPCompAirDesignArray_kWh = np.zeros(8760)
-    HPScDesignArray_Wh = np.zeros(8760)
+    Q_to_storage_avail_W = np.zeros(HOURS_IN_YEAR)
+    Q_from_storage_W = np.zeros(HOURS_IN_YEAR)
+    to_storage = np.zeros(HOURS_IN_YEAR)
+    Q_storage_content_fin_W = np.zeros(HOURS_IN_YEAR)
+    Q_server_to_directload_W = np.zeros(HOURS_IN_YEAR)
+    Q_server_to_storage_W = np.zeros(HOURS_IN_YEAR)
+    Q_compair_to_directload_W = np.zeros(HOURS_IN_YEAR)
+    Q_compair_to_storage_W = np.zeros(HOURS_IN_YEAR)
+    Q_PVT_to_directload_W = np.zeros(HOURS_IN_YEAR)
+    Q_PVT_to_storage_W = np.zeros(HOURS_IN_YEAR)
+    Q_SC_ET_to_directload_W = np.zeros(HOURS_IN_YEAR)
+    Q_SC_ET_to_storage_W = np.zeros(HOURS_IN_YEAR)
+    Q_SC_FP_to_directload_W = np.zeros(HOURS_IN_YEAR)
+    Q_SC_FP_to_storage_W = np.zeros(HOURS_IN_YEAR)
+    T_storage_fin_K = np.zeros(HOURS_IN_YEAR)
+    Q_from_storage_fin_W = np.zeros(HOURS_IN_YEAR)
+    Q_to_storage_fin_W = np.zeros(HOURS_IN_YEAR)
+    E_aux_ch_fin_W = np.zeros(HOURS_IN_YEAR)
+    E_aux_dech_fin_W = np.zeros(HOURS_IN_YEAR)
+    #E_PV_Wh_fin = np.zeros(HOURS_IN_YEAR)
+    E_aux_solar_W = np.zeros(HOURS_IN_YEAR)
+    Q_missing_fin_W = np.zeros(HOURS_IN_YEAR)
+    Q_from_storage_used_fin_W = np.zeros(HOURS_IN_YEAR)
+    Q_rejected_fin_W = np.zeros(HOURS_IN_YEAR)
+    mdot_DH_fin_kgpers = np.zeros(HOURS_IN_YEAR)
+    Q_uncontrollable_fin_Wh = np.zeros(HOURS_IN_YEAR)
+    E_aux_solar_and_heat_recovery_Wh = np.zeros(HOURS_IN_YEAR)
+    HPServerHeatDesignArray_kWh = np.zeros(HOURS_IN_YEAR)
+    HPpvt_designArray_Wh = np.zeros(HOURS_IN_YEAR)
+    HPCompAirDesignArray_kWh = np.zeros(HOURS_IN_YEAR)
+    HPScDesignArray_Wh = np.zeros(HOURS_IN_YEAR)
     
     T_amb_K = 10 + 273.0 # K
     T_storage_min_K = master_to_slave_vars.T_ST_MAX
     Q_disc_seasonstart_W = [0]
     Q_loss_tot_W = 0
     
-    while HOUR < 8760:
+    while HOUR < HOURS_IN_YEAR:
         # Store later on this data
         HPServerHeatDesign_kWh = 0
         HPpvt_design_Wh = 0
@@ -326,10 +327,10 @@ def Storage_Design(CSV_NAME, SOLCOL_TYPE, T_storage_old_K, Q_in_storage_old_W, l
         """ STORE DATA """
     E_aux_solar_and_heat_recovery_flat_Wh = E_aux_solar_and_heat_recovery_Wh.flatten()
     # Calculate imported and exported Electricity Arrays:
-    E_produced_total_W = np.zeros(8760)
-    E_consumed_for_storage_solar_and_heat_recovery_W = np.zeros(8760)
+    E_produced_total_W = np.zeros(HOURS_IN_YEAR)
+    E_consumed_for_storage_solar_and_heat_recovery_W = np.zeros(HOURS_IN_YEAR)
     
-    for hour in range(8760):
+    for hour in range(HOURS_IN_YEAR):
         E_produced_total_W[hour] = E_PV_Wh[hour] + E_PVT_Wh[hour]
         E_consumed_for_storage_solar_and_heat_recovery_W[hour] = E_aux_ch_fin_W[hour] + E_aux_dech_fin_W[hour] + E_aux_solar_and_heat_recovery_Wh[hour]
 

--- a/cea/plots/4D_plots_ArcGIS/demand_4D_plot.py
+++ b/cea/plots/4D_plots_ArcGIS/demand_4D_plot.py
@@ -3,6 +3,7 @@ import os
 from cea.utilities import dbf
 import cea.globalvar
 import cea.inputlocator
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"
@@ -16,7 +17,7 @@ __status__ = "Production"
 def calc_spatio_temporal_visuals(locator, period, variables_to_plot, list_of_buildings, initial_date):
 
     # now the dates in which the building demand is calculated is stored in 'date'
-    date = pd.date_range(initial_date, periods=8760, freq='H')[period[0]: period[1]]
+    date = pd.date_range(initial_date, periods=HOURS_IN_YEAR, freq='H')[period[0]: period[1]]
     time = date.strftime("%Y%m%d%H%M%S")
 
     # this loop checks if all the buildings are selected and gets the building names from Total demand.csv file

--- a/cea/plots/4D_plots_ArcGIS/pv_4D_plot.py
+++ b/cea/plots/4D_plots_ArcGIS/pv_4D_plot.py
@@ -1,12 +1,11 @@
 
-
-
 import pandas as pd
 import os
 from cea.utilities import dbf
 import cea.globalvar
 import cea.config
 import cea.inputlocator
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"
@@ -20,7 +19,7 @@ __status__ = "Production"
 def calc_spatio_temporal_visuals(locator, period, variables_to_plot, list_of_buildings, initial_date):
 
     # now the dates in which the building demand is calculated is stored in 'date'
-    date = pd.date_range(initial_date, periods=8760, freq='H')[period[0]: period[1]]
+    date = pd.date_range(initial_date, periods=HOURS_IN_YEAR, freq='H')[period[0]: period[1]]
     time = date.strftime("%Y%m%d%H%M%S")
 
     # this loop checks if all the buildings are selected and gets the building names from Total demand.csv file

--- a/cea/plots/4D_plots_ArcGIS/pvt_4D_plot.py
+++ b/cea/plots/4D_plots_ArcGIS/pvt_4D_plot.py
@@ -1,12 +1,11 @@
 
-
-
 import pandas as pd
 import os
 from cea.utilities import dbf
 import cea.globalvar
 import cea.config
 import cea.inputlocator
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"
@@ -20,7 +19,7 @@ __status__ = "Production"
 def calc_spatio_temporal_visuals(locator, period, variables_to_plot, list_of_buildings, initial_date):
 
     # now the dates in which the building demand is calculated is stored in 'date'
-    date = pd.date_range(initial_date, periods=8760, freq='H')[period[0]: period[1]]
+    date = pd.date_range(initial_date, periods=HOURS_IN_YEAR, freq='H')[period[0]: period[1]]
     time = date.strftime("%Y%m%d%H%M%S")
 
     # this loop checks if all the buildings are selected and gets the building names from Total demand.csv file

--- a/cea/plots/4D_plots_ArcGIS/radiation_4D_plot.py
+++ b/cea/plots/4D_plots_ArcGIS/radiation_4D_plot.py
@@ -4,6 +4,7 @@ import os
 import cea.config
 import cea.inputlocator
 from cea.utilities import dbf
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"
@@ -17,7 +18,7 @@ __status__ = "Production"
 def calc_spatio_temporal_visuals(locator, period, variables_to_plot, list_of_buildings, initial_date):
 
     # now the dates in which the building demand is calculated is stored in 'date'
-    date = pd.date_range(initial_date, periods=8760, freq='H')[period[0]: period[1]]
+    date = pd.date_range(initial_date, periods=HOURS_IN_YEAR, freq='H')[period[0]: period[1]]
     time = date.strftime("%Y%m%d%H%M%S")
 
     # this loop checks if all the buildings are selected and gets the building names from Total demand.csv file

--- a/cea/plots/4D_plots_ArcGIS/radiation_total.py
+++ b/cea/plots/4D_plots_ArcGIS/radiation_total.py
@@ -7,6 +7,7 @@ from cea.utilities import dbf
 import cea.inputlocator
 import cea.config
 from cea.utilities import epwreader
+from cea.constants import HOURS_IN_YEAR
 
 
 __author__ = "Sreepathi Bhargava Krishna"
@@ -21,7 +22,7 @@ __status__ = "Production"
 def calc_spatio_temporal_visuals(locator, list_of_buildings, initial_date, config):
 
     # now the dates in which the building demand is calculated is stored in 'date'
-    date = pd.date_range(initial_date, periods=8760, freq='H')
+    date = pd.date_range(initial_date, periods=HOURS_IN_YEAR, freq='H')
     time = date.strftime("%Y%m%d%H%M%S")
 
     # this loop checks if all the buildings are selected and gets the building names from Total demand.csv file

--- a/cea/plots/4D_plots_ArcGIS/sc_4D_plot.py
+++ b/cea/plots/4D_plots_ArcGIS/sc_4D_plot.py
@@ -7,6 +7,7 @@ from cea.utilities import dbf
 import cea.globalvar
 import cea.config
 import cea.inputlocator
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"
@@ -20,7 +21,7 @@ __status__ = "Production"
 def calc_spatio_temporal_visuals(locator, period, variables_to_plot, list_of_buildings, initial_date):
 
     # now the dates in which the building demand is calculated is stored in 'date'
-    date = pd.date_range(initial_date, periods=8760, freq='H')[period[0]: period[1]]
+    date = pd.date_range(initial_date, periods=HOURS_IN_YEAR, freq='H')[period[0]: period[1]]
     time = date.strftime("%Y%m%d%H%M%S")
 
     # this loop checks if all the buildings are selected and gets the building names from Total demand.csv file

--- a/cea/plots/demand/load_duration_curve.py
+++ b/cea/plots/demand/load_duration_curve.py
@@ -1,10 +1,9 @@
 from __future__ import division
-
 import plotly.graph_objs as go
 from plotly.offline import plot
 import cea.plots.demand
 from cea.plots.variable_naming import NAMING, COLOR, LOGO
-
+from cea.constants import HOURS_IN_YEAR
 import pandas as pd
 
 __author__ = "Jimeno A. Fonseca"
@@ -30,7 +29,7 @@ class LoadDurationCurvePlot(cea.plots.demand.DemandPlotBase):
 
     def calc_graph(self):
         graph = []
-        duration = range(8760)
+        duration = range(HOURS_IN_YEAR)
         x = [(a - min(duration)) / (max(duration) - min(duration)) * 100 for a in duration]
         for field in self.analysis_fields:
             name = NAMING[field]
@@ -69,7 +68,7 @@ def calc_table(analysis_fields, data_frame):
     load_utilization = []
     load_names = []
     # data = ''
-    duration = range(8760)
+    duration = range(HOURS_IN_YEAR)
     x = [(a - min(duration)) / (max(duration) - min(duration)) * 100 for a in duration]
     for field in analysis_fields:
         data_frame_new = data_frame.sort_values(by=field, ascending=False)
@@ -85,7 +84,7 @@ def calc_table(analysis_fields, data_frame):
 def calc_graph(analysis_fields, data_frame):
 
     graph = []
-    duration = range(8760)
+    duration = range(HOURS_IN_YEAR)
     x = [(a - min(duration)) / (max(duration) - min(duration)) * 100 for a in duration]
     for field in analysis_fields:
         name = NAMING[field]
@@ -102,7 +101,7 @@ def evaluate_utilization(x,y):
     if 0 in dataframe_util['y'].values:
         index_occurrence = dataframe_util['y'].idxmin(axis=0, skipna=True)
         utilization_perc = round(dataframe_util.loc[index_occurrence,'x'],1)
-        utilization_days = int(utilization_perc*8760/(24*100))
+        utilization_days = int(utilization_perc*HOURS_IN_YEAR/(24*100))
         return str(utilization_perc) + '% or ' + str(utilization_days) + ' days a year'
     else:
         return 'all year'

--- a/cea/plots/demand/load_duration_curve_supply.py
+++ b/cea/plots/demand/load_duration_curve_supply.py
@@ -8,7 +8,7 @@ import cea.plots.demand
 import plotly.graph_objs as go
 
 from cea.plots.variable_naming import NAMING, COLOR
-
+from cea.constants import HOURS_IN_YEAR
 
 class LoadDurationCurveSupplyPlot(cea.plots.demand.DemandPlotBase):
     """Implement the load-duration-curve-supply plot"""
@@ -28,7 +28,7 @@ class LoadDurationCurveSupplyPlot(cea.plots.demand.DemandPlotBase):
 
     def calc_graph(self):
         graph = []
-        duration = range(8760)
+        duration = range(HOURS_IN_YEAR)
         x = [(a - min(duration)) / (max(duration) - min(duration)) * 100 for a in duration]
         for field in self.analysis_fields:
             name = NAMING[field]

--- a/cea/plots/old/graphs_optimization.py
+++ b/cea/plots/old/graphs_optimization.py
@@ -17,6 +17,7 @@ import cea.config
 import cea.inputlocator
 import cea.optimization.master.normalization as norm
 import cea.optimization.supportFn as sFn
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2015, Architecture and Building Systems - ETH Zurich"
@@ -361,14 +362,14 @@ def Elec_ImportExport(individual, locator):
     # Extract Electricity needs
     buildList = sFn.extract_building_names_from_csv(locator.pathRaw + "/Total.csv")
 
-    allElec = np.zeros((8760,1))
+    allElec = np.zeros((HOURS_IN_YEAR,1))
 
     for build in buildList:
         buildFileRaw = locator.pathRaw + "/" + build + ".csv"
         builddf = pd.read_csv(buildFileRaw, usecols = ["Ealf", "Eauxf", "Ecaf", "Edataf", "Epf"])
         buildarray = np.array(builddf)
 
-        for i in range(8760):
+        for i in range(HOURS_IN_YEAR):
             allElec[i,0] += np.sum(buildarray[i,:])*1000
     print sum(allElec)
 
@@ -381,7 +382,7 @@ def Elec_ImportExport(individual, locator):
     # Compute Import / Export
     imp = 0
     exp = 0
-    for i in range(8760):
+    for i in range(HOURS_IN_YEAR):
         delta = allElec[i,0] - EsolarArray[i,0]
         if delta > 0:
             imp += delta

--- a/cea/plots/thermal_networks/loss_duration_curve.py
+++ b/cea/plots/thermal_networks/loss_duration_curve.py
@@ -5,6 +5,7 @@ import plotly.graph_objs as go
 from plotly.offline import plot
 
 from cea.plots.variable_naming import NAMING, LOGO, COLOR
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Lennart Rogenhofer"
 __copyright__ = "Copyright 2018, Architecture and Building Systems - ETH Zurich"
@@ -41,7 +42,7 @@ def calc_table(analysis_fields, data_frame):
     load_utilization = []
     loss_names = []
     # data = ''
-    duration = range(8760)
+    duration = range(HOURS_IN_YEAR)
     x = [(a - min(duration)) / (max(duration) - min(duration)) * 100 for a in duration]
     for field in analysis_fields:
         field_1 = field.split('_')[0]
@@ -60,7 +61,7 @@ def calc_table(analysis_fields, data_frame):
 
 def calc_graph(analysis_fields, data_frame):
     graph = []
-    duration = range(8760)
+    duration = range(HOURS_IN_YEAR)
     x = [(a - min(duration)) / (max(duration) - min(duration)) * 100 for a in duration]  # calculate relative values
     for field in analysis_fields:
         data_frame = data_frame.sort_values(by=field, ascending=False)
@@ -77,7 +78,7 @@ def evaluate_utilization(x, y):
     if 0 in dataframe_util['y'].values:
         index_occurrence = dataframe_util['y'].idxmin(axis=0, skipna=True)
         utilization_perc = round(dataframe_util.loc[index_occurrence, 'x'], 1)
-        utilization_days = int(utilization_perc * 8760 / (24 * 100))
+        utilization_days = int(utilization_perc * HOURS_IN_YEAR / (24 * 100))
         return str(utilization_perc) + '% or ' + str(utilization_days) + ' days a year'
     else:
         return 'all year'

--- a/cea/plots/thermal_networks/main.py
+++ b/cea/plots/thermal_networks/main.py
@@ -19,6 +19,7 @@ from cea.plots.thermal_networks.energy_loss_bar import energy_loss_bar_plot
 from cea.plots.thermal_networks.loss_curve import loss_curve
 from cea.plots.thermal_networks.loss_duration_curve import loss_duration_curve
 from cea.plots.thermal_networks.network_plot import network_plot
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Lennart Rogenhofer"
 __copyright__ = "Copyright 2018, Architecture and Building Systems - ETH Zurich"
@@ -223,7 +224,7 @@ class Plots(object):
         if len(df.columns.values) > 1:  # sum of all plants
             df = df.sum(axis=1)
         df[df == 0] = np.nan
-        df = np.reshape(df.values, (8760, 1))  # necessary to avoid errors from shape mismatch
+        df = np.reshape(df.values, (HOURS_IN_YEAR, 1))  # necessary to avoid errors from shape mismatch
         rel = absolute_loss.values / df * 100  # calculate relative value in %
         rel = np.nan_to_num(rel)  # remove nan or inf values to avoid runtime error
         # if relative losses are more than 100% temperature requirements are not met. All produced heat is lost.

--- a/cea/resources/geothermal.py
+++ b/cea/resources/geothermal.py
@@ -4,6 +4,7 @@
 import pandas as pd
 import numpy as np
 import math
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2015, Architecture and Building Systems - ETH Zurich"
@@ -39,8 +40,8 @@ def calc_ground_temperature(locator, config, T_ambient_C, depth_m):
 
     T_max = max(T_ambient_C) + 273.15 # to K
     T_avg = np.mean(T_ambient_C) + 273.15 # to K
-    e = depth_m * math.sqrt ((math.pi * heat_capacity_soil * density_soil) / (8760 * conductivity_soil)) # soil constants
-    Tg = [ T_avg + ( T_max - T_avg ) * math.exp( -e ) * math.cos ( ( 2 * math.pi * ( i + 1 ) / 8760 ) - e )
-           for i in range(8760)]
+    e = depth_m * math.sqrt ((math.pi * heat_capacity_soil * density_soil) / (HOURS_IN_YEAR * conductivity_soil)) # soil constants
+    Tg = [ T_avg + ( T_max - T_avg ) * math.exp( -e ) * math.cos ( ( 2 * math.pi * ( i + 1 ) / HOURS_IN_YEAR ) - e )
+           for i in range(HOURS_IN_YEAR)]
 
     return Tg

--- a/cea/resources/lake_potential.py
+++ b/cea/resources/lake_potential.py
@@ -10,6 +10,7 @@ from cea.constants import HEX_WIDTH_M,VEL_FLOW_MPERS, HEAT_CAPACITY_OF_WATER_JPE
 import cea.config
 import cea.globalvar
 import cea.inputlocator
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Sreepathi Bhargava Krishna"
 __copyright__ = "Copyright 2015, Architecture and Building Systems - ETH Zurich"
@@ -33,13 +34,13 @@ def calc_lake_potential(locator, config):
     Save the results to `SWP.csv`
     """
 
-    lake_potential = np.zeros(8760)
-    hour = range(8760)
+    lake_potential = np.zeros(HOURS_IN_YEAR)
+    hour = range(HOURS_IN_YEAR)
 
     if config.lake.available:
         lake_size = config.lake.size
-        lake_size_per_hour = float(lake_size) / 8760
-        for i in range(8760):
+        lake_size_per_hour = float(lake_size) / HOURS_IN_YEAR
+        for i in range(HOURS_IN_YEAR):
             lake_potential[i] = lake_size_per_hour
 
 

--- a/cea/technologies/solar/photovoltaic.py
+++ b/cea/technologies/solar/photovoltaic.py
@@ -18,6 +18,7 @@ from cea.utilities import epwreader
 from cea.utilities import solar_equations
 from cea.technologies.solar import constants
 import cea.config
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2016, Architecture and Building Systems - ETH Zurich"
@@ -101,7 +102,7 @@ def calc_PV(locator, config, radiation_path, metadata_csv, latitude, longitude, 
             {'PV_walls_north_E_kWh': 0, 'PV_walls_north_m2': 0, 'PV_walls_south_E_kWh': 0, 'PV_walls_south_m2': 0,
              'PV_walls_east_E_kWh': 0, 'PV_walls_east_m2': 0, 'PV_walls_west_E_kWh': 0, 'PV_walls_west_m2': 0,
              'PV_roofs_top_E_kWh': 0, 'PV_roofs_top_m2': 0,
-             'E_PV_gen_kWh': 0, 'Area_PV_m2': 0, 'radiation_kWh': 0}, index=range(8760))
+             'E_PV_gen_kWh': 0, 'Area_PV_m2': 0, 'radiation_kWh': 0}, index=range(HOURS_IN_YEAR))
         final.to_csv(locator.PV_results(building_name=building_name), index=True, float_format='%.2f')
         sensors_metadata_cat = pd.DataFrame(
             {'SURFACE': 0, 'AREA_m2': 0, 'BUILDING': 0, 'TYPE': 0, 'Xcoor': 0, 'Xdir': 0, 'Ycoor': 0, 'Ydir': 0,
@@ -160,7 +161,7 @@ def calc_pv_generation(sensor_groups, weather_data, date_local, solar_properties
     total_el_output_PV_kWh = [0 for i in range(number_groups)]
     total_radiation_kWh = [0 for i in range(number_groups)]
 
-    potential = pd.DataFrame(index=[range(8760)])
+    potential = pd.DataFrame(index=[range(HOURS_IN_YEAR)])
     panel_orientations = ['walls_south', 'walls_north', 'roofs_top', 'walls_east', 'walls_west']
     for panel_orientation in panel_orientations:
         potential['PV_' + panel_orientation + '_E_kWh'] = 0

--- a/cea/technologies/solar/solar_collector.py
+++ b/cea/technologies/solar/solar_collector.py
@@ -20,6 +20,7 @@ from cea.technologies.solar import constants
 from geopandas import GeoDataFrame as gdf
 from numba import jit
 from itertools import izip, repeat
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2015, Architecture and Building Systems - ETH Zurich"
@@ -117,7 +118,7 @@ def calc_SC(locator, config, latitude, longitude, weather_data, date_local, buil
              'SC_roofs_top_m2': 0, 'SC_roofs_top_Q_kWh': 0, 'SC_roofs_top_Tout_C': 0,
              'Q_SC_gen_kWh': 0, 'T_SC_sup_C': 0, 'T_SC_re_C': 0, 'mcp_SC_kWperC': 0, 'Eaux_SC_kWh': 0,
              'Q_SC_l_kWh': 0, 'Area_SC_m2': 0, 'radiation_kWh': 0},
-            index=range(8760))
+            index=range(HOURS_IN_YEAR))
         Final.to_csv(locator.SC_results(building_name, panel_type), index=True, float_format='%.2f')
         sensors_metadata_cat = pd.DataFrame(
             {'SURFACE': 0, 'AREA_m2': 0, 'BUILDING': 0, 'TYPE': 0, 'Xcoor': 0, 'Xdir': 0, 'Ycoor': 0, 'Ydir': 0,
@@ -157,7 +158,7 @@ def calc_SC_generation(sensor_groups, weather_data, date_local, solar_properties
     hourly_radiation = sensor_groups['hourlydata_groups']  # mean hourly radiation of sensors in each group [Wh/m2]
 
     T_in_C = get_t_in_sc(config)
-    Tin_array_C = np.zeros(8760) + T_in_C
+    Tin_array_C = np.zeros(HOURS_IN_YEAR) + T_in_C
 
     # create lists to store results
     list_results_from_SC = [0 for i in range(number_groups)]
@@ -168,7 +169,7 @@ def calc_SC_generation(sensor_groups, weather_data, date_local, solar_properties
     total_aux_el_kWh = [0 for i in range(number_groups)]
     total_Qh_output_kWh = [0 for i in range(number_groups)]
 
-    potential = pd.DataFrame(index=[range(8760)])
+    potential = pd.DataFrame(index=[range(HOURS_IN_YEAR)])
     panel_orientations = ['walls_south', 'walls_north', 'roofs_top', 'walls_east', 'walls_west']
     for panel_orientation in panel_orientations:
         potential['SC_' + panel_orientation + '_Q_kWh'] = 0
@@ -325,25 +326,32 @@ def calc_SC_module(config, radiation_Wperm2, panel_properties, Tamb_vector_C, IA
 
     # Do the calculation of every time step for every possible flow condition
     # get states where highly performing values are obtained.
-    specific_flows_kgpers = [np.zeros(8760), (np.zeros(8760) + mB0_r) * aperture_area_m2 / 3600,
-                             (np.zeros(8760) + mB_max_r) * aperture_area_m2 / 3600,
-                             (np.zeros(8760) + mB_min_r) * aperture_area_m2 / 3600, np.zeros(8760),
-                             np.zeros(8760)]  # in kg/s
-    specific_pressure_losses_Pa = [np.zeros(8760), (np.zeros(8760) + dP2) * aperture_area_m2,
-                                   (np.zeros(8760) + dP3) * aperture_area_m2,
-                                   (np.zeros(8760) + dP4) * aperture_area_m2, np.zeros(8760), np.zeros(8760)]  # in Pa
+    specific_flows_kgpers = [np.zeros(HOURS_IN_YEAR), (np.zeros(HOURS_IN_YEAR) + mB0_r) * aperture_area_m2 / 3600,
+                             (np.zeros(HOURS_IN_YEAR) + mB_max_r) * aperture_area_m2 / 3600,
+                             (np.zeros(HOURS_IN_YEAR) + mB_min_r) * aperture_area_m2 / 3600, np.zeros(HOURS_IN_YEAR),
+                             np.zeros(HOURS_IN_YEAR)]  # in kg/s
+    specific_pressure_losses_Pa = [np.zeros(HOURS_IN_YEAR), (np.zeros(HOURS_IN_YEAR) + dP2) * aperture_area_m2,
+                                   (np.zeros(HOURS_IN_YEAR) + dP3) * aperture_area_m2,
+                                   (np.zeros(HOURS_IN_YEAR) + dP4) * aperture_area_m2, np.zeros(HOURS_IN_YEAR),
+                                   np.zeros(HOURS_IN_YEAR)]  # in Pa
 
     # generate empty lists to store results
-    temperature_out_C = [np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760)]
-    temperature_in_C = [np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760)]
-    temperature_mean_C = [np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760),
-                          np.zeros(8760)]
-    supply_out_kW = [np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760)]
-    supply_losses_kW = [np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760)]
-    auxiliary_electricity_kW = [np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760), np.zeros(8760),
-                                np.zeros(8760)]
-    supply_out_total_kW = np.zeros(8760)
-    mcp_kWperK = np.zeros(8760)
+    temperature_out_C = [np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR),
+                         np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR)]
+    temperature_in_C = [np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR),
+                        np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR)]
+    temperature_mean_C = [np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR),
+                          np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR),
+                          np.zeros(HOURS_IN_YEAR)]
+    supply_out_kW = [np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR),
+                     np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR)]
+    supply_losses_kW = [np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR),
+                        np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR)]
+    auxiliary_electricity_kW = [np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR),
+                                np.zeros(HOURS_IN_YEAR), np.zeros(HOURS_IN_YEAR),
+                                np.zeros(HOURS_IN_YEAR)]
+    supply_out_total_kW = np.zeros(HOURS_IN_YEAR)
+    mcp_kWperK = np.zeros(HOURS_IN_YEAR)
 
     # calculate absorbed radiation
     tilt_rad = radians(tilt_angle_deg)
@@ -364,7 +372,7 @@ def calc_SC_module(config, radiation_Wperm2, panel_properties, Tamb_vector_C, IA
         TabsA = np.zeros(600)
         q_gain_Seg = np.zeros(101)  # maximum Iseg = maximum Nseg + 1 = 101
 
-        for time in range(8760):
+        for time in range(HOURS_IN_YEAR):
             Mfl_kgpers = calc_Mfl_kgpers(C_eff_Jperm2K, Cp_fluid_JperkgK, DELT, Nseg, STORED, TIME0, Tin_C,
                                          aperture_area_m2, specific_flows_kgpers[flow], time)
 
@@ -463,6 +471,7 @@ def calc_SC_module(config, radiation_Wperm2, panel_properties, Tamb_vector_C, IA
 
     return result
 
+
 @jit(nopython=True)
 def do_multi_segment_calculation(A_seg_m2, C_eff_Jperm2K, Cp_fluid_JperkgK, DT, Mfl_kgpers, Nseg, STORED,
                                  Tabs, TabsA, Tamb_C, Tfl, TflA, TflB, Tin_C, Tout_C, c1, c2, delts,
@@ -511,7 +520,6 @@ def do_multi_segment_calculation(A_seg_m2, C_eff_Jperm2K, Cp_fluid_JperkgK, DT, 
 @jit(nopython=True)
 def calc_Tout_C(Cp_fluid_JperkgK, DT, Nseg, STORED, Tabs, Tamb_C, Tfl, Tin_C, aperture_area_m2, c1,
                 q_rad_Wperm2, Mfl_kgpers):
-
     # calculate mean fluid temperature and average absorber temperature at the beginning of the time-step
 
     Tfl[1] = 0  # mean fluid temperature from the last timestep
@@ -589,6 +597,7 @@ def update_negative_total_supply(aperture_area_m2, auxiliary_electricity_kW, flo
                 auxiliary_electricity_kW[flow][i] = calc_Eaux_panels(specific_flows_kgpers[flow][i],
                                                                      specific_pressure_losses_Pa[flow][i],
                                                                      pipe_lengths, aperture_area_m2)
+
 
 @jit(nopython=True)
 def calc_q_rad(n0, IAM_b, IAM_d, I_direct_Wperm2, I_diffuse_Wperm2, tilt):
@@ -872,13 +881,13 @@ def calc_optimal_mass_flow(q1, q2, q3, q4, E1, E2, E3, E4, m1, m2, m3, m4, dP1, 
     Energy and Buildings, 2016.
     """
 
-    mass_flow_opt = np.empty(8760)
-    dP_opt = np.empty(8760)
+    mass_flow_opt = np.empty(HOURS_IN_YEAR)
+    dP_opt = np.empty(HOURS_IN_YEAR)
     const = Area_a / 3600
     mass_flow_all_kgpers = [m1 * const, m2 * const, m3 * const, m4 * const]  # [kg/s]
     dP_all_Pa = [dP1 * Area_a, dP2 * Area_a, dP3 * Area_a, dP4 * Area_a]  # [Pa]
     balances = [abs(q1) - E1 * 2, q2 - E2 * 2, q3 - E3 * 2, q4 - E4 * 2]  # energy generation function eq.(63)
-    for time in range(8760):
+    for time in range(HOURS_IN_YEAR):
         balances_time = [balances[0][time], balances[1][time], balances[2][time], balances[3][time]]
         max_heat_production = np.max(balances_time)
         ix_max_heat_production = np.where(balances_time == max_heat_production)
@@ -896,7 +905,7 @@ def calc_optimal_mass_flow_2(m, q, dp):
     :return m: hourly mass flow rate [kg/s]
     :return dp: hourly pressure drop [Pa]
     """
-    for time in range(8760):
+    for time in range(HOURS_IN_YEAR):
         if q[time] <= 0:
             m[time] = 0
             dp[time] = 0
@@ -975,16 +984,16 @@ def main(config):
                                        repeat(weather_data, building_count),
                                        repeat(date_local, building_count),
                                        list_buildings_names))
-        #locator, config, latitude, longitude, weather_data, date_local, building
+        # locator, config, latitude, longitude, weather_data, date_local, building
     else:
         print("Using single process")
         map(calc_SC_wrapper, izip(repeat(locator, building_count),
-                                       repeat(config, building_count),
-                                       repeat(latitude, building_count),
-                                       repeat(longitude, building_count),
-                                       repeat(weather_data, building_count),
-                                       repeat(date_local, building_count),
-                                       list_buildings_names))
+                                  repeat(config, building_count),
+                                  repeat(latitude, building_count),
+                                  repeat(longitude, building_count),
+                                  repeat(weather_data, building_count),
+                                  repeat(date_local, building_count),
+                                  list_buildings_names))
 
     # aggregate results from all buildings
     aggregated_annual_results = {}
@@ -1003,11 +1012,16 @@ def main(config):
 
     # save hourly results
     aggregated_hourly_results_df = aggregated_hourly_results_df.set_index('Date')
-    aggregated_hourly_results_df = aggregated_hourly_results_df[aggregated_hourly_results_df.columns.drop(aggregated_hourly_results_df.filter(like='Tout', axis=1).columns)]  # drop columns with Tout
+    aggregated_hourly_results_df = aggregated_hourly_results_df[aggregated_hourly_results_df.columns.drop(
+        aggregated_hourly_results_df.filter(like='Tout', axis=1).columns)]  # drop columns with Tout
     # recalculate average temperature supply and return of all panels
-    aggregated_hourly_results_df['T_SC_sup_C'] = np.where(aggregated_hourly_results_df['mcp_SC_kWperC'] != 0, temperature_sup, np.nan)
-    aggregated_hourly_results_df['T_SC_re_C'] = np.where(aggregated_hourly_results_df['mcp_SC_kWperC'] != 0, aggregated_hourly_results_df['T_SC_sup_C'] + aggregated_hourly_results_df['Q_SC_gen_kWh'] / aggregated_hourly_results_df['mcp_SC_kWperC'],
-                               np.nan)
+    aggregated_hourly_results_df['T_SC_sup_C'] = np.where(aggregated_hourly_results_df['mcp_SC_kWperC'] != 0,
+                                                          temperature_sup, np.nan)
+    aggregated_hourly_results_df['T_SC_re_C'] = np.where(aggregated_hourly_results_df['mcp_SC_kWperC'] != 0,
+                                                         aggregated_hourly_results_df['T_SC_sup_C'] +
+                                                         aggregated_hourly_results_df['Q_SC_gen_kWh'] /
+                                                         aggregated_hourly_results_df['mcp_SC_kWperC'],
+                                                         np.nan)
     aggregated_hourly_results_df.to_csv(locator.SC_totals(panel_type), index=True, float_format='%.2f', na_rep='nan')
     # save annual results
     aggregated_annual_results_df = pd.DataFrame(aggregated_annual_results).T

--- a/cea/technologies/substation.py
+++ b/cea/technologies/substation.py
@@ -11,6 +11,7 @@ import scipy
 from numba import jit
 import cea.config
 from cea.technologies.constants import DT_HEAT, DT_COOL, U_COOL, U_HEAT
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"
@@ -43,35 +44,35 @@ def substation_main(locator, total_demand, building_names, heating_configuration
 
     t0 = time.clock()
     # generate empty vectors
-    # Ths_ahu_supply = np.zeros(8760)
-    # Ths_aru_supply = np.zeros(8760)
-    # Ths_shu_supply = np.zeros(8760)
-    # Ths_ahu_return = np.zeros(8760)
-    # Ths_aru_return = np.zeros(8760)
-    # Ths_shu_return = np.zeros(8760)
-    # Tww_supply = np.zeros(8760)
-    # Tww_return = np.zeros(8760)
-    T_cooling_supply_initial = np.zeros(8760) + 1E6
-    T_cooling_return_initial = np.zeros(8760) - 1E6
-    # Tcdata_sys_supply = np.zeros(8760) + 1E6
-    # Tcref_supply = np.zeros(8760) + 1E6
-    # Tcs_ahu_supply = np.zeros(8760) + 1E6
-    # Tcs_aru_supply = np.zeros(8760) + 1E6
-    # Tcs_scu_supply = np.zeros(8760) + 1E6
-    # Tcdata_sys_return = np.zeros(8760) - 1E6
-    # Tcref_return = np.zeros(8760) - 1E6
-    # Tcs_ahu_return = np.zeros(8760) - 1E6
-    # Tcs_aru_return = np.zeros(8760) - 1E6
-    # Tcs_scu_return = np.zeros(8760) - 1E6
+    # Ths_ahu_supply = np.zeros(HOURS_IN_YEAR)
+    # Ths_aru_supply = np.zeros(HOURS_IN_YEAR)
+    # Ths_shu_supply = np.zeros(HOURS_IN_YEAR)
+    # Ths_ahu_return = np.zeros(HOURS_IN_YEAR)
+    # Ths_aru_return = np.zeros(HOURS_IN_YEAR)
+    # Ths_shu_return = np.zeros(HOURS_IN_YEAR)
+    # Tww_supply = np.zeros(HOURS_IN_YEAR)
+    # Tww_return = np.zeros(HOURS_IN_YEAR)
+    T_cooling_supply_initial = np.zeros(HOURS_IN_YEAR) + 1E6
+    T_cooling_return_initial = np.zeros(HOURS_IN_YEAR) - 1E6
+    # Tcdata_sys_supply = np.zeros(HOURS_IN_YEAR) + 1E6
+    # Tcref_supply = np.zeros(HOURS_IN_YEAR) + 1E6
+    # Tcs_ahu_supply = np.zeros(HOURS_IN_YEAR) + 1E6
+    # Tcs_aru_supply = np.zeros(HOURS_IN_YEAR) + 1E6
+    # Tcs_scu_supply = np.zeros(HOURS_IN_YEAR) + 1E6
+    # Tcdata_sys_return = np.zeros(HOURS_IN_YEAR) - 1E6
+    # Tcref_return = np.zeros(HOURS_IN_YEAR) - 1E6
+    # Tcs_ahu_return = np.zeros(HOURS_IN_YEAR) - 1E6
+    # Tcs_aru_return = np.zeros(HOURS_IN_YEAR) - 1E6
+    # Tcs_scu_return = np.zeros(HOURS_IN_YEAR) - 1E6
 
     # Calculate the plant supply temperautres according to all building demands
     # hence, the lowest temperature for DC, and the highest temperature for DH
     buildings_dict = {}
     cooling_system_temperatures_dict = {}
     heating_system_temperatures_dict = {}
-    T_DHN_supply = np.zeros(8760)
-    T_DCN_supply_to_cs_ref = np.zeros(8760) + 1E6
-    T_DCN_supply_to_cs_ref_data = np.zeros(8760) + 1E6
+    T_DHN_supply = np.zeros(HOURS_IN_YEAR)
+    T_DCN_supply_to_cs_ref = np.zeros(HOURS_IN_YEAR) + 1E6
+    T_DCN_supply_to_cs_ref_data = np.zeros(HOURS_IN_YEAR) + 1E6
     for name in building_names:
         buildings_dict[name] = pd.read_csv(locator.get_demand_results_folder() + '//' + name + ".csv",
                                            usecols=['Name', 'Ths_sys_sup_ahu_C', 'Ths_sys_sup_aru_C', 'Ths_sys_sup_shu_C',
@@ -142,8 +143,8 @@ def substation_main(locator, total_demand, building_names, heating_configuration
             T_hs_intermediate_2 = np.vectorize(calc_DH_return)(Ths_ahu_return, Ths_aru_return)
             Ths_return = np.vectorize(calc_DH_return)(T_hs_intermediate_2, Ths_shu_return)
         elif heating_configuration == 0: # when there is no heating requirement from the centralized plant
-            Ths_supply = np.zeros(8760)
-            Ths_return = np.zeros(8760)
+            Ths_supply = np.zeros(HOURS_IN_YEAR)
+            Ths_return = np.zeros(HOURS_IN_YEAR)
         else:
             raise ValueError('wrong heating configuration specified in substation_main!')
 
@@ -184,8 +185,8 @@ def substation_main(locator, total_demand, building_names, heating_configuration
             T_space_cooling_intermediate_2 = np.vectorize(calc_DC_return)(Tcs_ahu_return, Tcs_aru_return)
             Tcs_return = np.vectorize(calc_DC_return)(T_space_cooling_intermediate_2, Tcs_scu_return)
         elif cooling_configuration == 0:
-            Tcs_supply = np.zeros(8760) + 1E6
-            Tcs_return = np.zeros(8760) - 1E6
+            Tcs_supply = np.zeros(HOURS_IN_YEAR) + 1E6
+            Tcs_return = np.zeros(HOURS_IN_YEAR) - 1E6
         else:
             raise ValueError('wrong heating configuration specified in substation_main!')
 
@@ -278,10 +279,10 @@ def substation_model(building, DHN_supply, DCN_supply, cs_temperatures, hs_tempe
     # fixme: this is the wrong aggregation! the mcp should be recalculated according to the updated Tsup/re, and this does not aggregate the domestic hot water
 
     if hs_configuration == 0:
-        t_DH_return_hs = np.zeros(8760)
-        mcp_DH_hs = np.zeros(8760)
+        t_DH_return_hs = np.zeros(HOURS_IN_YEAR)
+        mcp_DH_hs = np.zeros(HOURS_IN_YEAR)
         A_hex_hs = 0
-        Qhs_sys_W = np.zeros(8760)
+        Qhs_sys_W = np.zeros(HOURS_IN_YEAR)
     else:
         thi = DHN_supply['T_DH_supply_C'] + 273  # In k
         Qhs_sys_W = Qhs_sys_kWh_dict[hs_configuration] * 1000  # in W
@@ -298,10 +299,10 @@ def substation_model(building, DHN_supply, DCN_supply, cs_temperatures, hs_tempe
             t_DH_return_hs, mcp_DH_hs, A_hex_hs = \
                 calc_substation_heating(Qhs_sys_W, thi, tco, tci, cc, cc_0, Qnom_W, thi_0, tci_0, tco_0)
         else:
-            t_DH_return_hs = np.zeros(8760)
-            mcp_DH_hs = np.zeros(8760)
+            t_DH_return_hs = np.zeros(HOURS_IN_YEAR)
+            mcp_DH_hs = np.zeros(HOURS_IN_YEAR)
             A_hex_hs = 0
-            tci = np.zeros(8760) + 273  # in K
+            tci = np.zeros(HOURS_IN_YEAR) + 273  # in K
 
     # HEX sizing for domestic hot water, calculate t_DH_return_ww, mcp_DH_ww
     Qww_sys_W = building.Qww_sys_kWh.values * 1000  # in W
@@ -319,10 +320,10 @@ def substation_model(building, DHN_supply, DCN_supply, cs_temperatures, hs_tempe
         t_DH_return_ww, mcp_DH_ww, A_hex_ww = \
             calc_substation_heating(Qww_sys_W, thi, tco, tci, cc, cc_0, Qnom_W, thi_0, tci_0, tco_0)
     else:
-        t_DH_return_ww = np.zeros(8760)
+        t_DH_return_ww = np.zeros(HOURS_IN_YEAR)
         A_hex_ww = 0
-        mcp_DH_ww = np.zeros(8760)
-        tci = np.zeros(8760) + 273  # in K
+        mcp_DH_ww = np.zeros(HOURS_IN_YEAR)
+        tci = np.zeros(HOURS_IN_YEAR) + 273  # in K
 
 
     # calculate mix temperature of return DH
@@ -350,7 +351,7 @@ def substation_model(building, DHN_supply, DCN_supply, cs_temperatures, hs_tempe
         t_DC_return_cs = tci
         mcp_DC_cs = 0
         A_hex_cs = 0
-        Qcs_sys_W = np.zeros(8760)
+        Qcs_sys_W = np.zeros(HOURS_IN_YEAR)
     else:
         tci = DCN_supply['T_DC_supply_to_cs_ref_data_C'] + 273 # fixme: change according to cs_ref or ce_ref_data
         Qcs_sys_W = abs(Qcs_sys_kWh_dict[cs_configuration]) * 1000  # in W
@@ -378,7 +379,7 @@ def substation_model(building, DHN_supply, DCN_supply, cs_temperatures, hs_tempe
         t_DC_return_ref = tci
         mcp_DC_ref = 0
         A_hex_ref = 0
-        Qcre_sys_W = np.zeros(8760)
+        Qcre_sys_W = np.zeros(HOURS_IN_YEAR)
 
     else:
         Qcre_sys_W = abs(building.Qcre_sys_kWh.values) * 1000  # in W
@@ -404,7 +405,7 @@ def substation_model(building, DHN_supply, DCN_supply, cs_temperatures, hs_tempe
         t_DC_return_data = tci
         mcp_DC_data = 0
         A_hex_data = 0
-        Qcdata_sys_W = np.zeros(8760)
+        Qcdata_sys_W = np.zeros(HOURS_IN_YEAR)
 
     else:
         Qcdata_sys_W = (abs(building.Qcdata_sys_kWh.values) * 1000)

--- a/cea/tests/test_schedules.py
+++ b/cea/tests/test_schedules.py
@@ -17,6 +17,7 @@ from cea.demand.occupancy_model import schedule_maker
 from cea.utilities import epwreader
 import cea.config
 from cea.demand.building_properties import BuildingProperties
+from cea.constants import HOURS_IN_YEAR
 
 REFERENCE_TIME = 3456
 
@@ -61,7 +62,7 @@ class TestScheduleCreation(unittest.TestCase):
         # get year from weather file
         weather_data = epwreader.epw_reader(config.weather)[['year']]
         year = weather_data['year'][0]
-        date = pd.date_range(str(year) + '/01/01', periods=8760, freq='H')
+        date = pd.date_range(str(year) + '/01/01', periods=HOURS_IN_YEAR, freq='H')
 
         building_properties = BuildingProperties(locator, False, False)
         bpr = building_properties['B01']
@@ -126,7 +127,7 @@ def create_test_data():
     # get year from weather file
     weather_data = epwreader.epw_reader(config.weather)[['year']]
     year = weather_data['year'][0]
-    date = pd.date_range(str(year) + '/01/01', periods=8760, freq='H')
+    date = pd.date_range(str(year) + '/01/01', periods=HOURS_IN_YEAR, freq='H')
 
     archetype_schedules, archetype_values = schedule_maker('CH', date, locator, list_uses)
     stochastic_occupancy = config.demand.use_stochastic_occupancy

--- a/cea/utilities/epwreader.py
+++ b/cea/utilities/epwreader.py
@@ -28,7 +28,7 @@ def epw_reader(weather_path):
                   'snowdepth_cm', 'days_last_snow', 'Albedo', 'liq_precip_depth_mm', 'liq_precip_rate_Hour']
 
     result = pd.read_csv(weather_path, skiprows=8, header=None, names=epw_labels).drop('datasource', axis=1)
-    result = result.loc[0:8759]
+    result = result.loc[0:HOURS_IN_YEAR]
     result['date'] = pd.Series(pd.date_range(str(result["year"][0])+"/1/1", periods=HOURS_IN_YEAR, freq='H'))
     result['dayofyear'] = pd.date_range(str(result["year"][0])+"/1/1", periods=HOURS_IN_YEAR, freq='H').dayofyear
     result['ratio_diffhout'] = result['difhorrad_Whm2'] / result['glohorrad_Whm2']

--- a/cea/utilities/epwreader.py
+++ b/cea/utilities/epwreader.py
@@ -28,7 +28,7 @@ def epw_reader(weather_path):
                   'snowdepth_cm', 'days_last_snow', 'Albedo', 'liq_precip_depth_mm', 'liq_precip_rate_Hour']
 
     result = pd.read_csv(weather_path, skiprows=8, header=None, names=epw_labels).drop('datasource', axis=1)
-    result = result.loc[0:HOURS_IN_YEAR]
+    result = result.loc[0:HOURS_IN_YEAR-1]
     result['date'] = pd.Series(pd.date_range(str(result["year"][0])+"/1/1", periods=HOURS_IN_YEAR, freq='H'))
     result['dayofyear'] = pd.date_range(str(result["year"][0])+"/1/1", periods=HOURS_IN_YEAR, freq='H').dayofyear
     result['ratio_diffhout'] = result['difhorrad_Whm2'] / result['glohorrad_Whm2']

--- a/cea/utilities/epwreader.py
+++ b/cea/utilities/epwreader.py
@@ -27,6 +27,7 @@ def epw_reader(weather_path):
                   'snowdepth_cm', 'days_last_snow', 'Albedo', 'liq_precip_depth_mm', 'liq_precip_rate_Hour']
 
     result = pd.read_csv(weather_path, skiprows=8, header=None, names=epw_labels).drop('datasource', axis=1)
+    result = result.loc[0:8759]
     result['date'] = pd.Series(pd.date_range(str(result["year"][0])+"/1/1", periods=8760, freq='H'))
     result['dayofyear'] = pd.date_range(str(result["year"][0])+"/1/1", periods=8760, freq='H').dayofyear
     result['ratio_diffhout'] = result['difhorrad_Whm2'] / result['glohorrad_Whm2']

--- a/cea/utilities/epwreader.py
+++ b/cea/utilities/epwreader.py
@@ -7,6 +7,7 @@ import math
 import cea.inputlocator
 import numpy as np
 from cea.utilities.physics import BOLTZMANN
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Clayton Miller"
 __copyright__ = "Copyright 2014, Architecture and Building Systems - ETH Zurich"
@@ -28,8 +29,8 @@ def epw_reader(weather_path):
 
     result = pd.read_csv(weather_path, skiprows=8, header=None, names=epw_labels).drop('datasource', axis=1)
     result = result.loc[0:8759]
-    result['date'] = pd.Series(pd.date_range(str(result["year"][0])+"/1/1", periods=8760, freq='H'))
-    result['dayofyear'] = pd.date_range(str(result["year"][0])+"/1/1", periods=8760, freq='H').dayofyear
+    result['date'] = pd.Series(pd.date_range(str(result["year"][0])+"/1/1", periods=HOURS_IN_YEAR, freq='H'))
+    result['dayofyear'] = pd.date_range(str(result["year"][0])+"/1/1", periods=HOURS_IN_YEAR, freq='H').dayofyear
     result['ratio_diffhout'] = result['difhorrad_Whm2'] / result['glohorrad_Whm2']
     result['skycover'] = result['ratio_diffhout'].fillna(1)
     result['wetbulb_C'] = np.vectorize(calc_wetbulb)(result['drybulb_C'], result['relhum_percent'])

--- a/cea/utilities/reporting.py
+++ b/cea/utilities/reporting.py
@@ -6,6 +6,7 @@ import pandas as pd
 import os
 from plotly.offline import plot
 import plotly.graph_objs as go
+from cea.constants import HOURS_IN_YEAR
 
 
 
@@ -82,7 +83,7 @@ def quick_visualization_tsd(tsd, output_folder, basename):
         traces = []
         for key in TSD_KEYS_COOLING_LOADS:
             y = tsd[key]
-            trace = go.Scatter(x=np.linspace(1, 8760, 8760), y=y, name=key, mode='lines+markers')
+            trace = go.Scatter(x=np.linspace(1, HOURS_IN_YEAR, HOURS_IN_YEAR), y=y, name=key, mode='lines+markers')
             traces.append(trace)
         fig = go.Figure(data=traces)
         plot(fig, filename=filename, auto_open=auto_open)
@@ -92,7 +93,7 @@ def quick_visualization_tsd(tsd, output_folder, basename):
         traces = []
         for key in TSD_KEYS_MOISTURE:
             y = tsd[key]
-            trace = go.Scatter(x=np.linspace(1, 8760, 8760), y=y, name=key, mode='lines+markers')
+            trace = go.Scatter(x=np.linspace(1, HOURS_IN_YEAR, HOURS_IN_YEAR), y=y, name=key, mode='lines+markers')
             traces.append(trace)
         fig = go.Figure(data=traces)
         plot(fig, filename=filename, auto_open=auto_open)
@@ -102,7 +103,7 @@ def quick_visualization_tsd(tsd, output_folder, basename):
         traces = []
         for key in TSD_KEYS_VENTILATION_FLOWS:
             y = tsd[key]
-            trace = go.Scatter(x=np.linspace(1, 8760, 8760), y=y, name=key, mode='lines+markers')
+            trace = go.Scatter(x=np.linspace(1, HOURS_IN_YEAR, HOURS_IN_YEAR), y=y, name=key, mode='lines+markers')
             traces.append(trace)
         fig = go.Figure(data=traces)
         plot(fig, filename=filename, auto_open=auto_open)
@@ -115,7 +116,7 @@ def quick_visualization_tsd(tsd, output_folder, basename):
         keys.extend(TSD_KEYS_COOLING_SUPPLY_FLOWS)
         for key in keys:
             y = tsd[key]
-            trace = go.Scatter(x=np.linspace(1, 8760, 8760), y=y, name=key, mode='lines+markers')
+            trace = go.Scatter(x=np.linspace(1, HOURS_IN_YEAR, HOURS_IN_YEAR), y=y, name=key, mode='lines+markers')
             traces.append(trace)
         fig = go.Figure(data=traces)
         plot(fig, filename=filename, auto_open=auto_open)

--- a/cea/utilities/solar_equations.py
+++ b/cea/utilities/solar_equations.py
@@ -11,6 +11,7 @@ import collections
 from math import *
 from timezonefinder import TimezoneFinder
 import pytz
+from cea.constants import HOURS_IN_YEAR
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2015, Architecture and Building Systems - ETH Zurich"
@@ -89,7 +90,7 @@ SunProperties = collections.namedtuple('SunProperties', ['g', 'Sz', 'Az', 'ha', 
 def calc_datetime_local_from_weather_file(weather_data, latitude, longitude):
     # read date from the weather file
     year = weather_data['year'][0]
-    datetime = pd.date_range(str(year) + '/01/01', periods=8760, freq='H')
+    datetime = pd.date_range(str(year) + '/01/01', periods=HOURS_IN_YEAR, freq='H')
 
     # get local time zone
     etc_timezone = get_local_etc_timezone(latitude, longitude)

--- a/legacy/radiation_arcgis/calculate_incident_radiation.py
+++ b/legacy/radiation_arcgis/calculate_incident_radiation.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from cea.constants import HOURS_IN_YEAR
 
 
 def calculate_incident_radiation(radiation, radiation_csv):
@@ -11,8 +12,7 @@ def calculate_incident_radiation(radiation, radiation_csv):
     """
 
     # Import Radiation table and compute the Irradiation in W in every building's surface
-    hours_in_year = 8760
-    column_names = ['T%i' % (i + 1) for i in range(hours_in_year)]
+    column_names = ['T%i' % (i + 1) for i in range(HOURS_IN_YEAR)]
     for column in column_names:
         # transform all the points of solar radiation into Wh
         radiation[column] = radiation[column] * radiation['Awall_all']


### PR DESCRIPTION
The length of a year is hard-coded as 8760 hours, which is reasonable for a "standard" year.

When running a simulation with measured weather data, however, the measured data might be longer than that - if it's a leap year.

The most practical solution (and consistent in order to make results comparable cross-year) is to force the weather data to be 8760 hours long.