### PR TITLE
1987 fix qt conf for installer

### DIFF
--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -131,6 +131,13 @@ Section "Base Installation" Base_Installation_Section
     Nsis7z::ExtractWithDetails ${CEA_ENV_FILENAME} "Installing Python %s..."
     Delete ${CEA_ENV_FILENAME}
 
+    # make sure qt.conf has the correct paths
+    DetailPrint "Updating qt.conf..."
+    WriteINIStr "$INSTDIR\Dependencies\Python\qt.conf" Paths Prefix "$INSTDIR/Dependencies/Python/Library"
+    WriteINIStr "$INSTDIR\Dependencies\Python\qt.conf" Paths Binaries "$INSTDIR/Dependencies/Python/Library/bin"
+    WriteINIStr "$INSTDIR\Dependencies\Python\qt.conf" Paths Libraries "$INSTDIR/Dependencies/Python/Library/lib"
+    WriteINIStr "$INSTDIR\Dependencies\Python\qt.conf" Paths Headers "$INSTDIR/Dependencies/Python/Library/include/qt"
+
     DetailPrint "Updating Pip"
     nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip install -U --force-reinstall pip'
     DetailPrint "Pip installing CityEnergyAnalyst==${VER}"

--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -4,6 +4,10 @@
 ; include the modern UI stuff
 !include "MUI2.nsh"
 
+; include some string functions
+!include "StrFunc.nsh"
+${StrRep}
+
 # icon stuff
 !define MUI_ICON "cea-icon.ico"
 
@@ -133,10 +137,11 @@ Section "Base Installation" Base_Installation_Section
 
     # make sure qt.conf has the correct paths
     DetailPrint "Updating qt.conf..."
-    WriteINIStr "$INSTDIR\Dependencies\Python\qt.conf" Paths Prefix "$INSTDIR/Dependencies/Python/Library"
-    WriteINIStr "$INSTDIR\Dependencies\Python\qt.conf" Paths Binaries "$INSTDIR/Dependencies/Python/Library/bin"
-    WriteINIStr "$INSTDIR\Dependencies\Python\qt.conf" Paths Libraries "$INSTDIR/Dependencies/Python/Library/lib"
-    WriteINIStr "$INSTDIR\Dependencies\Python\qt.conf" Paths Headers "$INSTDIR/Dependencies/Python/Library/include/qt"
+    ${StrRep} $0 "$INSTDIR" "\" "/" # $0 now constains the $INSTDIR with forward slashes instead of backward slashes
+    WriteINIStr "$INSTDIR\Dependencies\Python\qt.conf" Paths Prefix "$0/Dependencies/Python/Library"
+    WriteINIStr "$INSTDIR\Dependencies\Python\qt.conf" Paths Binaries "$0/Dependencies/Python/Library/bin"
+    WriteINIStr "$INSTDIR\Dependencies\Python\qt.conf" Paths Libraries "$0/Dependencies/Python/Library/lib"
+    WriteINIStr "$INSTDIR\Dependencies\Python\qt.conf" Paths Headers "$0/Dependencies/Python/Library/include/qt"
 
     DetailPrint "Updating Pip"
     nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip install -U --force-reinstall pip'


### PR DESCRIPTION
This PR addresses #1987 - `cea test` was not running through on a fresh install. The issue has to do with the QT_PLUGIN_PATH. The solution was to update the `CityEnergyAnalyst\Dependencies\Python\qt.conf` file to point to the proper paths.

This new installer does just that. It can be tested here: https://www.dropbox.com/s/cgf9jkcaikzo618/Setup_CityEnergyAnalyst_2.14.exe?dl=0

@gabriel-happle would you mind testing it please?

Steps:
- download installer from link above
- install (doesn't really matter which type)
- open CEA Console
- run `cea test`
- expect it to complete

Once this is merged, we can update the binary in the release 2.14.