### PR TITLE
Updated version number, changelog and credits for 2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+2019-08-26 - 2.20.3 - #2253 Feature: Supply system map plot @daren-thomas merging as we need it to plan for the 30 sec video for Arno
+2019-08-23 - 2.20.3 - #2258 2117 weather as input file
+2019-08-23 - 2.20.3 - #2257 FEATURE: lazy loading of cea.api module
+2019-08-23 - 2.20.3 - #2252 Fix: Add alert when user changes occupancy @reyery thanks for this!
+2019-08-22 - 2.20.3 - #2250 753 global variables removal 2.21
+2019-08-22 - 2.20.3 - #2248 Add legend toggle drop down to plots
+2019-08-21 - 2.20.3 - #2265 FEATURE: allow user-specified region databases for the data-helper
+2019-08-13 - 2.20.1 - #2241 updating version, changelog and credits for v2.20
+2019-08-13 - 2.19 - #2239 Bugfix: Map not initializing if district data does not exist
+2019-08-13 - 2.19 - #2238 Feature: Grid Layout for Dashboard
 2019-08-08 - 2.19 - #2216 Bugfix: Add script input validation for dashboard
 2019-08-08 - 2.19 - #2225 I2224 optimization heating
 2019-08-08 - 2.19 - #2230 fix occupancy

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -9,6 +9,41 @@ The CEA team
 Starting from version 2.9.1 the credits are structured alphabetically (surname) and split into the categories of developers,
 scrum master, project owner, project sponsor and collaborators.
 
+- Version 2.21 - August 2019
+
+    Developers:
+    * [Amr Elesawy](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/amr-elesawy.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+    * [Gabriel Happle](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/gabriel-happle.html)
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+    * [Reynold Mok](http://https://cityenergyanalyst.com/community)
+    * [Martín Mosteiro Romero](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/martin-mosteiro-romero.html)
+    * [Zhongming Shi](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/zhongming-shi.html)
+    * [Bhargava Krishna Sreepathi ](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/sreepathi-bhargava-krishna.html)
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Scrum master:
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Project owner:
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+
+    Project sponsor:
+    * [Arno Schlueter](http://www.systems.arch.ethz.ch/about-us/team/arno-schlueter.html)
+
+    Collaborators:
+    * Sebastian Troiztsch
+    * Jose Bello
+    * Kian Wee Chen
+    * Jack Hawthorne
+    * Fazel Khayatian
+    * Victor Marty
+    * Paul Neitzel
+    * Thuy-An Nguyen
+    * Lennart Rogenhofer
+    * Bo Lie Ong
+    * Tim Vollrath
+
 - Version 2.20 - August 2019
 
     Developers:

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.20.3"
+__version__ = "2.21"
 
 
 class ConfigError(Exception):

--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -154,7 +154,7 @@ Section "Base Installation" Base_Installation_Section
     DetailPrint "Updating Pip"
     nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip install -U --force-reinstall pip'
     DetailPrint "Pip installing CityEnergyAnalyst==${VER}"
-    nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip install -U --no-deps cityenergyanalyst==${VER}'
+    nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip install -U cityenergyanalyst==${VER}'
     DetailPrint "Pip installing Jupyter"
     nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip install --force-reinstall jupyter ipython'
 


### PR DESCRIPTION
This is the result of the M2.21 sprint which contains new plots as well as changes to how the weather file is used and custom region databases for the data-helper.

To install it on windows, download and run the attached Setup_CityEnergyAnalyst_2.21.exe. See [the guide](https://city-energy-analyst.readthedocs.io/en/latest/getting-started.html#install-and-set-up) for more options.

2019-08-26 - 2.20.3 - #2253 Feature: Supply system map plot @daren-thomas merging as we need it to plan for the 30 sec video for Arno
2019-08-23 - 2.20.3 - #2258 2117 weather as input file
2019-08-23 - 2.20.3 - #2257 FEATURE: lazy loading of cea.api module
2019-08-23 - 2.20.3 - #2252 Fix: Add alert when user changes occupancy @reyery thanks for this!
2019-08-22 - 2.20.3 - #2250 753 global variables removal 2.21
2019-08-22 - 2.20.3 - #2248 Add legend toggle drop down to plots
2019-08-21 - 2.20.3 - #2265 FEATURE: allow user-specified region databases for the data-helper
2019-08-13 - 2.20.1 - #2241 updating version, changelog and credits for v2.20
2019-08-13 - 2.19 - #2239 Bugfix: Map not initializing if district data does not exist
2019-08-13 - 2.19 - #2238 Feature: Grid Layout for Dashboard