### PR TITLE
2008 demand tool not working when non existing building selected

### DIFF
--- a/bin/trace-inputlocator.bat
+++ b/bin/trace-inputlocator.bat
@@ -16,6 +16,11 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 cea trace-inputlocator --scripts solar-collector
 if %errorlevel% neq 0 exit /b %errorlevel%
 
+cea-config solar-collector --type-scpanel ET
+cea trace-inputlocator --scripts solar-collector
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+
 cea trace-inputlocator --scripts photovoltaic, photovoltaic-thermal
 if %errorlevel% neq 0 exit /b %errorlevel%
 

--- a/cea/config.py
+++ b/cea/config.py
@@ -678,6 +678,13 @@ class MultiChoiceParameter(ChoiceParameter):
     """Like ChoiceParameter, but multiple values from the choices list can be used"""
     typename = 'MultiChoiceParameter'
 
+    def get(self):
+        """Handle case of config file containing "bad" data"""
+        try:
+            return super(MultiChoiceParameter, self).get()
+        except ValueError:
+            return self._choices
+
     def encode(self, value):
         assert not isinstance(value, basestring)
         for choice in value:
@@ -689,7 +696,7 @@ class MultiChoiceParameter(ChoiceParameter):
         choices = parse_string_to_list(value)
         for choice in choices:
             if choice not in self._choices:
-                raise cea.ConfigError(
+                raise ValueError(
                     'Invalid choice %s for %s, choose from: %s' % (choice, self.fqname, self._choices))
         return choices
 

--- a/cea/config.py
+++ b/cea/config.py
@@ -678,13 +678,6 @@ class MultiChoiceParameter(ChoiceParameter):
     """Like ChoiceParameter, but multiple values from the choices list can be used"""
     typename = 'MultiChoiceParameter'
 
-    def get(self):
-        """Handle case of config file containing "bad" data"""
-        try:
-            return super(MultiChoiceParameter, self).get()
-        except ValueError:
-            return self._choices
-
     def encode(self, value):
         assert not isinstance(value, basestring)
         for choice in value:
@@ -694,11 +687,7 @@ class MultiChoiceParameter(ChoiceParameter):
 
     def decode(self, value):
         choices = parse_string_to_list(value)
-        for choice in choices:
-            if choice not in self._choices:
-                raise ValueError(
-                    'Invalid choice %s for %s, choose from: %s' % (choice, self.fqname, self._choices))
-        return choices
+        return [choice for choice in choices if choice in self._choices]
 
 
 class SingleBuildingParameter(ChoiceParameter):


### PR DESCRIPTION
This PR addresses #2008 - to reproduce the bug:

- open `cea.config` file
- set `demand:buildings` to a value like... `X, Y, Z`
- run dashboard, navigate to a project (I used output of `cooling-case-workflow`)
- open demand tool - buggy behavior shows up.
 
With this PR, if the contents of the config file for any derivative of `MultiChoiceParameter` has an in valid choice, that choice is ignored.