### PR TITLE
don't create the inputs folder when opening a project + scenario

### DIFF
--- a/cea/datamanagement/terrain_helper.py
+++ b/cea/datamanagement/terrain_helper.py
@@ -68,6 +68,7 @@ def terrain_elevation_extractor(locator, config):
     grid_size = config.terrain_helper.grid_size
     extra_border = np.float32(30)  # adding extra 30 m to avoid errors of no data
     raster_path = locator.get_terrain()
+    locator.ensure_parent_folder_exists(raster_path)
 
     # get the bounding box coordinates
     assert os.path.exists(

--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -122,6 +122,11 @@ def zone_helper(locator, config):
     occupancy_output_path = locator.get_building_occupancy()
     age_output_path = locator.get_building_age()
 
+    # ensure folders exist
+    locator.ensure_parent_folder_exists(zone_output_path)
+    locator.ensure_parent_folder_exists(occupancy_output_path)
+    locator.ensure_parent_folder_exists(age_output_path)
+
     # get zone.shp file and save in folder location
     zone_df = polygon_to_zone(buildings_floors, buildings_floors_below_ground, buildings_height,
                               buildings_height_below_ground,

--- a/cea/inputlocator.py
+++ b/cea/inputlocator.py
@@ -38,6 +38,10 @@ class InputLocator(object):
             os.makedirs(folder)
         return folder
 
+    def ensure_parent_folder_exists(self, file_path):
+        """Use os.makedirs to ensure the folders exist"""
+        self._ensure_folder(os.path.dirname(file_path))
+
     def get_project_path(self):
         """Returns the parent folder of a scenario - this is called a project or 'case-study'"""
         return os.path.dirname(self.scenario)
@@ -550,14 +554,14 @@ class InputLocator(object):
 
     def get_building_geometry_folder(self):
         """scenario/inputs/building-geometry/"""
-        return self._ensure_folder(self.scenario, 'inputs', 'building-geometry')
+        return os.path.join(self.scenario, 'inputs', 'building-geometry')
 
     def get_building_properties_folder(self):
         """scenario/inputs/building-properties/"""
-        return self._ensure_folder(self.scenario, 'inputs', 'building-properties')
+        return os.path.join(self.scenario, 'inputs', 'building-properties')
 
     def get_terrain_folder(self):
-        return self._ensure_folder(self.scenario, 'inputs', 'topography')
+        return os.path.join(self.scenario, 'inputs', 'topography')
 
     def get_zone_geometry(self):
         """scenario/inputs/building-geometry/zone.shp"""

--- a/cea/interfaces/dashboard/landing/routes.py
+++ b/cea/interfaces/dashboard/landing/routes.py
@@ -185,6 +185,7 @@ def route_create_scenario_save():
                     site = geopandas.GeoDataFrame(crs=get_geographic_coordinate_system(),
                                                   geometry=[shape(data['geometry'])])
                     site_path = locator.get_site_polygon()
+                    locator.ensure_parent_folder_exists(site_path)
                     site.to_file(site_path)
                     print('site.shp file created at %s' % site_path)
                     cea.api.zone_helper(cea_config)


### PR DESCRIPTION
How to test:

- create a new project folder, with an empty scenario folder inside
- start CEA Dashboard
- choose "Open Project" and select the project folder
- in the project overview, choose the empty scenario folder
- you should see an image like the one below
- check in Windows Explorer to confirm the scenario folder is still empty

![image](https://user-images.githubusercontent.com/2969564/61295450-56a5ed00-a7d8-11e9-9535-397154fa794c.png)

NEXT:

- in project overview, choose "Create new scenario"
- try out all the possibilities
  - "Generate new input files" should work
  - "Copy input folder from other scenarios in the project." should work
  - "Import input files" should work