### PR TITLE
Feature: Grid Layout for Dashboard

### DIFF
--- a/cea/interfaces/dashboard/plots/routes.py
+++ b/cea/interfaces/dashboard/plots/routes.py
@@ -38,7 +38,7 @@ def route_dashboard(dashboard_index):
     layout = dashboard.layout
 
     # add new layouts here
-    if layout not in {"map", "row"}:
+    if layout not in {"map", "row", "grid"}:
         layout = "row"  # this is the default layout for Dashboards
 
     return render_template('layout/{}_layout.html'.format(layout), dashboard_index=dashboard_index, dashboards=dashboards,

--- a/cea/interfaces/dashboard/plots/static/css/map_layout.css
+++ b/cea/interfaces/dashboard/plots/static/css/map_layout.css
@@ -6,6 +6,7 @@
   display: flex;
   flex-direction: column;
   padding: 0px 5px;
+  flex-grow: 1;
 }
 
 @media (min-width: 1200px) {

--- a/cea/interfaces/dashboard/plots/templates/layout/grid_layout.html
+++ b/cea/interfaces/dashboard/plots/templates/layout/grid_layout.html
@@ -1,0 +1,29 @@
+{% extends "layout/layout_container.html" %}
+
+{% import 'plot_widget_macros.html' as plot_widget_macros %}
+
+{% block stylesheets %}
+  {{ super() }}
+  <link rel="stylesheet" href="{{ url_for('inputs_blueprint.static', filename='css/map.css') }}">
+  <link rel="stylesheet" href="{{ url_for('plots_blueprint.static', filename='css/map_layout.css') }}">
+{% endblock stylesheets %}
+
+{% block layout %}
+  <div class="row display-flex">
+    {% for i in range(6) %}
+      {% if dashboard.plots[i] is defined%}
+        {{ plot_widget_macros.plot_widget(dashboard_index, i, dashboard.plots[i]) }}
+      {% else %}
+        {{ plot_widget_macros.plot_empty_widget() }}
+      {% endif %}
+    {% endfor %}
+  </div>
+{% endblock layout %}
+
+{% block layout_javascripts %}
+  <script src="https://unpkg.com/deck.gl@latest/dist.min.js"></script>
+  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.0/mapbox-gl.js'></script>
+  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.0/mapbox-gl.css' rel='stylesheet' />
+  <script src="{{ url_for('inputs_blueprint.static', filename='vendor/turf.min.js') }}"></script>
+  <script src="{{ url_for('inputs_blueprint.static', filename='js/mapclass.js') }}?u={{ last_updated }}"></script>
+{% endblock layout_javascripts %}

--- a/cea/interfaces/dashboard/plots/templates/modal/new_dashboard.html
+++ b/cea/interfaces/dashboard/plots/templates/modal/new_dashboard.html
@@ -23,11 +23,15 @@
     <div class="form-group">
       <label class="control-label col-md-3 col-sm-3 col-xs-12">Layout</label>
       <div class="col-md-6 col-sm-6 col-xs-12">
+        {# FIXME: Obtain layout types programmatically #}
         <div class="radio">
           <label><input type="radio" name="layout" value="default" checked>Rows</label>
         </div>
         <div class="radio">
           <label><input type="radio" name="layout" value="map">Map</label>
+        </div>
+        <div class="radio">
+          <label><input type="radio" name="layout" value="grid">Grid</label>
         </div>
       </div>
     </div>

--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -10,6 +10,7 @@ import jinja2
 import plotly.graph_objs
 import plotly.offline
 import cea.inputlocator
+import cea.config
 from cea import MissingInputDataException
 from cea.plots.variable_naming import LOGO, COLOR, NAMING
 
@@ -47,7 +48,12 @@ class PlotBase(object):
         self.buildings = self.process_buildings_parameter() if 'buildings' in self.expected_parameters else None
 
         for parameter_name in self.expected_parameters:
-            assert parameter_name in parameters, "Missing parameter {}".format(parameter_name)
+            # Try to load missing parameters with default values
+            if parameter_name not in parameters:
+                try:
+                    self.parameters[parameter_name] = cea.config.Configuration(cea.config.DEFAULT_CONFIG).get('plots:{}'.format(parameter_name))
+                except Exception:
+                    assert parameter_name in parameters, "Missing parameter {}".format(parameter_name)
 
     def missing_input_files(self):
         """Return the list of missing input files for this plot"""


### PR DESCRIPTION
This PR resolves #2236 

Features
---
- Dashboard now has the grid layout, which is similar to the map layout where the map widget is replaced by two plot widgets.

Fixes
---
- Allow the width of the plot widget to grow to fill free space
- Allow plot parameters to load default values if the user has a older `dashboard.yml` that does not contain newly added parameters