### PR TITLE
Bugfix: REFERENCE column is not added when user changes parameters in zone and district helper

### DIFF
--- a/cea/datamanagement/district_geometry_helper.py
+++ b/cea/datamanagement/district_geometry_helper.py
@@ -150,15 +150,17 @@ def clean_attributes(shapefile, buildings_height, buildings_floors, key):
         shapefile["floors_ag"] = [int(x) if x is not np.nan else data_osm_floors_joined for x in
                                   data_floors_sum_with_nan]
         shapefile["height_ag"] = shapefile["floors_ag"] * constants.H_F
-    elif buildings_height is None and buildings_floors is not None:
-        shapefile["floors_ag"] = [buildings_floors] * no_buildings
-        shapefile["height_ag"] = shapefile["floors_ag"] * constants.H_F
-    elif buildings_height is not None and buildings_floors is None:
-        shapefile["height_ag"] = [buildings_height] * no_buildings
-        shapefile["floors_ag"] = [int(math.floor(x)) for x in shapefile["height_ag"] / constants.H_F]
-    else:  # both are not none
-        shapefile["height_ag"] = [buildings_height] * no_buildings
-        shapefile["floors_ag"] = [buildings_floors] * no_buildings
+    else:
+        shapefile['REFERENCE'] = "User - assumption"
+        if buildings_height is None and buildings_floors is not None:
+            shapefile["floors_ag"] = [buildings_floors] * no_buildings
+            shapefile["height_ag"] = shapefile["floors_ag"] * constants.H_F
+        elif buildings_height is not None and buildings_floors is None:
+            shapefile["height_ag"] = [buildings_height] * no_buildings
+            shapefile["floors_ag"] = [int(math.floor(x)) for x in shapefile["height_ag"] / constants.H_F]
+        else:  # both are not none
+            shapefile["height_ag"] = [buildings_height] * no_buildings
+            shapefile["floors_ag"] = [buildings_floors] * no_buildings
 
     #add description
     if "description" in list_of_columns:

--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -64,15 +64,17 @@ def clean_attributes(shapefile, buildings_height, buildings_floors, buildings_he
         shapefile["floors_ag"] = [int(x) if x is not np.nan else data_osm_floors_joined for x in
                                   data_floors_sum_with_nan]
         shapefile["height_ag"] = shapefile["floors_ag"] * constants.H_F
-    elif buildings_height is None and buildings_floors is not None:
-        shapefile["floors_ag"] = [buildings_floors] * no_buildings
-        shapefile["height_ag"] = shapefile["floors_ag"] * constants.H_F
-    elif buildings_height is not None and buildings_floors is None:
-        shapefile["height_ag"] = [buildings_height] * no_buildings
-        shapefile["floors_ag"] = [int(math.floor(x)) for x in shapefile["height_ag"] / constants.H_F]
-    else:  # both are not none
-        shapefile["height_ag"] = [buildings_height] * no_buildings
-        shapefile["floors_ag"] = [buildings_floors] * no_buildings
+    else:
+        shapefile['REFERENCE'] = "User - assumption"
+        if buildings_height is None and buildings_floors is not None:
+            shapefile["floors_ag"] = [buildings_floors] * no_buildings
+            shapefile["height_ag"] = shapefile["floors_ag"] * constants.H_F
+        elif buildings_height is not None and buildings_floors is None:
+            shapefile["height_ag"] = [buildings_height] * no_buildings
+            shapefile["floors_ag"] = [int(math.floor(x)) for x in shapefile["height_ag"] / constants.H_F]
+        else:  # both are not none
+            shapefile["height_ag"] = [buildings_height] * no_buildings
+            shapefile["floors_ag"] = [buildings_floors] * no_buildings
 
     # add fields for floorsa and height below ground
     shapefile["height_bg"] = [buildings_height_below_ground] * no_buildings


### PR DESCRIPTION
This PR solves #2107 and solves #2091.

There was a mistake in the `if` conditions of the `zone-helper` and `district-helper` where the `REFERENCE` column is only created if the user leaves `height_ag` and `floors_ag` blank.