### PR TITLE
Split coordinates to lat lon input

### DIFF
--- a/cea/interfaces/dashboard/landing/static/landing_map.js
+++ b/cea/interfaces/dashboard/landing/static/landing_map.js
@@ -3,12 +3,12 @@ var latlngs = [];
 var temp = [];
 var polygon = L.polygon(latlngs, {color: 'red'});
 // var temppoly = L.polygon(temp, {color: 'red'});
-var latlon = $("#coordinates").val().split(/[,\s]/);
-console.log(latlon)
+var lat = $("#latitude").val();
+var lon = $("#longitude").val();
 
 // const lassoResult = document.querySelector("#lassoResult");
 
-map = L.map('mapid').setView([latlon[0], latlon[latlon.length-1]], 11);
+map = L.map('mapid').setView([lat, lon], 11);
 
 L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png',
     {attribution: "Data copyright OpenStreetMap contributors"}).addTo(map);
@@ -19,8 +19,9 @@ map.on('click', onMapClick);
 	// map.on('mousemove', onMapHover);
 
 function goToLocation() {
-	var latlon = $("#coordinates").val().split(/[,\s]/);
-	map.setView([latlon[0], latlon[latlon.length-1]], 11);
+	var lat = $("#latitude").val();
+	var lon = $("#longitude").val();
+	map.setView([lat, lon], 11);
 }
 
 function onMapClick(e) {

--- a/cea/interfaces/dashboard/landing/templates/project_map.html
+++ b/cea/interfaces/dashboard/landing/templates/project_map.html
@@ -17,22 +17,22 @@
     <br>
     <form id="map-location" class="form-horizontal form-label-left" action="javascript:;" onsubmit="goToLocation()">
         <div class="form-group">
-            <label class="control-label col-md-3 col-sm-3 col-xs-12" for="coordinates">Coordinates of site</label>
             <div class="col-md-6 col-sm-6 col-xs-12">
+            <label class="control-label" for="latitude">Latitude</label>
+                 <input type="text" class="form-control" placeholder="Latitude"
+                        id="latitude" name="latitude" value="1.3521">
+            </div>
 
-                <div class="input-group">
-                    <input type="text" class="form-control" placeholder="Latitude, Longitude"
-                           id="coordinates" name="coordinates" value="1.3521, 103.8198">
-                    <div class="input-group-btn">
-                        <button class="btn btn-file-parameter" type="button" onclick="goToLocation()">Go</button>
-                    </div>
-                </div>
+            <div class="col-md-6 col-sm-6 col-xs-12">
+            <label class="control-label" for="longitude">Longitude</label>
+            <input type="text" class="form-control" placeholder="Longitude"
+                       id="longitude" name="longitude" value="103.8198">
             </div>
         </div>
     </form>
 
     <div style="text-align: center">
-        <div id="mapid" style="width: 600px; height: 400px;"></div>
+        <div id="mapid" style="width: 600px; height: 400px; display: inline-block;"></div>
 {#        <div id="lassoResult"></div>#}
         <button onclick="removePoly()">Clear</button>
         <button onclick="createPoly('{{ scenario }}')">Done</button>

--- a/cea/interfaces/dashboard/landing/templates/project_map.html
+++ b/cea/interfaces/dashboard/landing/templates/project_map.html
@@ -18,17 +18,24 @@
     <form id="map-location" class="form-horizontal form-label-left" action="javascript:;" onsubmit="goToLocation()">
         <div class="form-group">
             <div class="col-md-6 col-sm-6 col-xs-12">
-            <label class="control-label" for="latitude">Latitude</label>
-                 <input type="text" class="form-control" placeholder="Latitude"
-                        id="latitude" name="latitude" value="1.3521">
+                <label class="control-label" for="latitude">Latitude</label>
+                <input type="text" class="form-control" placeholder="Latitude"
+                       id="latitude" name="latitude" value="1.3521" required>
             </div>
 
             <div class="col-md-6 col-sm-6 col-xs-12">
-            <label class="control-label" for="longitude">Longitude</label>
-            <input type="text" class="form-control" placeholder="Longitude"
-                       id="longitude" name="longitude" value="103.8198">
+                <label class="control-label" for="longitude">Longitude</label>
+                <div class="input-group">
+                    <input type="text" class="form-control" placeholder="Longitude"
+                           id="longitude" name="longitude" value="103.8198" required>
+                    <div class="input-group-btn">
+                        <button class="btn" type="button" onclick="goToLocation()">Go</button>
+                    </div>
+                </div>
+
             </div>
         </div>
+
     </form>
 
     <div style="text-align: center">


### PR DESCRIPTION
This PR resolves #1934. It separates the coordinates input in the map tool to two separate latitude and longitude inputs.