### PR TITLE
2019.05.17 some documentation fixes

### DIFF
--- a/cea/api.py
+++ b/cea/api.py
@@ -13,10 +13,11 @@ def register_scripts():
     config = cea.config.Configuration()
 
     def script_wrapper(cea_script):
+        module_path = cea_script.module
+        script_module = importlib.import_module(module_path)
+        
         def script_runner(config=config, **kwargs):
             option_list = cea_script.parameters
-            module_path = cea_script.module
-            script_module = importlib.import_module(module_path)
             config.restrict_to(option_list)
             for section, parameter in config.matching_parameters(option_list):
                 parameter_py_name = parameter.name.replace('-', '_')
@@ -25,6 +26,10 @@ def register_scripts():
             # run the script
             cea_script.print_script_configuration(config)
             script_module.main(config)
+        if script_module.__doc__:
+            script_runner.__doc__ = script_module.__doc__.strip()
+        else:
+            script_runner.__doc__ = 'FIXME: Add API documentation to {}'.format(module_path)
         return script_runner
 
     for cea_script in sorted(cea.scripts.list_scripts()):
@@ -33,3 +38,7 @@ def register_scripts():
 
 
 register_scripts()
+
+
+if __name__ == '__main__':
+    print(demand.__doc__)

--- a/cea/api.py
+++ b/cea/api.py
@@ -15,7 +15,7 @@ def register_scripts():
     def script_wrapper(cea_script):
         module_path = cea_script.module
         script_module = importlib.import_module(module_path)
-        
+
         def script_runner(config=config, **kwargs):
             option_list = cea_script.parameters
             config.restrict_to(option_list)

--- a/cea/config.py
+++ b/cea/config.py
@@ -182,10 +182,6 @@ class Configuration(object):
         section, parameter = fqname.split(':')
         return self.sections[section].parameters[parameter]
 
-    def __repr__(self):
-        """Sometimes it would be nice to have a printable version of the config..."""
-        return repr({s.name: {p.name: p for p in s.parameters.values()} for s in self.sections.values()})
-
 
 def parse_command_line_args(args):
     """Group the arguments into a dictionary: parameter-name -> value"""

--- a/cea/datamanagement/district_geometry_helper.py
+++ b/cea/datamanagement/district_geometry_helper.py
@@ -35,8 +35,8 @@ def alpha_shape(points, alpha):
     """
     Compute the alpha shape (concave hull) of a set of points.
 
-    @param points: Iterable container of points.
-    @param alpha: alpha value to influence the gooeyness of the border. Smaller
+    :param points: Iterable container of points.
+    :param alpha: alpha value to influence the gooeyness of the border. Smaller
                   numbers don't fall inward as much as larger numbers. Too large,
                   and you lose everything!
     """

--- a/cea/scripts.yml
+++ b/cea/scripts.yml
@@ -346,12 +346,12 @@ default:
   module: cea.interfaces.cli.list_demand_graphs_fields
   parameters: ['general:scenario']
 
-- name: scenario-plots
-  label: scenario-plots
-  description: scenario-plots
-  interfaces: [cli]
-  module: cea.plots.scenario_plots
-  parameters: [scenario-plots]
+#- name: scenario-plots
+#  label: scenario-plots
+#  description: scenario-plots
+#  interfaces: [cli]
+#  module: cea.plots.scenario_plots
+#  parameters: [scenario-plots]
 
 - name: shapefile-to-excel
   label: shapefile-to-excel

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,12 +27,18 @@ sys.path.insert(0, os.path.abspath('../cea'))
 
 # mock out some imports so we don't have conflicts on the readthedocs server...
 class Mock(MagicMock):
+    __all__ = []
     @classmethod
     def __getattr__(cls, name):
             return MagicMock()
 
 
 MOCK_MODULES = ['COLOR',
+                'concept',
+                'concept.algorithm_planning_and_operation',
+                'concept.algorithm_planning_and_operation.planning_and_operation_main',
+                'CoolProp',
+                'CoolProp.HumidAirProp',
                 'SALib',
                 'SALib.analyze',
                 'SALib.analyze',
@@ -83,9 +89,11 @@ MOCK_MODULES = ['COLOR',
                 'OCC.gp',
                 'OCC.TopoDS',
                 'OCC.IntCurvesFace',
+                'osmnx',
                 'plotly',
                 'plotly.graph_objs',
                 'plotly.offline',
+                'pvlib',
                 'pyDOE',
                 'pycollada',
                 'py4design',
@@ -99,6 +107,8 @@ MOCK_MODULES = ['COLOR',
                 'py4design.pycitygml',
                 'py4design.shp2citygml',
                 'py4design.py3dmodel.utility',
+                'pyomo',
+                'pyomo.environ',
                 'pyproj',
                 'pysal',
                 'pyshp',

--- a/docs/how-are-schedules-defined.rst
+++ b/docs/how-are-schedules-defined.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 How are schedules defined?
 ==========================
 

--- a/docs/how-to-run-thermal-network-optimization.rst
+++ b/docs/how-to-run-thermal-network-optimization.rst
@@ -73,10 +73,16 @@ The default layout is branch when ``optimize-loop-branch = False``.
 
 Network Load
 ^^^^^^^^^^^^
-**WARNING: This functionality is not available yet, see github issue `#1757 <https://github.com/architecture-building-systems/CityEnergyAnalyst/issues/1757>`_. **
+
+.. warning::
+
+    This functionality is not available yet, see GitHub issue #1757_.
+
+.. _#1757: https://github.com/architecture-building-systems/CityEnergyAnalyst/issues/1757
 
 The optimization can evaluate which loads from the space heating/cooling systems to supply by the network.
-The space heating/cooling loads are divided into the loads from three units: Air Handling Units (AHU), Recirculated Air Units (RAU), and Sensible Cooling/Heating Units (SCU/SHU).
+The space heating/cooling loads are divided into the loads from three units: Air Handling Units (AHU), Recirculated
+Air Units (RAU), and Sensible Cooling/Heating Units (SCU/SHU).
 Since all three units require different supply temperatures, therefore, it will affect thermal network performance.
 To enable this variable, set ``optimize-network-loads = True``
 

--- a/docs/how-to-set-up-nsis.rst
+++ b/docs/how-to-set-up-nsis.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 How to set up NSIS
 ==================
 

--- a/docs/installation-guide-ubuntu.rst
+++ b/docs/installation-guide-ubuntu.rst
@@ -25,20 +25,26 @@ Prerequisites
   - ``sudo apt-get install git``
 
 #. Download and install `Daysim <https://daysim.ning.com/page/download>`__.
+
   - ``git clone https://github.com/MITSustainableDesignLab/Daysim.git``
   - ``mkdir build``
   - ``cd build``
   - if you don't have cmake installed, you can use ``sudo apt-get install cmake`` to install it.
+
     - Other packages that are missing in minimal setup of Ubuntu and need to be installedwith apt-get are:
+
       - ``sudo apt-get install build-essential`` (for error "No CMAKE_CXX_Compiler could be found.")
       - ``sudo apt-get install libgl1-mesa-dev`` (for error "Could NOT find OpenGL")
       - ``sudo apt-get install freeglut3-dev`` (for error "GL/glu.h: No such file or directory" while running ``make`` below)
+
   - ``cmake -DBUILD_HEADLESS=on -DCMAKE_INSTALL_PREFIX=$HOME/Daysim ../Daysim``
   - ``make``
   - ``make install``
   - open the file ``~/tmp/Daysim/CMakeLists.txt`` in your favorite text editor (the one that comes with Ubuntu is fine)
+
     - add a line just below the line "project (daysim VERSION 5.2.0)": ``add_definitions(-DDAYSIM)``
     - save and return to terminal
+
   - ``cmake -DBUILD_HEADLESS=on -DCMAKE_INSTALL_PREFIX=$HOME/Daysim ../Daysim``
   - ``make``
   - ``mv ./bin/rtrace ./bin/rtrace_dc``

--- a/docs/script-input-outputs.rst
+++ b/docs/script-input-outputs.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Script input and output files
 =============================
 This section aims to clarify the files used (inputs) or created (outputs) by each script, along with the methods used
@@ -417,77 +419,6 @@ solar-collector
     "solar-collector" -> "{BUILDING}_SC_ET.csv"[label="(SC_results)"]
     "solar-collector" -> "SC_ET_total_buildings.csv"[label="(SC_total_buildings)"]
     "solar-collector" -> "SC_ET_total.csv"[label="(SC_totals)"]
-    }
-
-digraph trace_inputlocator {
-    rankdir="LR";
-    graph [overlap=false, fontname=arial];
-    node [shape=box, style=filled, color=white, fontsize=15, fontname=arial, fixedsize=true, width=3.5];
-    edge [fontname=arial, fontsize = 15]
-    newrank=true
-    subgraph cluster_legend {
-    fontsize=25
-    style=invis
-    "process"[style=filled, fillcolor="#3FC0C2", shape=note, fontsize=20, fontname="arial"]
-    "inputs" [style=filled, shape=folder, color=white, fillcolor="#E1F2F2", fontsize=20]
-    "outputs"[style=filled, shape=folder, color=white, fillcolor="#aadcdd", fontsize=20]
-    "inputs"->"process"[style=invis]
-    "process"->"outputs"[style=invis]
-    }
-    "solar-collector"[style=filled, color=white, fillcolor="#3FC0C2", shape=note, fontsize=20, fontname=arial];
-    subgraph cluster_0_in {
-        style = filled;
-        color = "#E1F2F2";
-        fontsize = 20;
-        rank=same;
-        label="cea/databases/weather";
-        "Zug.epw"
-    }
-    subgraph cluster_1_in {
-        style = filled;
-        color = "#E1F2F2";
-        fontsize = 20;
-        rank=same;
-        label="databases/CH/systems";
-        "supply_systems.xls"
-    }
-    subgraph cluster_2_in {
-        style = filled;
-        color = "#E1F2F2";
-        fontsize = 20;
-        rank=same;
-        label="inputs/building-geometry";
-        "zone.shp"
-    }
-    subgraph cluster_3_out {
-        style = filled;
-        color = "#aadcdd";
-        fontsize = 20;
-        rank=same;
-        label="outputs/data/potentials/solar";
-        "{BUILDING}_SC_FP_sensors.csv"
-        "{BUILDING}_SC_FP.csv"
-        "SC_FP_total_buildings.csv"
-        "SC_FP_total.csv"
-    }
-    subgraph cluster_4_in {
-        style = filled;
-        color = "#E1F2F2";
-        fontsize = 20;
-        rank=same;
-        label="outputs/data/solar-radiation";
-        "{BUILDING}_insolation_Whm2.json"
-        "{BUILDING}_geometry.csv"
-    }
-    "{BUILDING}_insolation_Whm2.json" -> "solar-collector"[label="(get_radiation_building)"]
-    "{BUILDING}_geometry.csv" -> "solar-collector"[label="(get_radiation_metadata)"]
-    "supply_systems.xls" -> "solar-collector"[label="(get_supply_systems)"]
-    "Zug.epw" -> "solar-collector"[label="(get_weather)"]
-    "zone.shp" -> "solar-collector"[label="(get_zone_geometry)"]
-    "solar-collector" -> "{BUILDING}_SC_FP_sensors.csv"[label="(SC_metadata_results)"]
-    "solar-collector" -> "{BUILDING}_SC_FP.csv"[label="(SC_results)"]
-    "solar-collector" -> "SC_FP_total_buildings.csv"[label="(SC_total_buildings)"]
-    "solar-collector" -> "SC_FP_total.csv"[label="(SC_totals)"]
     }
 
 operation-costs


### PR DESCRIPTION
Some fixes to the documentation to remove sphinx warnings. 


I had to stop after this error - see issue #1974:

```
C:\Users\darthoma\Documents\GitHub\CityEnergyAnalyst\docs (2019.05.17-some-documentation-fixes -> origin)
λ make-warnings.bat

REM @ECHO OFF

pushd C:\Users\darthoma\Documents\GitHub\CityEnergyAnalyst\docs\

REM Run Sphinx and break on first error / warning

sphinx-build -b html -j 4 -Q -W . _build

Warning, treated as error:
autodoc: failed to import module u'planning_and_operation_batch_run' from module u'cea.optimization.flexibility_model.mpc_district'; the following exception was raised:
No module named concept

popd
```