### PR TITLE
2095 FIXED "ArcGIS interface installation does not work anymore"

### DIFF
--- a/cea/interfaces/arcgis/arcgishelper.py
+++ b/cea/interfaces/arcgis/arcgishelper.py
@@ -756,6 +756,7 @@ class OptimizationIndividualListParameterInfoBuilder(ParameterInfoBuilder):
                 logging.info('Invalid optimization individual: %s' % individual)
                 return
 
+
 class BuildingsParameterInfoBuilder(ParameterInfoBuilder):
     def get_parameter_info(self):
         parameter = super(BuildingsParameterInfoBuilder, self).get_parameter_info()
@@ -776,6 +777,10 @@ class BuildingsParameterInfoBuilder(ParameterInfoBuilder):
             return ''
         else:
             return cea_parameter.encode(parameter.valueAsText.split(';'))
+
+
+class SingleBuildingParameterInfoBuilder(ChoiceParameterInfoBuilder):
+    pass
 
 
 def list_buildings(scenario):
@@ -804,6 +809,7 @@ BUILDERS = {  # dict[cea.config.Parameter, ParameterInfoBuilder]
     cea.config.FileParameter: FileParameterInfoBuilder,
     cea.config.ListParameter: ListParameterInfoBuilder,
     cea.config.BuildingsParameter: BuildingsParameterInfoBuilder,
+    cea.config.SingleBuildingParameter: SingleBuildingParameterInfoBuilder,
     cea.config.DateParameter: ScalarParameterInfoBuilder,
     cea.config.OptimizationIndividualParameter: OptimizationIndividualParameterInfoBuilder,
     cea.config.OptimizationIndividualListParameter: OptimizationIndividualListParameterInfoBuilder,

--- a/cea/interfaces/arcgis/install_toolbox.py
+++ b/cea/interfaces/arcgis/install_toolbox.py
@@ -72,7 +72,6 @@ def copy_config(toolbox_folder):
 
     cea_dst_folder = get_cea_dst_folder(toolbox_folder)
     cea_src_folder = os.path.dirname(cea.config.__file__)
-    shutil.copy(os.path.join(cea_src_folder, 'concept_parameters.py'), cea_dst_folder)
     shutil.copy(os.path.join(cea_src_folder, 'default.config'), cea_dst_folder)
     shutil.copy(os.path.join(cea_src_folder, '__init__.py'), cea_dst_folder)
 

--- a/cea/interfaces/arcgis/install_toolbox.py
+++ b/cea/interfaces/arcgis/install_toolbox.py
@@ -38,6 +38,7 @@ def main(config):
     copy_config(toolbox_folder)
     copy_scripts(toolbox_folder)
     copy_inputlocator(toolbox_folder)
+    copy_weather_files(toolbox_folder)
 
     with open(os.path.expanduser('~/cea_arcpy.pth'), 'w') as f:
         f.writelines('\n'.join(get_arcgis_paths()))
@@ -72,6 +73,7 @@ def copy_config(toolbox_folder):
 
     cea_dst_folder = get_cea_dst_folder(toolbox_folder)
     cea_src_folder = os.path.dirname(cea.config.__file__)
+    shutil.copy(cea.config.__file__, cea_dst_folder)
     shutil.copy(os.path.join(cea_src_folder, 'default.config'), cea_dst_folder)
     shutil.copy(os.path.join(cea_src_folder, '__init__.py'), cea_dst_folder)
 
@@ -88,6 +90,19 @@ def copy_scripts(toolbox_folder):
 
     categories_dict = cea.scripts._get_categories_dict()
     pickle.dump(categories_dict, open(os.path.join(cea_dst_folder, 'scripts.pickle'), 'w'))
+
+
+def copy_weather_files(toolbox_folder):
+    import cea.databases
+    src_weather_folder = os.path.join(os.path.dirname(cea.databases.__file__), 'weather')
+    dst_weather_folder = os.path.join(toolbox_folder, 'cea', 'databases', 'weather')
+    if not os.path.exists(dst_weather_folder):
+        os.makedirs(dst_weather_folder)
+    for basename in os.listdir(src_weather_folder):
+        if basename.endswith('.epw'):
+            weather_file_path = os.path.join(src_weather_folder, basename)
+            if os.path.isfile(weather_file_path):
+                shutil.copy2(weather_file_path, dst_weather_folder)
 
 
 def get_cea_dst_folder(toolbox_folder):


### PR DESCRIPTION
This issue addresses #2095 in a minimal fashion: The toolbox now loads, but there are three tools that don't currently work:

- MpcBuildingTool
- MpcDistrictTool
- PlotsTool

Since we've dropped official support for this interface, I believe it's ok to leave those three as is and maybe address it later in a separate issue.

To test this PR:

- run `cea install-arcgis` from CEA Console
- open ArcScene and check "My Toolboxes/City Energy Analyst.pyt"
- run some tools