### PR TITLE
add message for script completion to dashboard

### DIFF
--- a/cea/api.py
+++ b/cea/api.py
@@ -3,7 +3,7 @@ Provide access to the scripts exported by the City Energy Analyst.
 """
 
 from __future__ import print_function
-
+import datetime
 
 def register_scripts():
     import cea.config
@@ -25,7 +25,14 @@ def register_scripts():
                     parameter.set(kwargs[parameter_py_name])
             # run the script
             cea_script.print_script_configuration(config)
+            t0 = datetime.datetime.now()
             script_module.main(config)
+
+            # print success message
+            msg = "Script completed. Execution time: %.2fs" % (datetime.datetime.now() - t0).total_seconds()
+            print("")
+            print("-" * len(msg))
+            print(msg)
         if script_module.__doc__:
             script_runner.__doc__ = script_module.__doc__.strip()
         else:


### PR DESCRIPTION
This PR fixes #1968 by adding a script completion message to all tools run by the Dashboard (and other uses of `cea.api`) along with the total time in seconds used by the script.

To test, run a tool in the Dashboard. Example output:

```
City Energy Analyst version 2.16
Running `cea operation-costs` with the following parameters:
- general:scenario = C:\Users\daren-thomas\Dropbox\tmp\reference-case-cooling\baseline
  (default: C:\reference-case-open\baseline)
Running operation-costs with scenario = C:\Users\daren-thomas\Dropbox\tmp\reference-case-cooling\baseline

---------------------------------------
Script completed. Execution time: 0.18s
```