### PR TITLE
Add collapsible fields for tools

### DIFF
--- a/cea/interfaces/dashboard/tools/routes.py
+++ b/cea/interfaces/dashboard/tools/routes.py
@@ -200,7 +200,18 @@ def route_tool(script_name):
     locator = cea.inputlocator.InputLocator(config.scenario)
     script = cea.scripts.by_name(script_name)
     weather_dict = {wn: locator.get_weather(wn) for wn in locator.get_weather_names()}
-    return render_template('tool.html', script=script, parameters=parameters_for_script(script_name, config),
+
+    parameters = []
+    categories = {}
+    for _, parameter in config.matching_parameters(script.parameters):
+        if parameter.category:
+            if parameter.category not in categories:
+                categories[parameter.category] = []
+            categories[parameter.category].append(parameter)
+        else:
+            parameters.append(parameter)
+
+    return render_template('tool.html', script=script, parameters=parameters, categories=categories,
                            weather_dict=weather_dict)
 
 

--- a/cea/interfaces/dashboard/tools/static/tools.css
+++ b/cea/interfaces/dashboard/tools/static/tools.css
@@ -20,3 +20,19 @@ ul.cea-file-listing li:hover {
     color: #050505;
     background-color: #f5f5f5;
 }
+
+.collapsed:after {
+    content: '\02795'; /* Unicode character for "plus" sign (+) */
+    font-size: 13px;
+    color: #777;
+    float: right;
+    margin-left: 5px;
+}
+
+.panel-title > a[class='']:after {
+    content: "\2796"; /* Unicode character for "minus" sign (-) */
+    font-size: 13px;
+    color: #777;
+    float: right;
+    margin-left: 5px;
+}

--- a/cea/interfaces/dashboard/tools/templates/tool.html
+++ b/cea/interfaces/dashboard/tools/templates/tool.html
@@ -95,6 +95,28 @@
                     {% for parameter in parameters %}
                     {{ input_macros.input(parameter, weather_dict) }}
                     {% endfor %}
+
+                    {% if categories|length != 0 %}
+                    <h3>Other Settings</h3>
+                    {% for category, parameters in categories.items() %}
+                    <div class="panel panel-default">
+                      <div class="panel-heading" role="tab" id="heading-{{ category|replace(' ', '-') }}">
+                        <h4 class="panel-title">
+                          <a class="collapsed" role="button" data-toggle="collapse" href="#collapse-{{ category|replace(' ', '-') }}" aria-expanded="false" aria-controls="collapse-{{ category|replace(' ', '-') }}">
+                            {{ category }}
+                          </a>
+                        </h4>
+                      </div>
+                      <div id="collapse-{{ category|replace(' ', '-') }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-{{ category|replace(' ', '-') }}">
+                        <div class="panel-body">
+                          {% for parameter in parameters %}
+                          {{ input_macros.input(parameter, weather_dict) }}
+                          {% endfor %}
+                        </div>
+                      </div>
+                    </div>
+                    {% endfor %}
+                    {% endif %}
                   </form>
                 </div>
 


### PR DESCRIPTION
This PR resolves #1979, by adding collapsible panels that group input fields based on their parameter category. 

To test this, try these on tools with parameters with categories. Changing settings of parameters in these panels should also be reflected when running the scripts.

![Screenshot_2019-06-28 City Energy Analyst cea cea demand ](https://user-images.githubusercontent.com/34395415/60311668-df282f00-998a-11e9-97a8-fe4065e01348.png)
