### PR TITLE
FEATURE: allow user-specified region databases for the data-helper

### DIFF
--- a/cea/config.py
+++ b/cea/config.py
@@ -635,7 +635,7 @@ class ChoiceParameter(Parameter):
     typename = 'ChoiceParameter'
 
     def initialize(self, parser):
-        # when called for the first time, make sure there is a `.choices` parameter
+        # when called for the first time, make sure there is a `._choices` parameter
         self._choices = parse_string_to_list(parser.get(self.section.name, self.name + '.choices'))
 
     def encode(self, value):
@@ -652,6 +652,49 @@ class ChoiceParameter(Parameter):
         else:
             assert self._choices, 'No choices for {fqname} to decode {value}'.format(fqname=self.fqname, value=value)
             return self._choices[0]
+
+
+class RegionParameter(ChoiceParameter):
+    """A parameter that can either be set to a region-specific CEA Database (e.g. CH or SG) or to a user-defined
+    folder that has the same structure."""
+    typename = "RegionParameter"
+
+    def initialize(self, parser):
+        self.locator = cea.inputlocator.InputLocator(None)
+
+    @property
+    def _choices(self):
+        """List the technology database template names available"""
+        return [region for region in os.listdir(self.locator.db_path)
+                if os.path.isdir(os.path.join(self.locator.db_path, region))
+                and not region == "weather"]
+
+    def encode(self, value):
+        """Make sure to use the friendly shorthands (e.g. CH and SG) if possible"""
+        if value in self._choices:
+            return value
+        for region in self._choices:
+            if self.locator.are_equal(value, os.path.join(self.locator.db_path, region)):
+                return region
+        if not os.path.exists(value):
+            # return the default value
+            print("Region template path does not exist, using default region. (Not found: {region})".format(
+                region=value))
+            return self.config.default_config.get(self.section.name, self.name)
+        return value
+
+    def decode(self, value):
+        """Return either built-in region name (e.g. CH or SG) OR a full path to the user-supplied template folder"""
+        if value in self._choices:
+            return value
+
+        if os.path.exists(value) and os.path.isdir(value):
+            return value
+        else:
+            print('Region template path does not exist, using default region. (Not found: {region})'.format(
+                region=value))
+            return self.default
+
 
 
 class PlantNodeParameter(ChoiceParameter):

--- a/cea/config.py
+++ b/cea/config.py
@@ -689,12 +689,36 @@ class RegionParameter(ChoiceParameter):
             return value
 
         if os.path.exists(value) and os.path.isdir(value):
-            return value
+            if self.is_valid_template(value):
+                return value
+            else:
+                print('Invalid region template path, using default region instead. (bad template: {region})'.format(
+                    region=value))
+                return self.default
         else:
             print('Region template path does not exist, using default region. (Not found: {region})'.format(
                 region=value))
             return self.default
 
+    def is_valid_template(self, path):
+        """True, if the path is a valid template path - containing the same excel files as the standard regions."""
+        default_template = os.path.join(self.locator.db_path, self.default)
+        for folder in os.listdir(default_template):
+            if not os.path.isdir(os.path.join(default_template, folder)):
+                continue
+            for file in os.listdir(os.path.join(default_template, folder)):
+                default_file_path = os.path.join(default_template, folder, file)
+                if not os.path.isfile(default_file_path):
+                    continue
+                if not os.path.splitext(default_file_path)[1] in {'.xls', '.xlsx'}:
+                    # we're only interested in the excel files
+                    continue
+                template_file_path = os.path.join(path, folder, file)
+                if not os.path.exists(template_file_path):
+                    print("Invalid user-specified region template - file not found: {template_file_path}".format(
+                        template_file_path=template_file_path))
+                    return False
+        return True
 
 
 class PlantNodeParameter(ChoiceParameter):

--- a/cea/datamanagement/data_helper.py
+++ b/cea/datamanagement/data_helper.py
@@ -28,6 +28,7 @@ __maintainer__ = "Daren Thomas"
 __email__ = "cea@arch.ethz.ch"
 __status__ = "Production"
 
+
 def get_technology_related_databases(locator, region):
     technology_database_cea = locator.get_region_specific_db_file(region)
     output_directory = locator.get_technology_folder()
@@ -35,18 +36,20 @@ def get_technology_related_databases(locator, region):
     from distutils.dir_util import copy_tree
     copy_tree(technology_database_cea, output_directory)
 
-def data_helper(locator, config, prop_architecture_flag, prop_hvac_flag, prop_comfort_flag, prop_internal_loads_flag,
-                prop_supply_systems_flag, prop_restrictions_flag, technology_flag):
+
+def data_helper(locator, region, overwrite_technology_folder,
+                update_architecture_dbf, update_technical_systems_dbf, update_indoor_comfort_dbf,
+                update_internal_loads_dbf, update_supply_systems_dbf, update_restrictions_dbf):
     """
     algorithm to query building properties from statistical database
     Archetypes_HVAC_properties.csv. for more info check the integrated demand
     model of Fonseca et al. 2015. Appl. energy.
 
     :param InputLocator locator: an InputLocator instance set to the scenario to work on
-    :param boolean prop_architecture_flag: if True, get properties about the construction and architecture.
-    :param boolean prop_comfort_flag: if True, get properties about thermal comfort.
-    :param boolean prop_hvac_flag: if True, get properties about types of HVAC systems, otherwise False.
-    :param boolean prop_internal_loads_flag: if True, get properties about internal loads, otherwise False.
+    :param boolean update_architecture_dbf: if True, update the construction and architecture properties.
+    :param boolean update_indoor_comfort_dbf: if True, get properties about thermal comfort.
+    :param boolean update_technical_systems_dbf: if True, get properties about types of HVAC systems, otherwise False.
+    :param boolean update_internal_loads_dbf: if True, get properties about internal loads, otherwise False.
 
     The following files are created by this script, depending on which flags were set:
 
@@ -62,9 +65,12 @@ def data_helper(locator, config, prop_architecture_flag, prop_hvac_flag, prop_co
     - indoor_comfort.shp
         describes the queried thermal properties of buildings
     """
+    # get technology database
+    if overwrite_technology_folder:
+        # copy all the region-specific archetypes to the scenario's technology folder
+        get_technology_related_databases(locator, region)
 
     # get occupancy and age files
-    region_database = config.data_helper.region
     building_occupancy_df = dbf_to_dataframe(locator.get_building_occupancy())
     columns = building_occupancy_df.columns
 
@@ -82,9 +88,6 @@ def data_helper(locator, config, prop_architecture_flag, prop_hvac_flag, prop_co
 
     building_age_df = dbf_to_dataframe(locator.get_building_age())
 
-    #get technology database
-    if technology_flag:
-        get_technology_related_databases(locator, region_database)
 
     # get occupant densities from archetypes schedules
     occupant_densities = {}
@@ -106,7 +109,7 @@ def data_helper(locator, config, prop_architecture_flag, prop_hvac_flag, prop_co
     categories_df = building_occupancy_df.merge(building_age_df, on='Name')
 
     # get properties about the construction and architecture
-    if prop_architecture_flag:
+    if update_architecture_dbf:
         architecture_DB = pd.read_excel(locator.get_archetypes_properties(), 'ARCHITECTURE')
         architecture_DB['Code'] = architecture_DB.apply(lambda x: calc_code(x['building_use'], x['year_start'],
                                                                             x['year_end'], x['standard']), axis=1)
@@ -126,7 +129,7 @@ def data_helper(locator, config, prop_architecture_flag, prop_hvac_flag, prop_co
         dataframe_to_dbf(prop_architecture_df_merged[fields], locator.get_building_architecture())
 
     # get properties about types of HVAC systems
-    if prop_hvac_flag:
+    if update_technical_systems_dbf:
         construction_properties_hvac = pd.read_excel(locator.get_archetypes_properties(), 'HVAC')
         construction_properties_hvac['Code'] = construction_properties_hvac.apply(lambda x: calc_code(x['building_use'], x['year_start'],
                                                             x['year_end'], x['standard']), axis=1)
@@ -141,7 +144,7 @@ def data_helper(locator, config, prop_architecture_flag, prop_hvac_flag, prop_co
         fields = ['Name', 'type_cs', 'type_hs', 'type_dhw', 'type_ctrl', 'type_vent']
         dataframe_to_dbf(prop_HVAC_df_merged[fields], locator.get_building_hvac())
 
-    if prop_comfort_flag:
+    if update_indoor_comfort_dbf:
         comfort_DB = pd.read_excel(locator.get_archetypes_properties(), 'INDOOR_COMFORT')
 
         # define comfort
@@ -155,7 +158,7 @@ def data_helper(locator, config, prop_architecture_flag, prop_hvac_flag, prop_co
                   'rhum_max_pc']
         dataframe_to_dbf(prop_comfort_df_merged[fields], locator.get_building_comfort())
 
-    if prop_internal_loads_flag:
+    if update_internal_loads_dbf:
         internal_DB = pd.read_excel(locator.get_archetypes_properties(), 'INTERNAL_LOADS')
 
         # define comfort
@@ -169,7 +172,7 @@ def data_helper(locator, config, prop_architecture_flag, prop_hvac_flag, prop_co
                   'Qhpro_Wm2']
         dataframe_to_dbf(prop_internal_df_merged[fields], locator.get_building_internal())
 
-    if prop_supply_systems_flag:
+    if update_supply_systems_dbf:
         supply_DB = pd.read_excel(locator.get_archetypes_properties(), 'SUPPLY')
         supply_DB['Code'] = supply_DB.apply(lambda x: calc_code(x['building_use'], x['year_start'],
                                                                 x['year_end'], x['standard']), axis=1)
@@ -184,7 +187,7 @@ def data_helper(locator, config, prop_architecture_flag, prop_hvac_flag, prop_co
         fields = ['Name', 'type_cs', 'type_hs', 'type_dhw', 'type_el']
         dataframe_to_dbf(prop_supply_df_merged[fields], locator.get_building_supply())
 
-    if prop_restrictions_flag:
+    if update_restrictions_dbf:
         new_names_df = names_df.copy() #this to avoid that the dataframe is reused
         COLUMNS_ZONE_RESTRICTIONS = ['SOLAR', 'GEOTHERMAL', 'WATERBODY', 'NATURALGAS', 'BIOGAS']
         for field in COLUMNS_ZONE_RESTRICTIONS:
@@ -403,22 +406,25 @@ def main(config):
     print('Running data-helper with scenario = %s' % config.scenario)
     print('Running data-helper with archetypes = %s' % config.data_helper.databases)
 
-    prop_architecture_flag = 'architecture' in config.data_helper.databases
-    prop_hvac_flag = 'HVAC' in config.data_helper.databases
-    prop_comfort_flag = 'comfort' in config.data_helper.databases
-    prop_internal_loads_flag = 'internal-loads' in config.data_helper.databases
-    prop_supply_systems_flag = 'supply' in config.data_helper.databases
-    prop_restrictions_flag = 'restrictions' in config.data_helper.databases
-    technology_flag = 'technology' in config.data_helper.databases
+    update_architecture_dbf = 'architecture' in config.data_helper.databases
+    update_technical_systems_dbf = 'HVAC' in config.data_helper.databases
+    update_indoor_comfort_dbf = 'comfort' in config.data_helper.databases
+    update_internal_loads_dbf = 'internal-loads' in config.data_helper.databases
+    update_supply_systems_dbf = 'supply' in config.data_helper.databases
+    update_restrictions_dbf = 'restrictions' in config.data_helper.databases
+
+    overwrite_technology_folder = config.data_helper.overwrite_technology_folder
 
     locator = cea.inputlocator.InputLocator(config.scenario)
 
-    data_helper(locator=locator, config=config, prop_architecture_flag=prop_architecture_flag,
-                prop_hvac_flag=prop_hvac_flag, prop_comfort_flag=prop_comfort_flag,
-                prop_internal_loads_flag=prop_internal_loads_flag,
-                prop_supply_systems_flag=prop_supply_systems_flag,
-                prop_restrictions_flag=prop_restrictions_flag,
-                technology_flag=technology_flag)
+    data_helper(locator=locator, region=config.data_helper.region,
+                overwrite_technology_folder=overwrite_technology_folder,
+                update_architecture_dbf=update_architecture_dbf,
+                update_technical_systems_dbf=update_technical_systems_dbf,
+                update_indoor_comfort_dbf=update_indoor_comfort_dbf,
+                update_internal_loads_dbf=update_internal_loads_dbf,
+                update_supply_systems_dbf=update_supply_systems_dbf,
+                update_restrictions_dbf=update_restrictions_dbf)
 
 
 if __name__ == '__main__':

--- a/cea/datamanagement/data_helper.py
+++ b/cea/datamanagement/data_helper.py
@@ -30,11 +30,12 @@ __status__ = "Production"
 
 
 def get_technology_related_databases(locator, region):
-    technology_database_cea = locator.get_region_specific_db_file(region)
+    technology_database_template = locator.get_technology_template_for_region(region)
+    print("Copying technology databases from {source}".format(source=technology_database_template))
     output_directory = locator.get_technology_folder()
 
     from distutils.dir_util import copy_tree
-    copy_tree(technology_database_cea, output_directory)
+    copy_tree(technology_database_template, output_directory)
 
 
 def data_helper(locator, region, overwrite_technology_folder,

--- a/cea/default.config
+++ b/cea/default.config
@@ -35,6 +35,10 @@ region.type = ChoiceParameter
 region.choices = CH, SG
 region.help = Region to use for the databases (either CH or SG).
 
+overwrite-technology-folder = true
+overwrite-technology-folder.help = Copy region-specific archetypes to the scenario's technology folder, overwriting previous databases
+overwrite-technology-folder.type = BooleanParameter
+
 databases = comfort, architecture, HVAC, internal-loads, supply, restrictions, technology
 databases.type = MultiChoiceParameter
 databases.choices = comfort, architecture, HVAC, internal-loads, supply, restrictions, technology

--- a/cea/default.config
+++ b/cea/default.config
@@ -41,7 +41,7 @@ overwrite-technology-folder.type = BooleanParameter
 
 databases = comfort, architecture, HVAC, internal-loads, supply, restrictions
 databases.type = MultiChoiceParameter
-databases.choices = comfort, architecture, HVAC, internal-loads, supply, restrictions, technology
+databases.choices = comfort, architecture, HVAC, internal-loads, supply, restrictions
 databases.help = List of input databases to automatically create.
 
 

--- a/cea/default.config
+++ b/cea/default.config
@@ -31,7 +31,7 @@ degub.category = Advanced
 
 [data-helper]
 region = CH
-region.type = ChoiceParameter
+region.type = RegionParameter
 region.choices = CH, SG
 region.help = Region to use for the databases (either CH or SG).
 
@@ -39,7 +39,7 @@ overwrite-technology-folder = true
 overwrite-technology-folder.help = Copy region-specific archetypes to the scenario's technology folder, overwriting previous databases
 overwrite-technology-folder.type = BooleanParameter
 
-databases = comfort, architecture, HVAC, internal-loads, supply, restrictions, technology
+databases = comfort, architecture, HVAC, internal-loads, supply, restrictions
 databases.type = MultiChoiceParameter
 databases.choices = comfort, architecture, HVAC, internal-loads, supply, restrictions, technology
 databases.help = List of input databases to automatically create.

--- a/cea/inputlocator.py
+++ b/cea/inputlocator.py
@@ -534,12 +534,14 @@ class InputLocator(object):
     def get_weather_folder(self):
         return self._ensure_folder(self.get_input_folder(), 'weather')
 
-    def get_region_specific_db_file(self, region):
-        """get path to CEA databases according to the region"""
-        technology_folder = os.path.join(self.db_path, region)
-        if not os.path.exists(technology_folder):
-            raise Exception("you are trying to get the technology database from a location that cea does not support")
-        return technology_folder
+    def get_technology_template_for_region(self, region):
+        """get path to technology database for the region as shipped by the CEA or return the region path, assuming
+        it's a user-supplied technology folder"""
+        if region in os.listdir(self.db_path):
+            return os.path.join(self.db_path, region)
+        if not os.path.exists(region):
+            raise ValueError("You are trying to get the technology database for an unsupported region.")
+        return region
 
     def get_archetypes_properties(self):
         """Returns the database of construction properties to be used by the data-helper. These are copied

--- a/cea/interfaces/dashboard/tools/static/tools.js
+++ b/cea/interfaces/dashboard/tools/static/tools.js
@@ -153,11 +153,6 @@ function save_file_name(target_id) {
     $('#' + target_id).val(file_path);
 }
 
-function select_weather_file(target_id, selected_element) {
-    var weather_file_path = $(selected_element).data('save-file-path');
-    $('#' + target_id).val(weather_file_path);
-}
-
 /**
  * Show an open folder dialog for a cea PathParameter and update the contents of the
  * input field.

--- a/cea/interfaces/dashboard/tools/static/tools.js
+++ b/cea/interfaces/dashboard/tools/static/tools.js
@@ -188,8 +188,3 @@ function save_folder_name(target_id, folder_path) {
     $('#' + target_id).val(folder_path).trigger("input").trigger("change");
     console.log(target_id)
 }
-
-/**
- * Some parameters need special treatment...
- */
-$(document)

--- a/cea/interfaces/dashboard/tools/templates/input_macros.html
+++ b/cea/interfaces/dashboard/tools/templates/input_macros.html
@@ -98,6 +98,22 @@
             </div>
           </div>
 
+          {% elif parameter.typename == "RegionParameter" %}
+          <div class="input-group">
+            <input type="text" class="form-control cea-parameter" value="{{parameter.get()}}" placeholder="{{parameter.help}}"
+                   id="{{parameter.name}}" name="{{parameter.name}}" data-cea-parameter-typename="{{ parameter.typename }}">
+            <div class="input-group-btn">
+              <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown"><span class="caret"></span></button>
+              <ul class="dropdown-menu dropdown-menu-right">
+                {% for region in parameter._choices|sort %}
+                <li><a href="#" onclick="$('#{{parameter.name}}').val('{{region|escapejs}}')">{{ region }}</a></li>
+                {% endfor %}
+                <li role="separator" class="divider"></li>
+                <li><a href="#" onclick="show_open_folder_dialog('{{parameter.fqname}}')">...</a></li>
+              </ul>
+            </div>
+          </div>
+
 
           {% elif parameter.typename == "PathParameter" %}
           <div class="input-group">

--- a/cea/tests/create_unittest_data.py
+++ b/cea/tests/create_unittest_data.py
@@ -36,7 +36,7 @@ def main(output_file):
 
     # run properties script
     import cea.datamanagement.data_helper
-    cea.datamanagement.data_helper.data_helper(locator, config, True, True, True, True, True, True, True)
+    cea.datamanagement.data_helper.data_helper(locator, 'CH', True, True, True, True, True, True, True)
 
     year = weather_data['year'][0]
     date_range = get_dates_from_year(year)

--- a/cea/tests/test_calc_thermal_loads.py
+++ b/cea/tests/test_calc_thermal_loads.py
@@ -37,7 +37,7 @@ class TestCalcThermalLoads(unittest.TestCase):
 
         # run properties script
         import cea.datamanagement.data_helper
-        cea.datamanagement.data_helper.data_helper(cls.locator, cls.config, True, True, True, True, True, True, True)
+        cea.datamanagement.data_helper.data_helper(cls.locator, 'CH', True, True, True, True, True, True, True)
 
         cls.building_properties = BuildingProperties(cls.locator, cls.config.demand.override_variables)
 


### PR DESCRIPTION
This PR updates the `data-helper` tool to allow the user to specify a path for `{data-helper:region}` instead of one of the pre-assigned region values (e.g. "CH" and "SG"). This allows users to create their own region templates.

The data-helper does its best to figure out if the path is a valid region template - defined as containing the same files as the default template (CH database).

In addition, the "technology" database choice was removed, as it didn't work like the other choices - it has been replaced with the parameter `{data-helper:overwrite-technology-folder}` which communicates more clearly what happens - the user can now run the data-helper multiple times _without_ overwriting the regional database (`inputs/technology/*`) by setting `overwrite-technology-folder` to `False`. This addresses #2152.

To test this, try the following:

- test the data-helper in CEA Console by setting the `--region` parameter to
  - SG and CH
  - an invalid path (non-existant)
  - an invalid path (not a region template)
  - the `inputs/technology` folder of another scenario
- test the data-helper tool in the CEA Dashboard, similar to above

This should solve the user story in #2036.