### PR TITLE
Fix: Dashboard popup tables

### DIFF
--- a/cea/interfaces/dashboard/plots/static/js/dashboard-plots.js
+++ b/cea/interfaces/dashboard/plots/static/js/dashboard-plots.js
@@ -71,10 +71,10 @@ function load_all_plots() {
         let dashboard_index = this.dataset.ceaDashboardIndex;
         let plot_index = this.dataset.ceaPlotIndex;
         let content_div = $(`#x_content-${dashboard_index}-${plot_index}`);
+        let table_div = $(`#x_table-${dashboard_index}-${plot_index}`);
 
         $.get(`../div/${dashboard_index}/${plot_index}`, function(data){
             content_div.children().replaceWith(data);
-            $('#table-btn-'+plot_index).show();
         }).fail(function(data) {
             // Server error
             if (data.status === 500) {
@@ -86,6 +86,18 @@ function load_all_plots() {
             if (data.status === 404) {
                 content_div.children().replaceWith(data.responseText);
             }
+        });
+
+        $.get(`../table/${dashboard_index}/${plot_index}`, function(data){
+            // When data is not empty
+            if(data.length) {
+                table_div.empty().append(data);
+                $('#table-btn-'+plot_index).show();
+            }
+        }).fail(function(data) {
+            table_div.children().replaceWith("");
+            console.log("error creating plot:", `table-${dashboard_index}-${plot_index}`);
+            console.log(data);
         });
     });
 }

--- a/cea/interfaces/dashboard/plots/static/js/dashboard-plots.js
+++ b/cea/interfaces/dashboard/plots/static/js/dashboard-plots.js
@@ -1,6 +1,20 @@
 /* get list of plots to work on... */
 
 $(document).ready(function() {
+    $( ".table-dialog" ).dialog({
+        autoOpen: false, height: "auto", width: "auto",
+
+        open: function (event, ui) {
+            $(`#${event.target.id}`).dialog( "option", "minWidth", event.target.offsetParent.offsetWidth)
+        },
+        resize: function( event, ui ) {
+            event.target.style.width = '100%';
+        },
+        resizeStop: function( event, ui ) {
+            event.target.style.width = '100%';
+        }
+
+    });
     load_all_plots();
 
     var categories = JSON.parse($('#cea-dashboard-add-plot').attr('data-cea-categories'));
@@ -117,18 +131,7 @@ function add_new_dashboard() {
 }
 
 function open_table(element) {
-    let style = document.styleSheets[0].ownerNode.cloneNode();
-    let height = 500;
-    let width = 900;
-    let table = window.open(`../table/${element.dataset.dashboardIndex}/${element.dataset.plotIndex}`,
-        `table-${element.dataset.dashboardIndex}-${element.dataset.plotIndex}`,
-        `height=${height},width=${width},location=no,menubar=no,status=no,titlebar=no,resizable`);
-    table.onload = function() {
-        table.document.title = `City Energy Analyst | ${element.dataset.plotTitle} Table`;
-        table.document.body.innerHTML = table.document.body.innerHTML || '<p>Table does not exist.</p>';
-        table.document.body.innerHTML = `<h1>${element.dataset.plotTitle}</h1><br>${table.document.body.innerHTML}`;
-        table.document.head.append(style);
-    }
+    $( `#x_table-${element.dataset.dashboardIndex}-${element.dataset.plotIndex}`).dialog( "open" );
 }
 
 window.addEventListener('resize', function () {

--- a/cea/interfaces/dashboard/plots/templates/layout/layout_container.html
+++ b/cea/interfaces/dashboard/plots/templates/layout/layout_container.html
@@ -127,6 +127,9 @@
   {% block layout_javascripts %}
   {% endblock layout_javascripts %}
 
+  <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+  <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+
   <script src="{{ url_for('.static', filename='js/plotly-latest.min.js') }}"></script>
   <script src="{{ url_for('.static', filename='js/dashboard-plots.js') }}?u={{ last_updated }}"></script>
   <script src="{{ url_for('tools_blueprint.static', filename='tools.js') }}"></script>

--- a/cea/interfaces/dashboard/plots/templates/layout/row_layout.html
+++ b/cea/interfaces/dashboard/plots/templates/layout/row_layout.html
@@ -49,8 +49,7 @@
         <div class="x_content" id="x_content-{{ dashboard_index }}-{{ loop.index0 }}">
           <p>Loading plot...</p>
         </div>
-        <div class="x_content table-dialog" id="x_table-{{ dashboard_index }}-{{ loop.index0 }}" title="{{ plot.title }}">
-        </div>
+        <div class="x_content table-dialog" id="x_table-{{ dashboard_index }}-{{ loop.index0 }}" title="{{ plot.title }}"></div>
       </div>
     </div>
   </div>

--- a/cea/interfaces/dashboard/plots/templates/layout/row_layout.html
+++ b/cea/interfaces/dashboard/plots/templates/layout/row_layout.html
@@ -49,9 +49,8 @@
         <div class="x_content" id="x_content-{{ dashboard_index }}-{{ loop.index0 }}">
           <p>Loading plot...</p>
         </div>
-<!--        <div class="x_content" id="x_table-{{ dashboard_index }}-{{ loop.index0 }}">-->
-<!--          <p>Loading table...</p>-->
-<!--        </div>-->
+        <div class="x_content table-dialog" id="x_table-{{ dashboard_index }}-{{ loop.index0 }}" title="{{ plot.title }}">
+        </div>
       </div>
     </div>
   </div>

--- a/cea/interfaces/dashboard/plots/templates/plot_widget_macros.html
+++ b/cea/interfaces/dashboard/plots/templates/plot_widget_macros.html
@@ -40,7 +40,7 @@
     <div class="x_content" id="x_content-{{ dashboard_index }}-{{ plot_index }}">
       <p>Loading plot...</p>
     </div>
-    <div class="x_content table-dialog" id="x_table-{{ dashboard_index }}-{{ loop.index0 }}" title="{{ plot.title }}"></div>
+    <div class="x_content table-dialog" id="x_table-{{ dashboard_index }}-{{ plot_index }}" title="{{ plot.title }}"></div>
   </div>
 </div>
 {% endmacro %}

--- a/cea/interfaces/dashboard/plots/templates/plot_widget_macros.html
+++ b/cea/interfaces/dashboard/plots/templates/plot_widget_macros.html
@@ -40,6 +40,7 @@
     <div class="x_content" id="x_content-{{ dashboard_index }}-{{ plot_index }}">
       <p>Loading plot...</p>
     </div>
+    <div class="x_content table-dialog" id="x_table-{{ dashboard_index }}-{{ loop.index0 }}" title="{{ plot.title }}"></div>
   </div>
 </div>
 {% endmacro %}


### PR DESCRIPTION
This PR resolves #2171, resolves #2172, resolves #2173.

Fixes
---
- Instead of using browser window popups for the plot tables, they appear as draggable modals within the browser.
- Plots without tables will not show the table button in their titlebar