### PR TITLE
Fix for cea install-grasshopper

### DIFF
--- a/cea/interfaces/grasshopper/install_grasshopper.py
+++ b/cea/interfaces/grasshopper/install_grasshopper.py
@@ -51,7 +51,6 @@ def copy_config(scripts_folder):
 
     cea_dst_folder = get_cea_dst_folder(scripts_folder)
     cea_src_folder = os.path.dirname(cea.config.__file__)
-    shutil.copy(os.path.join(cea_src_folder, 'concept_parameters.py'), cea_dst_folder)
     shutil.copy(os.path.join(cea_src_folder, 'default.config'), cea_dst_folder)
     shutil.copy(os.path.join(cea_src_folder, '__init__.py'), cea_dst_folder)
 


### PR DESCRIPTION
A tiny Bugfix for the `cea install-grasshopper` command: I did a `git log --full-history -- cea/concept_parameters.py` according to [this answer on stackoverflow](https://stackoverflow.com/questions/6839398/find-when-a-file-was-deleted-in-git) - I'm pretty sure that file never ever existed and explains the bug @shizhongming is having with https://github.com/architecture-building-systems/CityEnergyAnalyst/issues/1896#issuecomment-493307814

@shizhongming would you mind testing this to see if it solves the problem? thank you!