### PR TITLE
2026 dashboard tools parameters ignored

### DIFF
--- a/cea/api.py
+++ b/cea/api.py
@@ -20,9 +20,8 @@ def register_scripts():
             option_list = cea_script.parameters
             config.restrict_to(option_list)
             for section, parameter in config.matching_parameters(option_list):
-                parameter_py_name = parameter.name.replace('-', '_')
-                if parameter_py_name in kwargs:
-                    parameter.set(kwargs[parameter_py_name])
+                if parameter.py_name in kwargs:
+                    parameter.set(kwargs[parameter.py_name])
             # run the script
             cea_script.print_script_configuration(config)
             script_module.main(config)

--- a/cea/config.py
+++ b/cea/config.py
@@ -278,6 +278,7 @@ def construct_parameter(parameter_name, section, config):
 
 class Parameter(object):
     typename = 'Parameter'
+
     def __init__(self, name, section, config):
         """
         :param name: The name of the parameter (as it appears in the configuration file, all lowercase)
@@ -305,6 +306,10 @@ class Parameter(object):
 
     def __repr__(self):
         return "<Parameter %s:%s=%s>" % (self.section.name, self.name, self.get())
+
+    @property
+    def py_name(self):
+        return self.name.replace('-', '_')
 
     def initialize(self, parser):
         """

--- a/cea/default.config
+++ b/cea/default.config
@@ -781,13 +781,15 @@ diameter-iteration-limit.help = maximum amount of iterations allowed for the net
 diameter-iteration-limit.category = Advanced
 
 substation-cooling-systems = ahu, aru, scu
-substation-cooling-systems.type = ListParameter
+substation-cooling-systems.type = MultiChoiceParameter
+substation-cooling-systems.choices = ahu, aru, scu
 substation-cooling-systems.help = List of cooling loads to be supplied if we are in DC mode
 substation-cooling-systems.category = Advanced
 
 substation-heating-systems = ahu, aru, shu, ww
-substation-heating-systems.type = ListParameter
-substation-heating-systems.help = List of cooling loads to be supplied if we are in DC mode
+substation-heating-systems.type = MultiChoiceParameter
+substation-heating-systems.choices = ahu, aru, shu, ww
+substation-heating-systems.help = List of cooling loads to be supplied if we are in DH mode
 substation-heating-systems.category = Advanced
 
 [thermal-network-optimization]

--- a/cea/interfaces/dashboard/tools/routes.py
+++ b/cea/interfaces/dashboard/tools/routes.py
@@ -28,7 +28,8 @@ def route_start(script):
     print('/start/%s' % script)
     for parameter in parameters_for_script(script, current_app.cea_config):
         print('%s: %s' % (parameter.name, request.form.get(parameter.name)))
-        kwargs[parameter.name] = parameter.decode(request.form.get(parameter.name))
+        kwargs[parameter.py_name] = parameter.decode(request.form.get(parameter.name))
+    print('/tools/start: kwargs=%s' % kwargs)
     current_app.workers[script] = worker.main(script, **kwargs)
     return jsonify(script)
 

--- a/cea/interfaces/dashboard/tools/static/tools.js
+++ b/cea/interfaces/dashboard/tools/static/tools.js
@@ -7,7 +7,7 @@ function cea_run(script) {
     $('#cea-console-output-body').text('');
     $('#cea-console-output').modal({'show': true, 'backdrop': 'static'});
     $.post('start/' + script, get_parameter_values(), function(data) {
-        setTimeout(update_output, 100, script);
+        setTimeout(update_output, 1000, script);
     }, 'json');
 }
 
@@ -42,7 +42,7 @@ function update_output(script) {
        if (msg === null) {
            $.getJSON('is-alive/' + script, {}, function(msg) {
                if (msg) {
-                   setTimeout(update_output, 100, script);
+                   setTimeout(update_output, 1000, script);
                } else {
                    $('.cea-modal-close').removeAttr('disabled');
                    $.getJSON('exitcode/' + script, {}, function(msg){
@@ -58,7 +58,7 @@ function update_output(script) {
        }
        else {
            $('#cea-console-output-body').append(msg.message);
-           setTimeout(update_output, 100, script);
+           setTimeout(update_output, 1000, script);
        }
     });
 }


### PR DESCRIPTION
This PR fixes #2026 which noticed that tool parameters were being ignored for the `thermal-network` script when run from the Dashboard without first clicking on "Save Configuration".

While at it, I also added the fix from #1814 to the `thermal-network` script so we can see live output of  the script in the Dashboard window.