### PR TITLE
Bugfix: Allow decimal values for number inputs

### DIFF
--- a/cea/interfaces/dashboard/inputs/static/js/table.js
+++ b/cea/interfaces/dashboard/inputs/static/js/table.js
@@ -236,6 +236,9 @@ $(window).load(function () {
                 if (type === 'text') {
                     $(`#cea-input-${ column }`).prop('pattern', '[T][0-9]+')
                         .prop('title', 'T[number]');
+                } else if (type === 'number') {
+                    $(`#cea-input-${ column }`).prop('step', 'any')
+                        .prop('min', '0');
                 }
             }
         });


### PR DESCRIPTION
This PR resolves #2130.

Bugfix
---
- Allow for decimal values to be entered in number inputs in the edit selection menu
- Add validation to reject negative values