### PR TITLE
1761 fix grasshopper installer script

### DIFF
--- a/cea/interfaces/grasshopper/ghhelper.py
+++ b/cea/interfaces/grasshopper/ghhelper.py
@@ -10,7 +10,6 @@ The main function used is ``run`` which runs a CEA script (as defined in the ``s
 import subprocess
 import os
 import tempfile
-import ConfigParser
 
 import cea.config
 import cea.scripts

--- a/cea/interfaces/grasshopper/install_grasshopper.py
+++ b/cea/interfaces/grasshopper/install_grasshopper.py
@@ -51,6 +51,7 @@ def copy_config(scripts_folder):
 
     cea_dst_folder = get_cea_dst_folder(scripts_folder)
     cea_src_folder = os.path.dirname(cea.config.__file__)
+    shutil.copy(os.path.join(cea_src_folder, 'config.py'), cea_dst_folder)
     shutil.copy(os.path.join(cea_src_folder, 'default.config'), cea_dst_folder)
     shutil.copy(os.path.join(cea_src_folder, '__init__.py'), cea_dst_folder)
 


### PR DESCRIPTION
The PR fixes #1761, which ensures that the `config.py` is copied over to the destination folder for `Grasshopper` to work.