### PR TITLE
Update inputs.yml

### DIFF
--- a/cea/interfaces/dashboard/inputs/inputs.yml
+++ b/cea/interfaces/dashboard/inputs/inputs.yml
@@ -21,12 +21,8 @@ district:
   fields:
   - name: Name
     type: str
-  - name: floors_bg
-    type: int
   - name: floors_ag
     type: int
-  - name: height_bg
-    type: float
   - name: height_ag
     type: float
 age:


### PR DESCRIPTION
This PR resolves #1933. The dashboard is now able to show district input data after omitting the below ground attributes since it is not used during simulation.