### PR TITLE
1983 add solar technologies plots to the dashboard

### DIFF
--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -34,7 +34,8 @@ class PlotBase(object):
 
     @classmethod
     def id(cls):
-        return cls.name.lower().replace(' ', '-')  # use for js/html etc.
+        name = re.sub('\s+\(.*\)', '', cls.name)  # remove parenthesis
+        return name.lower().replace(' ', '_').replace('/', '_')  # use for js/html etc.
 
     def __init__(self, project, parameters, cache):
         self.cache = cache  # a PlotCache implementation for reading cached data
@@ -104,12 +105,8 @@ class PlotBase(object):
             prefix = 'Selected_Buildings'
         else:
             prefix = 'District'
-        file_name = "%s_%s" % (prefix, self.sanitize_name(self.name))
+        file_name = "%s_%s" % (prefix, self.id())
         return self.locator.get_timeseries_plots_file(file_name, self.category_path)
-
-    def sanitize_name(self, name):
-        name = re.sub('\s+\(.*\)', '', name)
-        return name.lower().replace(' ', '_').replace('/', '_')
 
     def remove_unused_fields(self, data, fields):
         """

--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -41,8 +41,8 @@ class PlotBase(object):
         self.cache = cache  # a PlotCache implementation for reading cached data
         self.project = project  # full path to the project this plot belongs to
         self.category_path = None  # override this in the __init__.py subclasses for each category (see cea/plots/demand/__init__.py for an example)
-        self.analysis_fields = None  # override this in the plot subclasses! set it to a list of fields in self.data
-        self.input_files = []  # override this in the plot subclasses! set it to a list of tuples (locator.method, args)
+        # self.analysis_fields = None  # override this in the plot subclasses! set it to a list of fields in self.data
+        # self.input_files = []  # override this in the plot subclasses! set it to a list of tuples (locator.method, args)
         self.parameters = parameters
         self.buildings = self.process_buildings_parameter()
 

--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -109,7 +109,7 @@ class PlotBase(object):
 
     def sanitize_name(self, name):
         name = re.sub('\s+\(.*\)', '', name)
-        return name.lower().replace(' ', '_')
+        return name.lower().replace(' ', '_').replace('/', '_')
 
     def remove_unused_fields(self, data, fields):
         """

--- a/cea/plots/life_cycle/__init__.py
+++ b/cea/plots/life_cycle/__init__.py
@@ -2,10 +2,8 @@ from __future__ import division
 from __future__ import print_function
 
 import pandas as pd
-import numpy as np
 import os
 import cea.inputlocator
-from cea.utilities import epwreader
 
 """
 Implements py:class:`cea.plots.LifeCycleAnalysisPlotBase` as a base class for all plots in the category 

--- a/cea/plots/solar_technology_potentials/__init__.py
+++ b/cea/plots/solar_technology_potentials/__init__.py
@@ -80,3 +80,42 @@ class SolarTechnologyPotentialsPlotBase(cea.plots.PlotBase):
                                       for building in self.buildings)
         pvt_hourly_aggregated_kW['DATE'] = weather_data["date"]
         return pvt_hourly_aggregated_kW
+
+    @property
+    def SC_FP_hourly_aggregated_kW(self):
+        return self.cache.lookup(data_path=os.path.join(self.category_name, 'SC_FP_hourly_aggregated_kW'),
+                                 plot=self, producer=self._calculate_SC_FP_hourly_aggregated_kW)
+
+    def _calculate_SC_FP_hourly_aggregated_kW(self):
+        weather_data = epwreader.epw_reader(self.weather)[["date", "drybulb_C", "wetbulb_C", "skytemp_C"]]
+        sc_fp_hourly_aggregated_kW = sum(
+            pd.read_csv(self.locator.SC_results(building, panel_type='FP'), usecols=self.sc_analysis_fields) for
+            building in self.buildings)
+        sc_fp_hourly_aggregated_kW.rename(columns={'SC_walls_east_Q_kWh': 'SC_FP_walls_east_Q_kWh',
+                                                   'SC_walls_west_Q_kWh': 'SC_FP_walls_west_Q_kWh',
+                                                   'SC_walls_south_Q_kWh': 'SC_FP_walls_south_Q_kWh',
+                                                   'SC_walls_north_Q_kWh': 'SC_FP_walls_north_Q_kWh',
+                                                   'SC_roofs_top_Q_kWh': 'SC_FP_roofs_top_Q_kWh'},
+                                          inplace=True)
+        sc_fp_hourly_aggregated_kW['DATE'] = weather_data["date"]
+        return sc_fp_hourly_aggregated_kW
+
+    @property
+    def SC_ET_hourly_aggregated_kW(self):
+        return self.cache.lookup(data_path=os.path.join(self.category_name, 'SC_ET_hourly_aggregated_kW'),
+                                 plot=self, producer=self._calculate_SC_ET_hourly_aggregated_kW)
+
+    def _calculate_SC_ET_hourly_aggregated_kW(self):
+        weather_data = epwreader.epw_reader(self.weather)[["date", "drybulb_C", "wetbulb_C", "skytemp_C"]]
+        sc_et_hourly_aggregated_kW = sum(
+            pd.read_csv(self.locator.SC_results(building, panel_type='FP'), usecols=self.sc_analysis_fields) for
+            building in self.buildings)
+        sc_et_hourly_aggregated_kW.rename(columns={'SC_walls_east_Q_kWh': 'SC_ET_walls_east_Q_kWh',
+                                                   'SC_walls_west_Q_kWh': 'SC_ET_walls_west_Q_kWh',
+                                                   'SC_walls_south_Q_kWh': 'SC_ET_walls_south_Q_kWh',
+                                                   'SC_walls_north_Q_kWh': 'SC_ET_walls_north_Q_kWh',
+                                                   'SC_roofs_top_Q_kWh': 'SC_ET_roofs_top_Q_kWh'},
+                                          inplace=True)
+        sc_et_hourly_aggregated_kW['DATE'] = weather_data["date"]
+        return sc_et_hourly_aggregated_kW
+

--- a/cea/plots/solar_technology_potentials/__init__.py
+++ b/cea/plots/solar_technology_potentials/__init__.py
@@ -1,0 +1,68 @@
+from __future__ import division
+from __future__ import print_function
+
+import pandas as pd
+import os
+import cea.inputlocator
+from cea.utilities import epwreader
+
+"""
+Implements py:class:`cea.plots.SolarTechnologyPotentialsPlotBase` as a base class for all plots in the category 
+"solar-technology-potentials" and also set's the label for that category.
+"""
+
+__author__ = "Daren Thomas"
+__copyright__ = "Copyright 2019, Architecture and Building Systems - ETH Zurich"
+__credits__ = ["Daren Thomas"]
+__license__ = "MIT"
+__version__ = "0.1"
+__maintainer__ = "Daren Thomas"
+__email__ = "cea@arch.ethz.ch"
+__status__ = "Production"
+
+# identifies this package as a plots category and sets the label name for the category
+label = 'Solar technology potentials'
+
+
+class SolarTechnologyPotentialsPlotBase(cea.plots.PlotBase):
+    """Implements properties / methods used by all plots in this category"""
+    category_name = "solar-technology-potentials"
+
+    # default parameters for plots in this category - override if your plot differs
+    expected_parameters = {
+        'buildings': 'plots:buildings',
+        'scenario-name': 'general:scenario-name',
+        'weather': 'general:weather',
+    }
+
+    def __init__(self, project, parameters, cache):
+        super(SolarTechnologyPotentialsPlotBase, self).__init__(project, parameters, cache)
+        self.category_path = os.path.join('new_basic', self.category_name)
+        self.weather = self.parameters['weather']
+        self.pv_analysis_fields = ['PV_walls_east_E_kWh', 'PV_walls_west_E_kWh', 'PV_walls_south_E_kWh',
+                                   'PV_walls_north_E_kWh', 'PV_roofs_top_E_kWh']
+        self.sc_fp_analysis_fields = ['SC_FP_walls_east_Q_kWh', 'SC_FP_walls_west_Q_kWh', 'SC_FP_walls_south_Q_kWh',
+                                      'SC_FP_walls_north_Q_kWh', 'SC_FP_roofs_top_Q_kWh']
+        self.sc_et_analysis_fields = ['SC_ET_walls_east_Q_kWh', 'SC_ET_walls_west_Q_kWh', 'SC_ET_walls_south_Q_kWh',
+                                      'SC_ET_walls_north_Q_kWh', 'SC_ET_roofs_top_Q_kWh']
+        self.sc_analysis_fields = ['SC_walls_east_Q_kWh', 'SC_walls_west_Q_kWh', 'SC_walls_south_Q_kWh',
+                                   'SC_walls_north_Q_kWh', 'SC_roofs_top_Q_kWh']
+        self.pvt_analysis_fields = ['PVT_walls_east_E_kWh', 'PVT_walls_west_E_kWh', 'PVT_walls_south_E_kWh',
+                                    'PVT_walls_north_E_kWh',
+                                    'PVT_roofs_top_E_kWh', 'PVT_walls_east_Q_kWh', 'PVT_walls_west_Q_kWh',
+                                    'PVT_walls_south_Q_kWh', 'PVT_walls_north_Q_kWh',
+                                    'PVT_roofs_top_Q_kWh']
+
+    @property
+    def PV_hourly_aggregated_kW(self):
+        return self.cache.lookup(data_path=os.path.join(self.category_name, 'PV_hourly_aggregated_kW'),
+                                 plot=self, producer=self._calculate_PV_hourly_aggregated_kW)
+
+    def _calculate_PV_hourly_aggregated_kW(self):
+        # get extra data of weather and date
+        weather_data = epwreader.epw_reader(self.weather)[["date", "drybulb_C", "wetbulb_C", "skytemp_C"]]
+
+        PV_hourly_aggregated_kW = sum(pd.read_csv(self.locator.PV_results(building), usecols=self.pv_analysis_fields)
+                                      for building in self.buildings)
+        PV_hourly_aggregated_kW['DATE'] = weather_data["date"]
+        return PV_hourly_aggregated_kW

--- a/cea/plots/solar_technology_potentials/__init__.py
+++ b/cea/plots/solar_technology_potentials/__init__.py
@@ -62,7 +62,21 @@ class SolarTechnologyPotentialsPlotBase(cea.plots.PlotBase):
         # get extra data of weather and date
         weather_data = epwreader.epw_reader(self.weather)[["date", "drybulb_C", "wetbulb_C", "skytemp_C"]]
 
-        PV_hourly_aggregated_kW = sum(pd.read_csv(self.locator.PV_results(building), usecols=self.pv_analysis_fields)
+        pv_hourly_aggregated_kW = sum(pd.read_csv(self.locator.PV_results(building), usecols=self.pv_analysis_fields)
                                       for building in self.buildings)
-        PV_hourly_aggregated_kW['DATE'] = weather_data["date"]
-        return PV_hourly_aggregated_kW
+        pv_hourly_aggregated_kW['DATE'] = weather_data["date"]
+        return pv_hourly_aggregated_kW
+
+    @property
+    def PVT_hourly_aggregated_kW(self):
+        return self.cache.lookup(data_path=os.path.join(self.category_name, 'PVT_hourly_aggregated_kW'),
+                                 plot=self, producer=self._calculate_PVT_hourly_aggregated_kW)
+
+    def _calculate_PVT_hourly_aggregated_kW(self):
+        # get extra data of weather and date
+        weather_data = epwreader.epw_reader(self.weather)[["date", "drybulb_C", "wetbulb_C", "skytemp_C"]]
+
+        pvt_hourly_aggregated_kW = sum(pd.read_csv(self.locator.PVT_results(building), usecols=self.pvt_analysis_fields)
+                                      for building in self.buildings)
+        pvt_hourly_aggregated_kW['DATE'] = weather_data["date"]
+        return pvt_hourly_aggregated_kW

--- a/cea/plots/solar_technology_potentials/all_tech_hourly_curve.py
+++ b/cea/plots/solar_technology_potentials/all_tech_hourly_curve.py
@@ -1,9 +1,10 @@
 from __future__ import division
 from __future__ import print_function
 
+import os
 import plotly.graph_objs as go
 from plotly.offline import plot
-
+import cea.plots.solar_technology_potentials
 from cea.plots.variable_naming import LOGO, COLOR
 
 __author__ = "Shanshan Hsieh"
@@ -14,6 +15,69 @@ __version__ = "0.1"
 __maintainer__ = "Daren Thomas"
 __email__ = "cea@arch.ethz.ch"
 __status__ = "Production"
+
+
+class AllTechHourlyPlot(cea.plots.solar_technology_potentials.SolarTechnologyPotentialsPlotBase):
+    """Implement the pv-electricity-potential plot"""
+    name = "PV/SC/PVT Potential"
+
+    def __init__(self, project, parameters, cache):
+        super(AllTechHourlyPlot, self).__init__(project, parameters, cache)
+        self.map_technologies = {  # tech-name: (locator_method, args, data_attribute)
+            'PV': (self.locator.PV_totals, [], 'PV_hourly_aggregated_kW'),
+            'PVT': (self.locator.PVT_totals, [], 'PVT_hourly_aggregated_kW'),
+            'SC_ET': (self.locator.SC_totals, ['ET'], 'SC_ET_hourly_aggregated_kW'),
+            'SC_FP': (self.locator.SC_totals, ['FP'], 'SC_FP_hourly_aggregated_kW')
+        }
+        self.input_files = [self.map_technologies[t][:2] for t in self.map_technologies.keys()]
+        self.__data_frame = None
+
+    @property
+    def layout(self):
+        return dict(title=self.title, yaxis=dict(title='Hourly production [kWh]'),
+                  xaxis=dict(rangeselector=dict(buttons=list([
+                      dict(count=1, label='1d', step='day', stepmode='backward'),
+                      dict(count=1, label='1w', step='week', stepmode='backward'),
+                      dict(count=1, label='1m', step='month', stepmode='backward'),
+                      dict(count=6, label='6m', step='month', stepmode='backward'),
+                      dict(count=1, label='1y', step='year', stepmode='backward'),
+                      dict(step='all')])), rangeslider=dict(), type='date', range=[self.data_frame.index[0],
+                                                                                   self.data_frame.index[168]],
+                      fixedrange=False))
+
+    def missing_input_files(self):
+        """Overriding the base version of this method, since for this plot, having at least one technology
+        available is ok."""
+        result = super(AllTechHourlyPlot, self).missing_input_files()
+        if len(result) < len(self.input_files):
+            # we know _at least_ some of the simulations have been made already, we can plot this
+            return []
+        return result
+
+
+    @property
+    def data_frame(self):
+        """Combine all the (available) hourly tech data_frames by inner join"""
+        if self.__data_frame is None:
+            data_frame_list = [getattr(self, t[2]).set_index('DATE') for t in self.map_technologies.values()
+                               if os.path.exists(t[0](*t[1]))]
+            self.__data_frame = reduce(lambda ldf, rdf: ldf.join(rdf, how='inner', on='DATE'), data_frame_list)
+        return self.__data_frame
+
+    def calc_graph(self):
+        graph = []
+        data_frame = self.data_frame
+        analysis_fields = [f for f in data_frame.columns if f.endswith('_kWh')]
+        for field in analysis_fields:
+            y = data_frame[field].values
+            name = field.split('_kWh', 1)[0]
+            if name.startswith('PV_'):
+                trace = go.Scatter(x=data_frame.index, y=y, name=name, marker=dict(color=COLOR[field]))
+            else:
+                trace = go.Scatter(x=data_frame.index, y=y, name=name, visible='legendonly',
+                                   marker=dict(color=COLOR[field]))
+            graph.append(trace)
+        return graph
 
 
 def all_tech_district_hourly(data_frame, all_tech_analysis_fields, title, output_path):
@@ -47,3 +111,31 @@ def all_tech_district_hourly(data_frame, all_tech_analysis_fields, title, output
     plot(fig, auto_open=False, filename=output_path)
 
     return {'data': traces, 'layout': layout}
+
+
+def main():
+    """Test this plot"""
+    import cea.config
+    import cea.inputlocator
+    import cea.plots.cache
+    config = cea.config.Configuration()
+    locator = cea.inputlocator.InputLocator(config.scenario)
+    cache = cea.plots.cache.PlotCache(config.project)
+    # cache = cea.plots.cache.NullPlotCache()
+    AllTechHourlyPlot(config.project, {'buildings': None,
+                                       'scenario-name': config.scenario_name,
+                                       'weather': config.weather},
+                      cache).plot(auto_open=True)
+    AllTechHourlyPlot(config.project, {'buildings': locator.get_zone_building_names()[0:2],
+                                       'scenario-name': config.scenario_name,
+                                       'weather': config.weather},
+                      cache).plot(auto_open=True)
+    AllTechHourlyPlot(config.project, {'buildings': [locator.get_zone_building_names()[0]],
+                                       'scenario-name': config.scenario_name,
+                                       'weather': config.weather},
+                      cache).plot(auto_open=True)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/cea/plots/solar_technology_potentials/all_tech_hourly_curve.py
+++ b/cea/plots/solar_technology_potentials/all_tech_hourly_curve.py
@@ -54,7 +54,6 @@ class AllTechHourlyPlot(cea.plots.solar_technology_potentials.SolarTechnologyPot
             return []
         return result
 
-
     @property
     def data_frame(self):
         """Combine all the (available) hourly tech data_frames by inner join"""

--- a/cea/plots/solar_technology_potentials/all_tech_yearly.py
+++ b/cea/plots/solar_technology_potentials/all_tech_yearly.py
@@ -2,10 +2,11 @@ from __future__ import division
 from __future__ import print_function
 
 import math
-
+import os
+import pandas as pd
 import plotly.graph_objs as go
 from plotly.offline import plot
-
+import cea.plots.solar_technology_potentials
 from cea.plots.variable_naming import LOGO, COLOR, NAMING
 
 __author__ = "Shanshan Hsieh"
@@ -16,6 +17,175 @@ __version__ = "0.1"
 __maintainer__ = "Daren Thomas"
 __email__ = "cea@arch.ethz.ch"
 __status__ = "Production"
+
+
+class AllTechYearlyPlot(cea.plots.solar_technology_potentials.SolarTechnologyPotentialsPlotBase):
+    """Implement the pv-electricity-potential plot"""
+    name = "PV/SC/PVT Potential per Building"
+
+    def __init__(self, project, parameters, cache):
+        super(AllTechYearlyPlot, self).__init__(project, parameters, cache)
+        self.map_technologies = {  # technology: (locator_method, args, analysis_fields, rename_analysis_fields)
+            'PV': (self.locator.PV_total_buildings, [], self.pv_analysis_fields, None),
+            'PVT': (self.locator.PVT_total_buildings, [], self.pvt_analysis_fields, None),
+            'SC_ET': (self.locator.SC_total_buildings, ['ET'], self.sc_analysis_fields, self.sc_et_analysis_fields),
+            'SC_FP': (self.locator.SC_total_buildings, ['FP'], self.sc_analysis_fields, self.sc_fp_analysis_fields)
+        }
+        self.input_files = [(lm, args) for lm, args, _, __ in self.map_technologies.values()]
+        self.__data_frame = None
+
+    def missing_input_files(self):
+        """Overriding the base version of this method, since for this plot, having at least one technology
+        available is ok."""
+        result = super(AllTechYearlyPlot, self).missing_input_files()
+        if len(result) < len(self.input_files):
+            # we know _at least_ some of the simulations have been made already, we can plot this
+            return []
+        return result
+
+    @property
+    def layout(self):
+        data_frame_MWh = self.annual_results_all_buildings_kW / 1000
+        range = self.calc_range(data_frame_MWh)
+        annotations = list(
+            [dict(
+                text='<b>In this plot, users can explore the combined potentials of all solar technologies.</b><br>'
+                     'Instruction:'
+                     'Click on the technologies to install on each building surface.<br>'
+                     'Example: PV_walls_east_E + PVT_walls_south_E/Q + SC_FP_roofs_top_Q <br><br>'
+                , x=0.8, y=1.1,
+                xanchor='left', xref='paper', yref='paper', align='left', showarrow=False, bgcolor="rgb(254,220,198)")])
+        return go.Layout(title=self.title, barmode='stack', annotations=annotations,
+                       yaxis=dict(title='Electricity/Thermal Potential [MWh/yr]', domain=[0.35, 1], range=range),
+                       yaxis2=dict(overlaying='y', anchor='x', domain=[0.35, 1], range=range),
+                       xaxis=dict(title='Building'), legend=dict(x=1, y=0.1, xanchor='left'))
+
+    def calc_range(self, df):
+        """Determines the highest range of y-axis. This is a work-around to fix the range for both y-axes so they can
+        overlap. We rely on the fact that all E fields end in ``_E_kWh`` and all Q fields end in ``_Q_kWh``"""
+        E_analysis_fields = df.columns[df.columns.str.endswith('_E_kWh')]
+        Q_analysis_fields = df.columns[df.columns.str.endswith('_Q_kWh')]
+        E_max = df[E_analysis_fields].max().max()
+        Q_max = df[Q_analysis_fields].max().max()
+        return [0, math.ceil(max(E_max, Q_max))]
+
+    def calc_graph(self):
+        # calculate graph
+        graph = []
+        data_frame_MWh = self.annual_results_all_buildings_kW / 1000
+        E_analysis_fields = data_frame_MWh.columns[data_frame_MWh.columns.str.endswith('_E_kWh')]
+        Q_analysis_fields = data_frame_MWh.columns[data_frame_MWh.columns.str.endswith('_Q_kWh')]
+
+        data_frame_MWh['total_E'] = data_frame_MWh[E_analysis_fields].sum(axis=1)
+        data_frame_MWh['total_Q'] = data_frame_MWh[Q_analysis_fields].sum(axis=1)
+        # data_frame_MWh = data_frame_MWh.sort_values(by='total', ascending=False) # this will get the maximum value to the left
+        for field in E_analysis_fields:
+            y = data_frame_MWh[field]
+            if field.split('_')[0] == 'PVT':
+                trace1 = go.Bar(x=data_frame_MWh.index, y=y, name=field.split('_kWh', 1)[0],
+                                marker=dict(color=COLOR[field]), visible='legendonly',
+                                width=0.3, offset=-0.35, legendgroup='PVT' + field.split('_')[2])
+            else:
+                trace1 = go.Bar(x=data_frame_MWh.index, y=y, name=field.split('_kWh', 1)[0],
+                                marker=dict(color=COLOR[field]), visible='legendonly',
+                                width=0.3, offset=-0.35)
+            graph.append(trace1)
+
+        for field in Q_analysis_fields:
+            y = data_frame_MWh[field]
+            if field.split('_')[0] == 'PVT':
+                trace2 = go.Bar(x=data_frame_MWh.index, y=y, yaxis='y2', name=field.split('_kWh', 1)[0],
+                                marker=dict(color=COLOR[field], line=dict(
+                                    color="rgb(105,105,105)", width=1)), opacity=1, visible='legendonly',
+                                width=0.3, offset=0, legendgroup='PVT' + field.split('_')[2])
+            elif field.split('_')[1] == 'FP':
+                trace2 = go.Bar(x=data_frame_MWh.index, y=y, yaxis='y2', name=field.split('_kWh', 1)[0],
+                                marker=dict(color=COLOR[field], line=dict(
+                                    color="rgb(105,105,105)", width=1)), opacity=1, visible='legendonly',
+                                width=0.3, offset=0)
+            elif field.split('_')[1] == 'ET':
+                trace2 = go.Bar(x=data_frame_MWh.index, y=y, name=field.split('_kWh', 1)[0],
+                                marker=dict(color=COLOR[field], line=dict(
+                                    color="rgb(105,105,105)", width=1)), opacity=1, visible='legendonly',
+                                width=0.3, offset=0)
+            else:
+                raise ValueError('the specified analysis field is not in the right form: ', field)
+
+            graph.append(trace2)
+        return graph
+
+    def calc_table(self):
+        data_frame_MWh = self.annual_results_all_buildings_kW / 1000
+        E_analysis_fields = data_frame_MWh.columns[data_frame_MWh.columns.str.endswith('_E_kWh')]
+        Q_analysis_fields = data_frame_MWh.columns[data_frame_MWh.columns.str.endswith('_Q_kWh')]
+        total_perc = []
+        median = []
+        # find the three highest
+        anchors = []
+        load_names = []
+
+        E_median = data_frame_MWh[E_analysis_fields].median().round(2).tolist()
+        E_total = data_frame_MWh[E_analysis_fields].sum().round(2).tolist()
+        if sum(E_total) > 0:
+            E_total_perc = [str(x) + " (" + str(round(x / sum(E_total) * 100, 1)) + " %)" for x in E_total]
+            for field in E_analysis_fields:
+                anchors.append(calc_top_three_anchor_loads(data_frame_MWh, field))
+                load_names.append(NAMING[field].split(' ')[6] + ' (' + field.split('_kWh', 1)[0] + ')')
+        else:
+            E_total_perc = ['0 (0%)'] * len(E_total)
+            for field in E_analysis_fields:
+                anchors.append('-')
+                load_names.append(NAMING[field].split(' ')[6] + ' (' + field.split('_kWh', 1)[0] + ')')
+        total_perc.extend(E_total_perc)
+        median.extend(E_median)
+
+        Q_median = (data_frame_MWh[Q_analysis_fields].median() / 1000).round(2).tolist()  # to MWh
+        Q_total = data_frame_MWh[Q_analysis_fields].sum().round(2).tolist()
+        if sum(Q_total) > 0:
+            Q_total_perc = [str(x) + " (" + str(round(x / sum(Q_total) * 100, 1)) + " %)" for x in Q_total]
+            for field in Q_analysis_fields:
+                anchors.append(calc_top_three_anchor_loads(data_frame_MWh, field))
+                load_names.append(NAMING[field].split(' ')[6] + ' (' + field.split('_kWh', 1)[0] + ')')
+        else:
+            Q_total_perc = ['0 (0%)'] * len(Q_total)
+            for field in Q_analysis_fields:
+                anchors.append('-')
+                load_names.append(NAMING[field].split(' ')[6] + ' (' + field.split('_kWh', 1)[0] + ')')
+
+        total_perc.extend(Q_total_perc)
+        median.extend(Q_median)
+
+        column_names = ['Surface', 'Total [MWh/yr]', 'Median [MWh/yr]', 'Top 3 most irradiated']
+        column_values = [load_names, total_perc, median, anchors]
+        table_df = pd.DataFrame({cn: cv for cn, cv in zip(column_names, column_values)}, columns=column_names)
+        return table_df
+
+    @property
+    def annual_results_all_buildings_kW(self):
+        return self.cache.lookup(data_path=os.path.join(self.category_name, 'annual_results_all_buildings_kW'),
+                                 plot=self, producer=self._calculate_annual_results_all_buildings_kW)
+
+    def _calculate_annual_results_all_buildings_kW(self):
+        def get_data_for_technology(technology):
+            locator_method, args, analysis_fields, rename_analysis_fields = self.map_technologies[technology]
+            input_file = locator_method(*args)
+            if os.path.exists(input_file):
+                df = pd.read_csv(input_file)
+                df = df.set_index(df.columns[0])
+                if rename_analysis_fields:
+                    return df.rename(index=str,
+                                     columns={old: new for old, new in zip(analysis_fields, rename_analysis_fields)})[
+                        rename_analysis_fields]
+
+                return df[analysis_fields]
+
+        print('-' * 120)
+        print(get_data_for_technology('PV'))
+        print('-' * 120)
+        df = reduce(lambda ldf, rdf: ldf.join(rdf, how='inner'),
+                    [get_data_for_technology(tech) for tech in self.map_technologies.keys()])
+        return df
+
 
 
 def all_tech_district_yearly(data_frame, pv_analysis_fields, pvt_analysis_fields, sc_fp_analysis_fields,
@@ -198,3 +368,31 @@ def calc_top_three_anchor_loads(data_frame, field):
     data_frame = data_frame.sort_values(by=field, ascending=False)
     anchor_list = data_frame[:3].index.values
     return anchor_list
+
+
+def main():
+    """Test this plot"""
+    import cea.config
+    import cea.inputlocator
+    import cea.plots.cache
+    config = cea.config.Configuration()
+    locator = cea.inputlocator.InputLocator(config.scenario)
+    cache = cea.plots.cache.PlotCache(config.project)
+    # cache = cea.plots.cache.NullPlotCache()
+    AllTechYearlyPlot(config.project, {'buildings': None,
+                                       'scenario-name': config.scenario_name,
+                                       'weather': config.weather},
+                      cache).plot(auto_open=True)
+    AllTechYearlyPlot(config.project, {'buildings': locator.get_zone_building_names()[0:2],
+                                       'scenario-name': config.scenario_name,
+                                       'weather': config.weather},
+                      cache).plot(auto_open=True)
+    AllTechYearlyPlot(config.project, {'buildings': [locator.get_zone_building_names()[0]],
+                                       'scenario-name': config.scenario_name,
+                                       'weather': config.weather},
+                      cache).plot(auto_open=True)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/cea/plots/solar_technology_potentials/main.py
+++ b/cea/plots/solar_technology_potentials/main.py
@@ -201,16 +201,16 @@ class Plots(object):
                                                                      usecols=all_tech_analysis_fields['PVT'])
                     PVT_hourly_aggregated_kW = PVT_hourly_aggregated_kW + hourly_data_per_building_kW['PVT']
                 if 'SC_FP' in all_tech_analysis_fields:
-                    SC_FP_houlry_per_building_kW = pd.read_csv(self.locator.SC_results(building, panel_type='FP'),
+                    SC_FP_hourly_per_building_kW = pd.read_csv(self.locator.SC_results(building, panel_type='FP'),
                                                                usecols=SC_analysis_fields)
-                    SC_FP_houlry_per_building_kW.rename(columns={'SC_walls_east_Q_kWh': 'SC_FP_walls_east_Q_kWh',
+                    SC_FP_hourly_per_building_kW.rename(columns={'SC_walls_east_Q_kWh': 'SC_FP_walls_east_Q_kWh',
                                                                  'SC_walls_west_Q_kWh': 'SC_FP_walls_west_Q_kWh',
                                                                  'SC_walls_south_Q_kWh': 'SC_FP_walls_south_Q_kWh',
                                                                  'SC_walls_north_Q_kWh': 'SC_FP_walls_north_Q_kWh',
                                                                  'SC_roofs_top_Q_kWh': 'SC_FP_roofs_top_Q_kWh'},
                                                         inplace=True)
-                    hourly_data_per_building_kW['SC_FP'] = SC_FP_houlry_per_building_kW
-                    SC_FP_hourly_aggregated_kW = SC_FP_hourly_aggregated_kW + SC_FP_houlry_per_building_kW
+                    hourly_data_per_building_kW['SC_FP'] = SC_FP_hourly_per_building_kW
+                    SC_FP_hourly_aggregated_kW = SC_FP_hourly_aggregated_kW + SC_FP_hourly_per_building_kW
                 if 'SC_ET' in all_tech_analysis_fields:
                     SC_ET_hourly_per_building_kW = pd.read_csv(self.locator.SC_results(building, panel_type='ET'),
                                                                usecols=SC_analysis_fields)

--- a/cea/plots/solar_technology_potentials/main.py
+++ b/cea/plots/solar_technology_potentials/main.py
@@ -245,7 +245,6 @@ class Plots(object):
 
         hourly_results_aggregated_kW = reduce(join_dfs, dfs)
         hourly_results_aggregated_kW['DATE'] = weather_data["date"]
-
         return {"data_hourly": hourly_results_aggregated_kW, "data_yearly": annual_results_all_buildings_kW}
 
     def pv_district_monthly(self, category):

--- a/cea/plots/solar_technology_potentials/pv_monthly.py
+++ b/cea/plots/solar_technology_potentials/pv_monthly.py
@@ -145,6 +145,7 @@ def main():
     """Test this plot"""
     import cea.config
     import cea.inputlocator
+    import cea.plots.cache
     config = cea.config.Configuration()
     locator = cea.inputlocator.InputLocator(config.scenario)
     cache = cea.plots.cache.PlotCache(config.project)

--- a/cea/plots/solar_technology_potentials/pv_monthly.py
+++ b/cea/plots/solar_technology_potentials/pv_monthly.py
@@ -2,8 +2,9 @@ from __future__ import division
 from __future__ import print_function
 
 import plotly.graph_objs as go
+import pandas as pd
 from plotly.offline import plot
-
+import cea.plots.solar_technology_potentials
 from cea.plots.variable_naming import LOGO, COLOR, NAMING
 
 __author__ = "Shanshan Hsieh"
@@ -14,6 +15,62 @@ __version__ = "0.1"
 __maintainer__ = "Daren Thomas"
 __email__ = "cea@arch.ethz.ch"
 __status__ = "Production"
+
+
+class PhotovoltaicMonthlyPlot(cea.plots.solar_technology_potentials.SolarTechnologyPotentialsPlotBase):
+    """Implement the pv-electricity-potential plot"""
+    name = "PV Electricity Potential"
+
+    def __init__(self, project, parameters, cache):
+        super(PhotovoltaicMonthlyPlot, self).__init__(project, parameters, cache)
+        self.input_files = [(self.locator.PV_totals, [])] + [(self.locator.PV_results, [building])
+                                                             for building in self.buildings]
+
+    @property
+    def layout(self):
+        return go.Layout(title=self.title, barmode='stack', yaxis=dict(title='PV Electricity [MWh]', domain=[0.35, 1]))
+
+    def calc_graph(self):
+        graph = []
+        data_frame = self.PV_hourly_aggregated_kW
+        analysis_fields = self.pv_analysis_fields
+        monthly_df = (data_frame.set_index("DATE").resample("M").sum() / 1000).round(2)  # to MW
+        monthly_df["month"] = monthly_df.index.strftime("%B")
+        total = monthly_df[analysis_fields].sum(axis=1)
+        for field in analysis_fields:
+            y = monthly_df[field]
+            total_percent = (y.divide(total) * 100).round(2).values
+            total_percent_txt = ["(" + str(x) + " %)" for x in total_percent]
+            trace = go.Bar(x=monthly_df["month"], y=y, name=field.split('_kWh', 1)[0], text=total_percent_txt,
+                           marker=dict(color=COLOR[field]))
+            graph.append(trace)
+        return graph
+
+    def calc_table(self):
+        data_frame = self.PV_hourly_aggregated_kW
+        analysis_fields = self.pv_analysis_fields
+        total = (data_frame[analysis_fields].sum(axis=0) / 1000).round(2).tolist()  # to MW
+        anchors = []
+        load_names = []
+        monthly_df = (data_frame.set_index("DATE").resample("M").sum() / 1000).round(2)  # to MW
+        monthly_df["month"] = monthly_df.index.strftime("%B")
+        monthly_df.set_index("month", inplace=True)
+        if sum(total) > 0:
+            total_percent = [str(x) + " (" + str(round(x / sum(total) * 100, 1)) + " %)" for x in total]
+            # calculate graph
+            for field in analysis_fields:
+                load_names.append(NAMING[field] + ' (' + field.split('_kWh', 1)[0] + ')')
+                anchors.append(', '.join(calc_top_three_anchor_loads(monthly_df, field)))
+        else:
+            total_percent = ['0 (0%)'] * len(total)
+            for field in analysis_fields:
+                load_names.append(NAMING[field] + ' (' + field.split('_kWh', 1)[0] + ')')
+                anchors.append('-')
+
+        column_names = ['Surface', 'Total [MWh/yr]', 'Months with the highest potentials']
+        column_values = [load_names, total_percent, anchors]
+        table_df = pd.DataFrame({cn: cv for cn, cv in zip(column_names, column_values)}, columns=column_names)
+        return table_df
 
 
 def pv_district_monthly(data_frame, analysis_fields, title, output_path):
@@ -82,3 +139,29 @@ def calc_top_three_anchor_loads(data_frame, field):
     data_frame = data_frame.sort_values(by=field, ascending=False)
     anchor_list = data_frame[:3].index.values
     return anchor_list
+
+
+def main():
+    """Test this plot"""
+    import cea.config
+    import cea.inputlocator
+    config = cea.config.Configuration()
+    locator = cea.inputlocator.InputLocator(config.scenario)
+    cache = cea.plots.cache.PlotCache(config.project)
+    # cache = cea.plots.cache.NullPlotCache()
+    PhotovoltaicMonthlyPlot(config.project, {'buildings': None,
+                                             'scenario-name': config.scenario_name,
+                                             'weather': config.weather},
+                            cache).plot(auto_open=True)
+    PhotovoltaicMonthlyPlot(config.project, {'buildings': locator.get_zone_building_names()[0:2],
+                                             'scenario-name': config.scenario_name,
+                                             'weather': config.weather},
+                            cache).plot(auto_open=True)
+    PhotovoltaicMonthlyPlot(config.project, {'buildings': [locator.get_zone_building_names()[0]],
+                                             'scenario-name': config.scenario_name,
+                                             'weather': config.weather},
+                            cache).plot(auto_open=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/cea/plots/solar_technology_potentials/pvt_monthly.py
+++ b/cea/plots/solar_technology_potentials/pvt_monthly.py
@@ -2,11 +2,12 @@ from __future__ import division
 from __future__ import print_function
 
 import math
-
+import pandas as pd
 import plotly.graph_objs as go
 from plotly.offline import plot
-
+import cea.plots.solar_technology_potentials
 from cea.plots.variable_naming import LOGO, COLOR, NAMING
+
 
 __author__ = "Shanshan Hsieh"
 __copyright__ = "Copyright 2018, Architecture and Building Systems - ETH Zurich"
@@ -16,6 +17,132 @@ __version__ = "0.1"
 __maintainer__ = "Daren Thomas"
 __email__ = "cea@arch.ethz.ch"
 __status__ = "Production"
+
+
+class PvtMonthlyPlot(cea.plots.solar_technology_potentials.SolarTechnologyPotentialsPlotBase):
+    """Implement the pv-electricity-potential plot"""
+    name = "PVT Electricity/Thermal Potential"
+
+    def __init__(self, project, parameters, cache):
+        super(PvtMonthlyPlot, self).__init__(project, parameters, cache)
+        self.input_files = [(self.locator.PVT_totals, [])] + [(self.locator.PVT_results, [building])
+                                                              for building in self.buildings]
+        self.__data_frame = None
+        self.__E_analysis_fields_used = None
+        self.__Q_analysis_fields_used = None
+
+    @property
+    def data_frame(self):
+        """This get's used a couple of times in the calculations, avoid hitting the PlotCache each time"""
+        if self.__data_frame is None:
+            self.__data_frame = self.PVT_hourly_aggregated_kW
+        return self.__data_frame
+
+    @property
+    def E_analysis_fields_used(self):
+        if self.__E_analysis_fields_used is None:
+            self.__E_analysis_fields_used = self.data_frame.columns[
+                self.data_frame.columns.str.endswith('_E_kWh')].tolist()
+        return self.__E_analysis_fields_used
+
+    @property
+    def Q_analysis_fields_used(self):
+        if self.__Q_analysis_fields_used is None:
+            self.__Q_analysis_fields_used = self.data_frame.columns[
+                self.data_frame.columns.str.endswith('_Q_kWh')].tolist()
+        return self.__Q_analysis_fields_used
+
+    @property
+    def layout(self):
+        analysis_range = calc_range(self.data_frame, self.E_analysis_fields_used, self.Q_analysis_fields_used)
+        return go.Layout(title=self.title, barmode='stack',
+                         yaxis=dict(title='PVT Electricity/Heat production [MWh]', domain=[0.35, 1], rangemode='tozero',
+                                    scaleanchor='y2', range=analysis_range),
+                         yaxis2=dict(overlaying='y', anchor='x', domain=[0.35, 1], range=analysis_range))
+
+    def calc_graph(self):
+        # calculate graph
+        graph = []
+        data_frame = self.data_frame
+        monthly_df = (data_frame.set_index("DATE").resample("M").sum() / 1000).round(2)  # to MW
+        monthly_df["month"] = monthly_df.index.strftime("%B")
+
+
+        E_total = monthly_df[self.E_analysis_fields_used].sum(axis=1)
+        Q_total = monthly_df[self.Q_analysis_fields_used].sum(axis=1)
+
+        for field in self.Q_analysis_fields_used:
+            y = monthly_df[field]
+            total_perc = (y.divide(Q_total) * 100).round(2).values
+            total_perc_txt = ["(" + str(x) + " %)" for x in total_perc]
+            trace1 = go.Bar(x=monthly_df["month"], y=y, yaxis='y2', name=field.split('_kWh', 1)[0], text=total_perc_txt,
+                            marker=dict(color=COLOR[field], line=dict(color="rgb(105,105,105)", width=1)),
+                            opacity=1, width=0.3, offset=0, legendgroup=field.split('_Q_kWh', 1)[0])
+            graph.append(trace1)
+
+        for field in self.E_analysis_fields_used:
+            y = monthly_df[field]
+            total_perc = (y / E_total * 100).round(2).values
+            total_perc_txt = ["(" + str(x) + " %)" for x in total_perc]
+            trace2 = go.Bar(x=monthly_df["month"], y=y, name=field.split('_kWh', 1)[0], text=total_perc_txt,
+                            marker=dict(color=COLOR[field]), width=0.3, offset=-0.35,
+                            legendgroup=field.split('_E_kWh', 1)[0])
+            graph.append(trace2)
+        return graph
+
+    def calc_table(self):
+        analysis_fields_used = []
+        total_perc = []
+        data_frame = self.data_frame
+        E_analysis_fields_used = self.E_analysis_fields_used
+        Q_analysis_fields_used = self.Q_analysis_fields_used
+
+        # calculation for electricity production
+        E_total = (data_frame[E_analysis_fields_used].sum(axis=0) / 1000).round(2).tolist()  # to MW
+        # calculate top three potentials
+        E_anchors = []
+        E_names = []
+        monthly_df = (data_frame.set_index("DATE").resample("M").sum() / 1000).round(2)  # to MW
+        monthly_df["month"] = monthly_df.index.strftime("%B")
+        monthly_df.set_index("month", inplace=True)
+
+        if sum(E_total) > 0:
+            E_total_perc = [str(x) + " (" + str(round(x / sum(E_total) * 100, 1)) + " %)" for x in E_total]
+            for field in E_analysis_fields_used:
+                E_anchors.append(', '.join(calc_top_three_anchor_loads(monthly_df, field)))
+                E_names.append(NAMING[field].split(' ')[6] + ' (' + field.split('_kWh', 1)[0] + ')')
+        else:
+            E_total_perc = ['0 (0%)'] * len(E_total)
+            for field in E_analysis_fields_used:
+                E_anchors.append('-')
+                E_names.append(NAMING[field].split(' ')[6] + ' (' + field.split('_kWh', 1)[0] + ')')
+
+        analysis_fields_used.extend(E_analysis_fields_used)
+        total_perc.extend(E_total_perc)
+
+        # calculation for heat production
+        Q_total = (data_frame[Q_analysis_fields_used].sum(axis=0) / 1000).round(2).tolist()  # to MW
+        Q_names = []
+        Q_anchors = []
+        if sum(Q_total) > 0:
+            Q_total_perc = [str(x) + " (" + str(round(x / sum(Q_total) * 100, 1)) + " %)" for x in Q_total]
+            for field in Q_analysis_fields_used:
+                Q_anchors.append(', '.join(calc_top_three_anchor_loads(monthly_df, field)))
+                Q_names.append(NAMING[field].split(' ')[6] + ' (' + field.split('_kWh', 1)[0] + ')')
+        else:
+            Q_total_perc = ['0 (0%)'] * len(Q_total)
+            for field in Q_analysis_fields_used:
+                Q_anchors.append('-')
+                Q_names.append(NAMING[field].split(' ')[6] + ' (' + field.split('_kWh', 1)[0] + ')')
+
+        analysis_fields_used.extend(Q_analysis_fields_used)
+        total_perc.extend(Q_total_perc)
+
+        column_names = ['Surfaces', 'Total electricity production [MWh/yr]', 'Months with the highest potentials',
+                       'Surfaces ', 'Total heat production [MWh/yr]', 'Months with the highest potentials']
+        column_values = [E_names, E_total_perc, E_anchors, Q_names, Q_total_perc, Q_anchors]
+        table_df = pd.DataFrame({cn: cv for cn, cv in zip(column_names, column_values)}, columns=column_names)
+        return table_df
 
 
 def pvt_district_monthly(data_frame, analysis_fields, title, output_path):
@@ -138,3 +265,30 @@ def calc_top_three_anchor_loads(data_frame, field):
     data_frame = data_frame.sort_values(by=field, ascending=False)
     anchor_list = data_frame[:3].index.values
     return anchor_list
+
+
+def main():
+    """Test this plot"""
+    import cea.config
+    import cea.inputlocator
+    import cea.plots.cache
+    config = cea.config.Configuration()
+    locator = cea.inputlocator.InputLocator(config.scenario)
+    cache = cea.plots.cache.PlotCache(config.project)
+    # cache = cea.plots.cache.NullPlotCache()
+    PvtMonthlyPlot(config.project, {'buildings': None,
+                                    'scenario-name': config.scenario_name,
+                                    'weather': config.weather},
+                   cache).plot(auto_open=True)
+    PvtMonthlyPlot(config.project, {'buildings': locator.get_zone_building_names()[0:2],
+                                    'scenario-name': config.scenario_name,
+                                    'weather': config.weather},
+                   cache).plot(auto_open=True)
+    PvtMonthlyPlot(config.project, {'buildings': [locator.get_zone_building_names()[0]],
+                                    'scenario-name': config.scenario_name,
+                                    'weather': config.weather},
+                   cache).plot(auto_open=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/cea/plots/solar_technology_potentials/sc_monthly.py
+++ b/cea/plots/solar_technology_potentials/sc_monthly.py
@@ -17,11 +17,27 @@ __email__ = "cea@arch.ethz.ch"
 __status__ = "Production"
 
 
-class SolarCollectorMonthlyPlotBase(cea.plots.solar_technology_potentials.SolarTechnologyPotentialsPlotBase):
-    """Common functionality for ET / FP plots"""
+class SolarCollectorEvacuatedTubeMonthlyPlot(cea.plots.solar_technology_potentials.SolarTechnologyPotentialsPlotBase):
+    """Monthly plots for evacuated tubes (flat plates work exactly the same but on different data,
+    see :py:class:`SolarCollectorFlatPlateMonthlyPlot`)"""
+
+    name = "Evacuated Tube SC Thermal Potential"
 
     def __init__(self, project, parameters, cache):
-        super(SolarCollectorMonthlyPlotBase, self).__init__(project, parameters, cache)
+        super(SolarCollectorEvacuatedTubeMonthlyPlot, self).__init__(project, parameters, cache)
+
+    @property
+    def data_frame(self):
+        return self.SC_ET_hourly_aggregated_kW
+
+    @property
+    def analysis_fields(self):
+        return [f.replace('SC_', 'SC_ET_') for f in self.sc_analysis_fields]
+
+    @property
+    def input_files(self):
+        return [(self.locator.SC_totals, ['ET'])] + [(self.locator.SC_results, [building, 'ET'])
+                                                     for building in self.buildings]
 
     @property
     def layout(self):
@@ -74,24 +90,7 @@ class SolarCollectorMonthlyPlotBase(cea.plots.solar_technology_potentials.SolarT
         return table_df
 
 
-class SolarCollectorEvacuatedTubeMonthlyPlot(SolarCollectorMonthlyPlotBase):
-    name = "Evacuated Tube SC Thermal Potential"
-
-    @property
-    def data_frame(self):
-        return self.SC_ET_hourly_aggregated_kW
-
-    @property
-    def analysis_fields(self):
-        return [f.replace('SC_', 'SC_ET_') for f in self.sc_analysis_fields]
-
-    @property
-    def input_files(self):
-        return [(self.locator.SC_totals, ['ET'])] + [(self.locator.SC_results, [building, 'ET'])
-                                                     for building in self.buildings]
-
-
-class SolarCollectorFlatPlateMonthlyPlot(SolarCollectorMonthlyPlotBase):
+class SolarCollectorFlatPlateMonthlyPlot(SolarCollectorEvacuatedTubeMonthlyPlot):
     name = "Flat Plate SC Thermal Potential"
 
     @property

--- a/cea/plots/solar_technology_potentials/sc_monthly.py
+++ b/cea/plots/solar_technology_potentials/sc_monthly.py
@@ -1,9 +1,10 @@
 from __future__ import division
 from __future__ import print_function
 
+import pandas as pd
 import plotly.graph_objs as go
 from plotly.offline import plot
-
+import cea.plots.solar_technology_potentials
 from cea.plots.variable_naming import LOGO, COLOR, NAMING
 
 __author__ = "Shanshan Hsieh"
@@ -14,6 +15,98 @@ __version__ = "0.1"
 __maintainer__ = "Daren Thomas"
 __email__ = "cea@arch.ethz.ch"
 __status__ = "Production"
+
+
+class SolarCollectorMonthlyPlotBase(cea.plots.solar_technology_potentials.SolarTechnologyPotentialsPlotBase):
+    """Common functionality for ET / FP plots"""
+
+    def __init__(self, project, parameters, cache):
+        super(SolarCollectorMonthlyPlotBase, self).__init__(project, parameters, cache)
+
+    @property
+    def layout(self):
+        return go.Layout(title=self.title, barmode='stack', yaxis=dict(title='SC Heat Production [MWh]',
+                                                                       domain=[0.35, 1]))
+
+    def calc_graph(self):
+        # calculate graph
+        data_frame = self.data_frame
+        analysis_fields = self.analysis_fields
+
+        graph = []
+        monthly_df = (data_frame.set_index("DATE").resample("M").sum() / 1000).round(2)  # to MW
+        monthly_df["month"] = monthly_df.index.strftime("%B")
+        # analysis_fields_used = monthly_df.columns[monthly_df.columns.isin(analysis_fields)].tolist()
+        total = monthly_df[analysis_fields].sum(axis=1)
+        for field in analysis_fields:
+            y = monthly_df[field]
+            total_percent = (y.divide(total) * 100).round(2).values
+            total_percent_txt = ["(" + str(x) + " %)" for x in total_percent]
+            trace = go.Bar(x=monthly_df["month"], y=y, name=field.split('_kWh', 1)[0], text=total_percent_txt,
+                           marker=dict(color=COLOR[field]))
+            graph.append(trace)
+        return graph
+
+    def calc_table(self):
+        data_frame = self.data_frame
+        analysis_fields = self.analysis_fields
+        total = (data_frame[analysis_fields].sum(axis=0) / 1000).round(2).tolist()  # to MW
+        # calculate top three potentials
+        anchors = []
+        load_names = []
+        monthly_df = (data_frame.set_index("DATE").resample("M").sum() / 1000).round(2)  # to MW
+        monthly_df["month"] = monthly_df.index.strftime("%B")
+        monthly_df.set_index("month", inplace=True)
+        if sum(total) > 0:
+            total_percent = [str(x) + " (" + str(round(x / sum(total) * 100, 1)) + " %)" for x in total]
+            for field in analysis_fields:
+                anchors.append(', '.join(calc_top_three_anchor_loads(monthly_df, field)))
+                load_names.append(NAMING[field] + ' (' + field.split('_kWh', 1)[0] + ')')
+        else:
+            total_percent = ['0 (0%)'] * len(total)
+            for field in analysis_fields:
+                anchors.append('-')
+                load_names.append(NAMING[field] + ' (' + field.split('_kWh', 1)[0] + ')')
+
+        column_names = ['Surface', 'Total [MWh/yr]', 'Months with the highest potentials']
+        column_values = [load_names, total_percent, anchors]
+        table_df = pd.DataFrame({cn: cv for cn, cv in zip(column_names, column_values)}, columns=column_names)
+        return table_df
+
+
+class SolarCollectorEvacuatedTubeMonthlyPlot(SolarCollectorMonthlyPlotBase):
+    name = "Evacuated Tube SC Thermal Potential"
+
+    @property
+    def data_frame(self):
+        return self.SC_ET_hourly_aggregated_kW
+
+    @property
+    def analysis_fields(self):
+        return [f.replace('SC_', 'SC_ET_') for f in self.sc_analysis_fields]
+
+    @property
+    def input_files(self):
+        return [(self.locator.SC_totals, ['ET'])] + [(self.locator.SC_results, [building, 'ET'])
+                                                     for building in self.buildings]
+
+
+class SolarCollectorFlatPlateMonthlyPlot(SolarCollectorMonthlyPlotBase):
+    name = "Flat Plate SC Thermal Potential"
+
+    @property
+    def data_frame(self):
+        return self.SC_FP_hourly_aggregated_kW
+
+    @property
+    def analysis_fields(self):
+        return [f.replace('SC_', 'SC_FP_') for f in self.sc_analysis_fields]
+
+    @property
+    def input_files(self):
+        return [(self.locator.SC_totals, ['FP'])] + [(self.locator.SC_results, [building, 'FP'])
+                                                     for building in self.buildings]
+
 
 
 def sc_district_monthly(data_frame, analysis_fields, title, output_path):
@@ -83,3 +176,46 @@ def calc_top_three_anchor_loads(data_frame, field):
     data_frame = data_frame.sort_values(by=field, ascending=False)
     anchor_list = data_frame[:3].index.values
     return anchor_list
+
+
+def main():
+    """Test this plot"""
+    import cea.config
+    import cea.inputlocator
+    import cea.plots.cache
+    config = cea.config.Configuration()
+    locator = cea.inputlocator.InputLocator(config.scenario)
+    cache = cea.plots.cache.PlotCache(config.project)
+    # cache = cea.plots.cache.NullPlotCache()
+
+    # panel_type=ET
+    SolarCollectorEvacuatedTubeMonthlyPlot(config.project, {'buildings': None,
+                                                            'scenario-name': config.scenario_name,
+                                                            'weather': config.weather},
+                                           cache).plot(auto_open=True)
+    SolarCollectorEvacuatedTubeMonthlyPlot(config.project, {'buildings': locator.get_zone_building_names()[0:2],
+                                                            'scenario-name': config.scenario_name,
+                                                            'weather': config.weather},
+                                           cache).plot(auto_open=True)
+    SolarCollectorEvacuatedTubeMonthlyPlot(config.project, {'buildings': [locator.get_zone_building_names()[0]],
+                                                            'scenario-name': config.scenario_name,
+                                                            'weather': config.weather},
+                                           cache).plot(auto_open=True)
+
+    # panel_type=FP
+    SolarCollectorFlatPlateMonthlyPlot(config.project, {'buildings': None,
+                                                        'scenario-name': config.scenario_name,
+                                                        'weather': config.weather},
+                                       cache).plot(auto_open=True)
+    SolarCollectorFlatPlateMonthlyPlot(config.project, {'buildings': locator.get_zone_building_names()[0:2],
+                                                        'scenario-name': config.scenario_name,
+                                                        'weather': config.weather},
+                                       cache).plot(auto_open=True)
+    SolarCollectorFlatPlateMonthlyPlot(config.project, {'buildings': [locator.get_zone_building_names()[0]],
+                                                        'scenario-name': config.scenario_name,
+                                                        'weather': config.weather},
+                                       cache).plot(auto_open=True)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR implements #1983 (Add solar technologies plots to the dashboard).

To test it, run the Dashboard and add all the plots from the "Solar technology potentials" category. Try out different settings.

The plot "PV/SC/PVT Potential per Building for District" is not as nice as it could be. This is a one-to-one translation from how it was originally generated. I think the "instructions" part are in the way. I will create a separate issue to fix that.