### PR TITLE
Improve description of variable `network-type`

### DIFF
--- a/cea/default.config
+++ b/cea/default.config
@@ -727,7 +727,7 @@ show-plots.help = Set to false to disable showing the plots
 network-type = DH
 network-type.type = ChoiceParameter
 network-type.choices = DH, DC
-network-type.help = type of network used, based on the region, for Switzerland it is DH, for Singapore it is DC
+network-type.help = Type of network to be simulated, either DH (district heating) or DC (district cooling)
 
 network-names =
 network-names.type = ListParameter
@@ -794,7 +794,7 @@ substation-heating-systems.category = Advanced
 network-type = DH
 network-type.type = ChoiceParameter
 network-type.choices = DH, DC
-network-type.help = type of network used, based on the region, for Switzerland it is DH, for Singapore it is DC
+network-type.help = Type of network to be optimized, either DH (district heating) or DC (district cooling)
 
 network-names =
 network-names.type = ListParameter


### PR DESCRIPTION
Variable network-type was described as follows: "type of network used, based on the region, for Switzerland it is DH, for Singapore it is DC". This is not a good description of what the variable means.

1. The point is to describe what DH and DC means (that is, district heating and district cooling), not to associate them to specific countries.
2. The description is inaccurate: what if you are modeling a district cooling network in Switzerland?
3. What if your case study is neither in Singapore nor in Switzerland?

This PR changes the descriptions to something more explanatory:
- For `cea.config.thermal_network`: `network-type.help = Type of network to be simulated, either DH (district heating) or DC (district cooling)`
- For `cea.config.thermal_network_optimization`: `network-type.help = Type of network to be optimized, either DH (district heating) or DC (district cooling)`