### PR TITLE
Heating case workflow

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,3 +15,6 @@ recursive-include cea/interfaces/dashboard *.html *.js *.css *.otf *.eot *.svg *
 
 include cea/plots/naming.csv
 include cea/glossary.csv
+
+include cea/tests/heating-case.yml
+include cea/tests/cooling-case.yml

--- a/cea/config.py
+++ b/cea/config.py
@@ -430,6 +430,23 @@ class WeatherPathParameter(Parameter):
         return weather_path
 
 
+class WorkflowParameter(Parameter):
+    typename = "WorkflowParameter"
+    examples = {
+        "heating-case": os.path.join(os.path.dirname(__file__), "tests", "heating-case.yml"),
+        "cooling-case": os.path.join(os.path.dirname(__file__), "tests", "cooling-case.yml")
+    }
+
+    def decode(self, value):
+        if value in self.examples:
+            return self.examples[value]
+        elif os.path.exists(value) and value.endswith(".yml"):
+            return value
+        else:
+            print("ERROR: Workflow not found: {workflow} - using heating-case instead".format(workflow=value))
+            return self.examples["heating-case"]
+
+
 class BooleanParameter(Parameter):
     """Read / write boolean parameters to the config file."""
     typename = 'BooleanParameter'

--- a/cea/default.config
+++ b/cea/default.config
@@ -1427,15 +1427,6 @@ mutationprobability = 0.2
 mutationprobability.type = RealParameter
 mutationprobability.help = For optimization mutation
 
-[cooling-case-workflow]
-scenario =
-scenario.type = StringParameter
-scenario.help = Set this to an existing scenario created by cooling-case-workflow to continue an interrupted simulation
-
-last = 0
-last.type = IntegerParameter
-last.help = last attempted step in workflow - index of the first step to run
-
 [workflow]
 workflow = heating-case
 workflow.type = WorkflowParameter

--- a/cea/default.config
+++ b/cea/default.config
@@ -1432,4 +1432,14 @@ workflow = heating-case
 workflow.type = WorkflowParameter
 workflow.help = Either a built-in workflow (heating-case / cooling-case) OR a path to a user-specified workflow.yml
 
+resume = off
+resume.type = BooleanParameter
+resume.help = Turn this parameter on to resume the workflow from the last successful step
+
+resume-file = {general:project}/../resume-workflow.yml
+resume-file.type = FileParameter
+resume-file.extensions = yml
+resume-file.direction = output
+resume-file.help = Path to a file to store information on how to resume a workflow in case it doesn't run through
+
 

--- a/cea/default.config
+++ b/cea/default.config
@@ -1435,3 +1435,10 @@ scenario.help = Set this to an existing scenario created by cooling-case-workflo
 last = 0
 last.type = IntegerParameter
 last.help = last attempted step in workflow - index of the first step to run
+
+[workflow]
+workflow = heating-case
+workflow.type = WorkflowParameter
+workflow.help = Either a built-in workflow (heating-case / cooling-case) OR a path to a user-specified workflow.yml
+
+

--- a/cea/scripts.yml
+++ b/cea/scripts.yml
@@ -5,7 +5,7 @@ Analysis:
     description: Multicriteria analysis
     interfaces: [cli, arcgis, dashboard]
     module: cea.analysis.multicriteria.main
-    parameters: ['general:scenario', 'general:detailed-electricity-pricing', multi-criteria,
+    parameters: ['general:scenario', multi-criteria,
                  'thermal-network:network-names', 'thermal-network:network-type']
 
 
@@ -222,7 +222,7 @@ Optimization:
     module: cea.technologies.thermal_network.thermal_network_optimization
     parameters: ['general:scenario', 'general:weather', 'general:multiprocessing',
                  'general:number-of-cpus-to-keep-free', 'thermal-network', 'thermal-network-optimization',
-                 'network-layout', 'general:detailed-electricity-pricing']
+                 'network-layout']
 
   - name: optimization
     label: Central supply system
@@ -237,8 +237,7 @@ Optimization:
     description: Run decentralized building optimization
     interfaces: [cli, arcgis, dashboard]
     module: cea.optimization.preprocessing.decentralized_building_main
-    parameters: ['general:scenario', 'general:weather', 'decentralized',
-                 'general:detailed-electricity-pricing']
+    parameters: ['general:scenario', 'general:weather', 'decentralized']
 
 
   - name: supply-system-simulation
@@ -408,6 +407,13 @@ default:
     interfaces: [cli]
     module: cea.tests.cooling_case_workflow
     parameters: ['cooling-case-workflow:scenario', 'cooling-case-workflow:last']
+
+  - name: workflow
+    lable: Workflow
+    description: Run a workflow.yml file from start to end
+    interfaces: [cli]
+    module: cea.tests.workflow
+    parameters: [workflow]
 
 
 Documentation:

--- a/cea/scripts.yml
+++ b/cea/scripts.yml
@@ -271,7 +271,7 @@ Thermal networks:
                  'general:number-of-cpus-to-keep-free', 'thermal-network',
                  'thermal-network-optimization:use-representative-week-per-month']
     input-files:
-      - [get_network_layout_nodes_shapefile, network_type, network_name]
+      - [get_network_layout_nodes_shapefile, "thermal-network:network_type", "thermal-network:network_name"]
       - [get_demand_results_file, building_name]
       - [get_thermal_networks]
       - [get_supply_systems]

--- a/cea/scripts.yml
+++ b/cea/scripts.yml
@@ -401,13 +401,6 @@ default:
     module: cea.tests.trace_inputlocator
     parameters: ['general:scenario', trace-inputlocator]
 
-  - name: cooling-case-workflow
-    label: cooling case workflow
-    description: Run the cooling case from start to end to test the cea
-    interfaces: [cli]
-    module: cea.tests.cooling_case_workflow
-    parameters: ['cooling-case-workflow:scenario', 'cooling-case-workflow:last']
-
   - name: workflow
     lable: Workflow
     description: Run a workflow.yml file from start to end

--- a/cea/tests/cooling-case.yml
+++ b/cea/tests/cooling-case.yml
@@ -1,0 +1,52 @@
+- config: default
+  "general:multiprocessing": on
+  "general:project": ${TEMP}/${NOW}-heating-case-workflow/reference-case-cooling
+  "radiation-daysim:daysim-bin-directory": ${RAYPATH}
+- script: extract-reference-case
+  parameters:
+    destination: "{general:project}/.."
+    case: cooling
+- config: .
+  "general:scenario-name": baseline
+- script: data-helper
+- script: radiation-daysim
+- script: demand
+- script: emissions
+- script: operation-costs
+- script: network-layout
+  parameters:
+    network-type: DC
+- script: lake-potential
+- script: sewage-potential
+- script: photovoltaic
+- script: solar-collector
+  parameters:
+    type-scpanel: FP
+- script: solar-collector
+  parameters:
+    type-scpanel: ET
+- script: photovoltaic-thermal
+  parameters:
+    type-scpanel: FP
+- script: photovoltaic-thermal
+  parameters:
+    type-scpanel: ET
+- script: thermal-network
+  parameters:
+    network-type: DC
+    use-representative-week-per-month: true
+- script: thermal-network-optimization
+  parameters:
+    network-type: DC
+    use-representative-week-per-month: true
+    yearly-cost-calculations: true
+- script: decentralized
+- script: optimization
+  parameters:
+    initialind: 2
+    ngen: 2
+    halloffame: 5
+    random-seed: 1234
+- script: multi-criteria-analysis
+  parameters:
+    generations: 2

--- a/cea/tests/cooling-case.yml
+++ b/cea/tests/cooling-case.yml
@@ -1,6 +1,6 @@
 - config: default
   "general:multiprocessing": on
-  "general:project": ${TEMP}/${NOW}-heating-case-workflow/reference-case-cooling
+  "general:project": "{general:project}/../reference-case-cooling"
   "radiation-daysim:daysim-bin-directory": ${RAYPATH}
 - script: extract-reference-case
   parameters:

--- a/cea/tests/cooling-case.yml
+++ b/cea/tests/cooling-case.yml
@@ -1,7 +1,7 @@
 - config: default
   "general:multiprocessing": on
-  "general:project": "{general:project}/../reference-case-cooling"
-  "radiation-daysim:daysim-bin-directory": ${RAYPATH}
+  "general:project": "${cea_general_project}/../reference-case-open"
+  "radiation-daysim:daysim-bin-directory": "${cea_radiation-daysim_daysim-bin-directory}"
 - script: extract-reference-case
   parameters:
     destination: "{general:project}/.."

--- a/cea/tests/cooling_case_workflow.py
+++ b/cea/tests/cooling_case_workflow.py
@@ -34,7 +34,7 @@ def main(config):
         config.weather = 'Singapore'
         # local variables
         config.optimization.district_cooling_network = True
-        config.config.supply_system_simulation.district_cooling_network = True
+        config.supply_system_simulation.district_cooling_network = True
         config.thermal_network.network_type = 'DC'
         config.data_helper.region = 'SG'
     else:

--- a/cea/tests/heating-case.yml
+++ b/cea/tests/heating-case.yml
@@ -1,6 +1,6 @@
 - config: default
   "general:multiprocessing": on
-  "general:project": ${TEMP}/${NOW}-heating-case-workflow/reference-case-open
+  "general:project": "{general:project}/../reference-case-open"
   "radiation-daysim:daysim-bin-directory": ${RAYPATH}
 - script: extract-reference-case
   parameters:

--- a/cea/tests/heating-case.yml
+++ b/cea/tests/heating-case.yml
@@ -1,7 +1,7 @@
 - config: default
   "general:multiprocessing": on
-  "general:project": "{general:project}/../reference-case-open"
-  "radiation-daysim:daysim-bin-directory": ${RAYPATH}
+  "general:project": "${cea_general_project}/../reference-case-open"
+  "radiation-daysim:daysim-bin-directory": "${cea_radiation-daysim_daysim-bin-directory}"
 - script: extract-reference-case
   parameters:
     destination: "{general:project}/.."

--- a/cea/tests/heating-case.yml
+++ b/cea/tests/heating-case.yml
@@ -1,0 +1,42 @@
+- script: data-helper
+- script: radiation-daysim
+- script: demand
+- script: emissions
+- script: operation-costs
+- script: network-layout
+  parameters:
+    network-type: DH
+- script: lake-potential
+- script: sewage-potential
+- script: photovoltaic
+- script: solar-collector
+  parameters:
+    type-scpanel: FP
+- script: solar-collector
+  parameters:
+    type-scpanel: ET
+- script: photovoltaic-thermal
+  parameters:
+    type-scpanel: FP
+- script: photovoltaic-thermal
+  parameters:
+    type-scpanel: ET
+- script: thermal-network
+  parameters:
+    network-type: DH
+    use-representative-week-per-month: true
+- script: thermal-network-optimization
+  parameters:
+    network-type: DH
+    use-representative-week-per-month: true
+    yearly-cost-calculations: true
+- script: decentralized
+- script: optimization
+  parameters:
+    initialind: 2
+    ngen: 2
+    halloffame: 5
+    random-seed: 1234
+- script: multi-criteria-analysis
+  parameters:
+    generations: 2

--- a/cea/tests/heating-case.yml
+++ b/cea/tests/heating-case.yml
@@ -1,3 +1,13 @@
+- config: default
+  "general:multiprocessing": on
+  "general:project": ${TEMP}/${NOW}-heating-case-workflow/reference-case-open
+  "radiation-daysim:daysim-bin-directory": ${RAYPATH}
+- script: extract-reference-case
+  parameters:
+    destination: "{general:project}/.."
+    case: open
+- config: .
+  "general:scenario-name": baseline
 - script: data-helper
 - script: radiation-daysim
 - script: demand

--- a/cea/tests/workflow.py
+++ b/cea/tests/workflow.py
@@ -1,0 +1,49 @@
+"""
+Run a workflow.yml file - this is like a cea-are "batch" file for running multiple cea scripts including parameters.
+``cea workflow`` can also pick up from previous (failed?) runs, which can help in debugging.
+"""
+from __future__ import division
+from __future__ import print_function
+
+import os
+import cea.config
+import cea.inputlocator
+import cea.api
+import cea.scripts
+import yaml
+
+__author__ = "Daren Thomas"
+__copyright__ = "Copyright 2019, Architecture and Building Systems - ETH Zurich"
+__credits__ = ["Daren Thomas"]
+__license__ = "MIT"
+__version__ = "0.1"
+__maintainer__ = "Daren Thomas"
+__email__ = "cea@arch.ethz.ch"
+__status__ = "Production"
+
+
+def run(config, script, **kwargs):
+    print('Running {script} with args {args}'.format(script=script, args=kwargs))
+    f = getattr(cea.api, script.replace('-', '_'))
+    f(config=config, **kwargs)
+    print('-' * 80)
+
+
+def main(config):
+    workflow_yml = config.workflow.workflow
+    if not os.path.exists(workflow_yml):
+        raise cea.ConfigError("Workflow YAML file not found: {workflow}".format(workflow=workflow_yml))
+
+    with open(workflow_yml, 'r') as workflow_fp:
+        workflow = yaml.load(workflow_fp)
+
+    for step in workflow:
+        script = cea.scripts.by_name(step["script"])
+        print("Workflow step: script={script}".format(script=script.name))
+        parameters = {p for s, p in config.matching_parameters(script.parameters)}
+        if "parameters" in step:
+            parameters.update(step["parameters"])
+
+
+if __name__ == '__main__':
+    main(cea.config.Configuration())

--- a/cea/tests/workflow.py
+++ b/cea/tests/workflow.py
@@ -31,7 +31,7 @@ def run(config, script, **kwargs):
 
 
 def main(config):
-    os.environ["NOW"] = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
+    set_up_environment_variables(config)
 
     workflow_yml = config.workflow.workflow
     if not os.path.exists(workflow_yml):
@@ -47,6 +47,20 @@ def main(config):
             config = do_config_step(config, step)
         else:
             raise ValueError("Invalid step configuration: {step}".format(step=step))
+
+
+def set_up_environment_variables(config):
+    """
+    create some environment variables to be used when configuring stuff. this includes the variable NOW, plus
+    one variable for each config parameter, named "CEA_{SECTION}_{PARAMETER}".
+
+    This is useful for referring to the "user" config, when basing a workflow of the default config.
+    """
+    os.environ["NOW"] = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
+    for section in config.sections.values():
+        for parameter in section.parameters.values():
+            variable = "CEA_{section}_{parameter}".format(section=section.name, parameter=parameter.name)
+            os.environ[variable] = parameter.get_raw()
 
 
 def do_config_step(config, step):


### PR DESCRIPTION
This PR adds a new script `cea workflow` (currently only CLI interface supported) that allows running a "workflow.yml" file. The cooling-case-workflow script is removed and the functionality is merged into the workflow script. To test, in the CEA Console, do:

- `cea workflow --workflow heating-case --resume on`
- `cea workflow --workflow cooling-case --resume on`

These scripts will fail after a while, but show exactly how far our workflows currently go.

An example (first few steps) of a workflow.yml file: 

```
- config: default
  "general:multiprocessing": on
  "general:project": "{general:project}/../reference-case-open"
  "radiation-daysim:daysim-bin-directory": ${RAYPATH}
- script: extract-reference-case
  parameters:
    destination: "{general:project}/.."
    case: open
- config: .
  "general:scenario-name": baseline
- script: data-helper
- script: radiation-daysim
- script: demand
- script: emissions
- script: operation-costs
- script: network-layout
  parameters:
    network-type: DH
- script: lake-potential
```

This runs a workflow based on the `default` config file (`default.config`) - other values are `user` (use `cea.config`), `.` (use the one provided to the script or, as in the second config step, the one currently modified) and a path to a user-specified config file can also be used. Inside a config step, environment variables are interpolated (e.g. `${RAYPATH}`) most notably, all the original config variables are saved in the format `${cea_[section-name]_[parameter-name]}` - so elements of the user config file (like daysim bin path and current project) can be used in conjunction with the default config. 

The `script` steps specify a cea script (similar to how to run via CLI) and an optional dict of parameters.