### PR TITLE
Bugfix: Map not initializing if district data does not exist

### DIFF
--- a/cea/interfaces/dashboard/base/templates/site_template/sidebar.html
+++ b/cea/interfaces/dashboard/base/templates/site_template/sidebar.html
@@ -23,17 +23,11 @@
           </ul>
         </li>
       {% if scenario_name != '' %}
-        <li><a><i class="fa fa-building-o"></i> Input Editor <span class="fa fa-chevron-down"></span></a>
-          <ul class="nav child_menu">
-            <li><a href="/inputs/building-properties">Building Properties</a></li>
-<!--            <li><a href="/inputs/table/district">District</a></li>-->
-<!--            <li><a href="/inputs/table/age">Age</a></li>-->
-<!--            <li><a href="/inputs/table/occupancy">Occupancy</a></li>-->
-<!--            <li><a href="/inputs/table/internal-loads">Internal Loads</a></li>-->
-<!--            <li><a href="/inputs/table/supply-systems">Supply Systems</a></li>-->
-<!--            <li><a href="/inputs/table/architecture">Architecture</a></li>-->
-<!--            <li><a href="/inputs/table/restrictions">Restrictions</a></li>-->
-          </ul>
+        <li><a href="/inputs/building-properties"><i class="fa fa-building-o"></i> Input Editor </a>
+<!--          <span class="fa fa-chevron-down"></span></a>-->
+<!--          <ul class="nav child_menu">-->
+<!--            <li><a href="/inputs/building-properties">Building Properties</a></li>-->
+<!--          </ul>-->
         </li>
         <li><a><i class="fa fa-wrench"></i> Tools <span class="fa fa-chevron-down"></span></a>
           <ul class="nav child_menu">

--- a/cea/interfaces/dashboard/inputs/static/js/mapclass.js
+++ b/cea/interfaces/dashboard/inputs/static/js/mapclass.js
@@ -180,8 +180,10 @@ class MapClass {
             points.push([bbox[0],bbox[1]],[bbox[2],bbox[3]])
         }
         if (this.data.hasOwnProperty('district')) {
-            let bbox = this.data.district.bbox;
-            points.push([bbox[0],bbox[1]],[bbox[2],bbox[3]])
+            if (this.data.district) {
+                let bbox = this.data.district.bbox;
+                points.push([bbox[0],bbox[1]],[bbox[2],bbox[3]])
+            }
         }
         let bbox = turf.bbox(turf.multiPoint(points));
         this.cameraOptions = this.deckgl.getMapboxMap().cameraForBounds(

--- a/cea/interfaces/dashboard/inputs/static/js/mapclass.js
+++ b/cea/interfaces/dashboard/inputs/static/js/mapclass.js
@@ -87,11 +87,13 @@ class MapClass {
 
     init({data = {}, urls = {}, extrude = false} = {}) {
         let _this = this;
-        if (data.hasOwnProperty('zone') || this.data.hasOwnProperty('zone')) {
+        try {
             this.data.zone = data.zone;
             $.each(data, function (layer) {
                 console.log(layer, data[layer]);
-                _this.addLayer(layer, data[layer]);
+                if (data[layer]) {
+                    _this.addLayer(layer, data[layer]);
+                }
             });
 
             this.calculateCamera();
@@ -117,7 +119,7 @@ class MapClass {
 
             let _jsonURLs = jsonURLs;
             if (Object.keys(urls).length) {
-                _jsonURLs =  urls;
+                _jsonURLs = urls;
             }
             $.each(_jsonURLs, function (key, value) {
                 $.getJSON(value, function (json) {
@@ -127,9 +129,8 @@ class MapClass {
                     console.log(`Get ${key} failed.`);
                 });
             });
-
-        } else {
-            console.error('Please enter a zone geojson file')
+        } catch (e) {
+            console.error('Init method requires a zone geojson\n', e)
         }
     }
 

--- a/cea/interfaces/dashboard/inputs/templates/table.html
+++ b/cea/interfaces/dashboard/inputs/templates/table.html
@@ -59,7 +59,7 @@
                   <div>
                     <ul class="nav nav-pills">
                       {% for tab in tabs %}
-                      <li class="tab" id="{{ tab }}-tab" data-name="{{ tab }}"><a href="#">{{ tab }}</a></li>
+                      <li class="tab" id="{{ tab }}-tab" data-name="{{ tab }}"><a>{{ tab }}</a></li>
                       {% endfor %}
                     </ul>
                   </div>

--- a/cea/interfaces/dashboard/plots/static/js/map_layout.js
+++ b/cea/interfaces/dashboard/plots/static/js/map_layout.js
@@ -10,7 +10,7 @@ $(document).ready(function () {
         district = data;
     });
 
-    $.when(getZone, getDistrict).done(function () {
+    $.when(getZone, getDistrict).always(function () {
         let map = new MapClass('map-div');
         map.init({
             data:{


### PR DESCRIPTION
This PR resolves #2208 and resolves #2206 

Changes
---
- Navigation to the input editor in the side navbar is changed to a link instead of a drop down.

Fixes
---
- Map is now able to fully initialize even if the district data is not passed in or is undefined.
- Window does not scroll to the top when clicking table tabs in the input editor.