### PR TITLE
Retain dtypes of dataframe columns

### DIFF
--- a/cea/datamanagement/data_helper.py
+++ b/cea/datamanagement/data_helper.py
@@ -16,6 +16,7 @@ import pandas as pd
 import cea.config
 import cea.inputlocator
 from cea.utilities.dbf import dbf_to_dataframe, dataframe_to_dbf
+from cea.datamanagement.databases_verification import COLUMNS_ZONE_OCCUPANCY
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2015, Architecture and Building Systems - ETH Zurich"
@@ -64,7 +65,14 @@ def data_helper(locator, config, prop_architecture_flag, prop_hvac_flag, prop_co
     # get occupancy and age files
     region_database = config.data_helper.region
     building_occupancy_df = dbf_to_dataframe(locator.get_building_occupancy())
-    list_uses = list(building_occupancy_df.drop(['Name'], axis=1).columns)  # parking excluded in U-Values
+    columns = building_occupancy_df.columns
+
+    #validate list of uses
+    list_uses = []
+    for name in columns:
+        if name in COLUMNS_ZONE_OCCUPANCY:
+            list_uses.append(name)
+
     building_age_df = dbf_to_dataframe(locator.get_building_age())
 
     #get technology database

--- a/cea/interfaces/dashboard/inputs/routes.py
+++ b/cea/interfaces/dashboard/inputs/routes.py
@@ -131,10 +131,14 @@ def route_table_post(db):
 
     # copy data from form POST data
     new_data = json.loads(request.form.get('cea-table-data'))
+    column_types = table_df.dtypes
     for row in new_data:
         for column in row.keys():
             table_df.loc[table_df[pk] == row[pk], column] = row[column]
     print table_df
+    # allow columns to maintain their original type
+    for (types, column) in zip(column_types, table_df):
+        table_df[column] = table_df[column].astype(types)
 
     # safe dataframe back to disk
     if db_info['type'] == 'shp':


### PR DESCRIPTION
This PR fixes #1964. Users should now be able to edit and save any updates to the input databases from the dashboard.

To test, try to update and save any changes to any of the input databases from the dashboard.