### PR TITLE
Bugfix: Remove 'Open project' default value if path does not exists.

### DIFF
--- a/cea/interfaces/dashboard/landing/routes.py
+++ b/cea/interfaces/dashboard/landing/routes.py
@@ -190,6 +190,9 @@ def route_create_scenario_save():
 def route_open_project():
     cea_config = current_app.cea_config
     project = cea_config.project
+    # Check if the path exists
+    if not os.path.exists(project):
+        project = ''
     return render_template('open_project.html', project=project)
 
 

--- a/cea/interfaces/dashboard/landing/routes.py
+++ b/cea/interfaces/dashboard/landing/routes.py
@@ -54,7 +54,7 @@ def route_project_overview():
     descriptions = {}
     for scenario in scenarios:
         descriptions[scenario] = {}
-        locator = cea.inputlocator.InputLocator(scenario)
+        locator = cea.inputlocator.InputLocator(os.path.join(project_path, scenario))
         zone = locator.get_zone_geometry()
         if os.path.isfile(zone):
             zone_df = geopandas.read_file(zone).to_crs(get_geographic_coordinate_system())
@@ -222,7 +222,7 @@ def route_open_project_scenario(scenario):
 def route_get_images(scenario):
     cea_config = current_app.cea_config
     project_path = cea_config.project
-    locator = cea.inputlocator.InputLocator(scenario)
+    locator = cea.inputlocator.InputLocator(os.path.join(project_path, scenario))
     zone_path = locator.get_zone_geometry()
     if not os.path.isfile(zone_path):
         abort(404, 'Zone file not found')


### PR DESCRIPTION
This PR fixes #1996. Dashboard will check if the project path exists before setting it as the default value.

This also fixes error of using scenario name instead of scenario path for `inputlocator` 