### PR TITLE
Bugfix: Update scenario image if zone file is modified

### DIFF
--- a/cea/interfaces/dashboard/landing/routes.py
+++ b/cea/interfaces/dashboard/landing/routes.py
@@ -68,6 +68,14 @@ def route_project_overview():
         else:
             descriptions[scenario]['Warning'] = 'Zone file does not exist.'
 
+    # Clean .cache images
+    for filepath in glob.glob(os.path.join(os.path.join(project_path, '.cache', '*.png'))):
+        print(filepath)
+        image = os.path.basename(filepath).split('.')[0]
+        if image not in scenarios:
+            os.remove(filepath)
+
+
     return render_template('project_overview.html', project_name=project_name, scenarios=scenarios, descriptions=descriptions)
 
 

--- a/cea/interfaces/dashboard/landing/routes.py
+++ b/cea/interfaces/dashboard/landing/routes.py
@@ -233,7 +233,13 @@ def route_get_images(scenario):
     cache_path = os.path.join(project_path, '.cache')
     image_path = os.path.join(cache_path, scenario+'.png')
 
+    zone_modified = os.path.getmtime(zone_path)
     if not os.path.isfile(image_path):
+        image_modified = 0
+    else:
+        image_modified = os.path.getmtime(image_path)
+
+    if zone_modified > image_modified:
         # Make sure .cache folder exists
         if not os.path.exists(cache_path):
             os.makedirs(cache_path)


### PR DESCRIPTION
This PR resolves #2088.

Scenario images will now be updated in the `project overview` if the `zone` file is updated, by comparing their modification timestamp. Images of deleted/non-existing scenarios in the `.cache` folder will also be deleted.