### PR TITLE
Thermal network simulation config file

### DIFF
--- a/cea/technologies/thermal_network/thermal_network.py
+++ b/cea/technologies/thermal_network/thermal_network.py
@@ -436,7 +436,7 @@ def thermal_network_main(locator, network_type, network_name, file_type, set_dia
     thermal_network.t_target_supply_df = write_substation_temperatures_to_nodes_df(thermal_network.all_nodes_df,
                                                                                    thermal_network.t_target_supply_C)  # (1 x n)
 
-    if config.thermal_network_optimization.use_representative_week_per_month:
+    if config.thermal_network.use_representative_week_per_month:
         # we run the predefined schedule of the first week of each month for the year
         start_t = 0
         stop_t = 2016  # 24 hours x 7 days x 12 months
@@ -457,7 +457,7 @@ def thermal_network_main(locator, network_type, network_name, file_type, set_dia
                                                                    use_multiprocessing=config.multiprocessing)
 
         # save results to file
-        if config.thermal_network_optimization.use_representative_week_per_month:
+        if config.thermal_network.use_representative_week_per_month:
             # need to repeat lines to make sure our outputs have 8760 timesteps. Otherwise plots
             # and network optimization will fail as they expect 8760 timesteps.
             edge_mass_flow_for_csv = pd.DataFrame(thermal_network.edge_mass_flow_df)
@@ -587,7 +587,7 @@ def prepare_inputs_of_representative_weeks(thermal_network):
 
 
 def save_all_results_to_csv(csv_outputs, thermal_network):
-    if thermal_network.config.thermal_network_optimization.use_representative_week_per_month:
+    if thermal_network.config.thermal_network.use_representative_week_per_month:
         # Flag indicating that we are running the representative week option, important for the creation of a subfolder with original results below
         representative_week = True
         # need to repeat lines to make sure our outputs have 8760 timesteps. Otherwise plots
@@ -1615,7 +1615,7 @@ def calc_max_edge_flowrate(thermal_network, set_diameter, start_t, stop_t, subst
     """
 
     # create empty DataFrames to store results
-    if config.thermal_network_optimization.use_representative_week_per_month:
+    if config.thermal_network.use_representative_week_per_month:
         thermal_network.edge_mass_flow_df = pd.DataFrame(
             data=np.zeros((2016, len(thermal_network.edge_node_df.columns.values))),
             columns=thermal_network.edge_node_df.columns.values)  # stores values for 2016 timesteps
@@ -1720,7 +1720,7 @@ def calc_max_edge_flowrate(thermal_network, set_diameter, start_t, stop_t, subst
         iterations += 1
 
     # output csv files with node mass flows
-    if config.thermal_network_optimization.use_representative_week_per_month:
+    if config.thermal_network.use_representative_week_per_month:
         # need to repeat lines to make sure our outputs have 8760 timesteps. Otherwise plots
         # and network optimization will fail as they expect 8760 timesteps.
         node_mass_flow_for_csv = pd.DataFrame(thermal_network.node_mass_flow_df)
@@ -2014,7 +2014,7 @@ def initial_diameter_guess(thermal_network, set_diameter, substation_systems, co
 
     # Identify time steps of highest 50 demands
     if thermal_network.network_type == 'DH':
-        if config.thermal_network_optimization.use_representative_week_per_month:
+        if config.thermal_network.use_representative_week_per_month:
             heating_sum = np.zeros(2016)
         else:
             heating_sum = np.zeros(HOURS_IN_YEAR)
@@ -2027,7 +2027,7 @@ def initial_diameter_guess(thermal_network, set_diameter, substation_systems, co
                         'Qhs_sys_' + system + '_kWh']
         timesteps_top_demand = np.argsort(heating_sum)[-50:]  # identifies 50 time steps with largest demand
     else:
-        if config.thermal_network_optimization.use_representative_week_per_month:
+        if config.thermal_network.use_representative_week_per_month:
             cooling_sum = np.zeros(2016)
         else:
             cooling_sum = np.zeros(HOURS_IN_YEAR)
@@ -3418,7 +3418,7 @@ def main(config):
     print('Running thermal_network for network type %s' % network_type)
     print('Running thermal_network for file type %s' % file_type)
     print('Running thermal_network for networks %s' % network_names)
-    if config.thermal_network_optimization.use_representative_week_per_month:
+    if config.thermal_network.use_representative_week_per_month:
         print('Running thermal_network with representative week per month.')
     else:
         print('Running thermal_network with start-t %s' % config.thermal_network.start_t)

--- a/cea/technologies/thermal_network/thermal_network_optimization.py
+++ b/cea/technologies/thermal_network/thermal_network_optimization.py
@@ -68,6 +68,8 @@ class Network_info(object):
 def thermal_network_optimization(config, gv, locator):
     # initialize timer
     start = time.time()
+    # synchronize representative week method in network simulation
+    config.thermal_network.use_representative_week_per_month = config.thermal_network_optimization.use_representative_week_per_month
     # read network type and ensure consistency in network layout and network_info
     network_type = config.thermal_network.network_type
     config.network_layout.network_type = network_type

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ INSTALL_REQUIRES = ['SALib==1.2',  # last version to work with python2
                     'numba',
                     'plotly',
                     'py4design==0.27',
-                    'pymc3',
+                    'pymc3==3.6',
                     'pysal',
                     'pyyaml',
                     'requests',


### PR DESCRIPTION
This PR changes a few lines in `thermal_network.py` so that whether the representative week per month method is defined by the `thermal_network` section of the config file, not `thermal_network_optimization`. 

Up until now the variable was called as `config.thermal_network_optimization.use_representative_week_per_month`, so whether the representative week method is used or not was defined not by the thermal-network section of the config file, but by the thermal-network-optimization section (i.e., when running thermal network simulation the optimization configuration overrides the simulation configuration).