### PR TITLE
1938 relocate sidepanel links

### DIFF
--- a/cea/interfaces/dashboard/base/templates/site_template/sidebar.html
+++ b/cea/interfaces/dashboard/base/templates/site_template/sidebar.html
@@ -13,17 +13,12 @@
     <div class="menu_section">
       <h3>City Energy Analyst</h3>
       <ul class="nav side-menu">
-        <li><a><i class="fa fa-bar-chart"></i> Dashboard <span class="fa fa-chevron-down"></span></a>
+        <li><a><i class="fa fa-file-text"></i> Project Management <span class="fa fa-chevron-down"></span></a>
           <ul class="nav child_menu">
-            {% for dashboard in dashboards %}
-                <li><a href="{{ url_for('plots_blueprint.route_dashboard', dashboard_index=loop.index0) }}">{{ dashboard.name }}</a></li>
-            {% endfor %}
-            <li><a href="{{ url_for('plots_blueprint.route_new_dashboard') }}"><i>add new dashboard</i></a></li>
-          </ul>
-        </li>
-        <li><a><i class="fa fa-map-marker"></i> Project <span class="fa fa-chevron-down"></span></a>
-          <ul class="nav child_menu">
-            <li><a href="/project/show">Project data</a></li>
+            <li><a href="{{ url_for('landing_blueprint.route_project_overview') }}">Project Overview</a></li>
+            <li><a href="{{ url_for('landing_blueprint.route_open_project') }}">Open Project</a></li>
+            <li><a href="{{ url_for('landing_blueprint.route_create_project') }}">New Project</a></li>
+            <li><a href="{{ url_for('landing_blueprint.route_create_scenario') }}">New Scenario</a></li>
           </ul>
         </li>
         <li><a><i class="fa fa-building-o"></i> Inputs <span class="fa fa-chevron-down"></span></a>
@@ -42,23 +37,22 @@
         <li><a><i class="fa fa-cog"></i> Tools <span class="fa fa-chevron-down"></span></a>
           <ul class="nav child_menu">
             {% for tool_category in tools.keys()|sort %}
-            <li><a href="#">{{tool_category}} <span class="fa fa-chevron-down"></span></a>
-              <ul class="nav child_menu">
-                {% for tool in tools[tool_category] %}
-                <li><a href="/tools/{{tool.name}}">{{tool.label}}</a></li>
-                {% endfor %}
-              </ul>
-            </li>
+              <li><a href="#">{{tool_category}} <span class="fa fa-chevron-down"></span></a>
+                <ul class="nav child_menu">
+                  {% for tool in tools[tool_category] %}
+                    <li><a href="/tools/{{tool.name}}">{{tool.label}}</a></li>
+                  {% endfor %}
+                </ul>
+              </li>
             {% endfor %}
           </ul>
         </li>
-
-        <li><a><i class="fa fa-file-text"></i> Project Management <span class="fa fa-chevron-down"></span></a>
+        <li><a><i class="fa fa-bar-chart"></i> Dashboard <span class="fa fa-chevron-down"></span></a>
           <ul class="nav child_menu">
-            <li><a href="{{ url_for('landing_blueprint.route_project_overview') }}">Project Overview</a></li>
-            <li><a href="{{ url_for('landing_blueprint.route_open_project') }}">Open Project</a></li>
-            <li><a href="{{ url_for('landing_blueprint.route_create_project') }}">New Project</a></li>
-              <li><a href="{{ url_for('landing_blueprint.route_create_scenario') }}">New Scenario</a></li>
+            {% for dashboard in dashboards %}
+              <li><a href="{{ url_for('plots_blueprint.route_dashboard', dashboard_index=loop.index0) }}">{{ dashboard.name }}</a></li>
+            {% endfor %}
+            <li><a href="{{ url_for('plots_blueprint.route_new_dashboard') }}"><i>add new dashboard</i></a></li>
           </ul>
         </li>
       </ul>
@@ -87,7 +81,7 @@
 
   <!-- /menu footer buttons -->
   <div class="sidebar-footer hidden-small">
-    <a data-toggle="tooltip" data-placement="top" title="Settings">
+    <a data-toggle="tooltip" data-placement="top" title="Settings" href="/project/show">
       <span class="glyphicon glyphicon-cog" aria-hidden="true"></span>
     </a>
     <a data-toggle="tooltip" data-placement="top" title="FullScreen">

--- a/cea/interfaces/dashboard/base/templates/site_template/sidebar.html
+++ b/cea/interfaces/dashboard/base/templates/site_template/sidebar.html
@@ -33,8 +33,7 @@
             <li><a href="/inputs/table/restrictions">Restrictions</a></li>
           </ul>
         </li>
-
-        <li><a><i class="fa fa-cog"></i> Tools <span class="fa fa-chevron-down"></span></a>
+        <li><a><i class="fa fa-wrench"></i> Tools <span class="fa fa-chevron-down"></span></a>
           <ul class="nav child_menu">
             {% for tool_category in tools.keys()|sort %}
               <li><a href="#">{{tool_category}} <span class="fa fa-chevron-down"></span></a>


### PR DESCRIPTION
This PR resolves #1938. The sidebar navigation links are relocated accordingly, with project management at the top and dashboard at the bottom. Project navigation link is moved to the settings icon at the bottom left. Icon for tools is also changed to not look like the settings icon.