### PR TITLE
2279 generate network from building supply properties

### DIFF
--- a/cea/default.config
+++ b/cea/default.config
@@ -986,6 +986,7 @@ multicriteria.help = True to include the results of multi-criteria assessment pl
 generation = 3
 generation.type = IntegerParameter
 generation.help = Select one generation of the optimization routine where the supply system is going to be studied.
+generation.nullable = true
 
 individual = 1
 individual.type = IntegerParameter

--- a/cea/plots/supply_system/supply_system_map.py
+++ b/cea/plots/supply_system/supply_system_map.py
@@ -13,6 +13,7 @@ import cea.plots.supply_system
 from cea.plots.variable_naming import COLORS_TO_RGB
 from cea.technologies.network_layout.main import network_layout
 from cea.utilities.standardize_coordinates import get_geographic_coordinate_system
+from cea.utilities.dbf import dbf_to_dataframe
 
 __author__ = "Jimeno Fonseca"
 __copyright__ = "Copyright 2019, Architecture and Building Systems - ETH Zurich"
@@ -49,10 +50,11 @@ class SupplySystemMapPlot(cea.plots.supply_system.SupplySystemPlotBase):
     def __init__(self, project, parameters, cache):
         super(SupplySystemMapPlot, self).__init__(project, parameters, cache)
         self.generation = self.parameters['generation']
-        self.individual = self.parameters['individual']
+        self.individual = self.parameters['individual'] if self.generation is not None else 0
         self.scenario = self.parameters['scenario-name']
         self.config = cea.config.Configuration()
-        self.input_files = [(self.locator.get_optimization_slave_building_connectivity, [self.individual, self.generation])]
+        self.input_files = [(self.locator.get_optimization_slave_building_connectivity,
+                             [self.individual, self.generation])] if self.generation is not None else []
 
     @property
     def title(self):
@@ -95,9 +97,26 @@ class SupplySystemMapPlot(cea.plots.supply_system.SupplySystemPlotBase):
         return json.dumps(network_json)
 
     def data_processing(self):
-        # get data from generation
-        building_connectivity = pd.read_csv(self.locator.get_optimization_slave_building_connectivity(self.individual,
-                                                                                                      self.generation))
+        building_connectivity = None
+
+        if self.generation is not None:
+            # get data from generation
+            building_connectivity = pd.read_csv(self.locator.get_optimization_slave_building_connectivity
+                                                (self.individual, self.generation))
+            network_name = "gen_" + str(self.generation) + "_ind_" + str(self.individual)
+        else:
+            supply_systems = dbf_to_dataframe(self.locator.get_building_supply())
+            heating_infrastructure = pd.read_excel(self.locator.get_life_cycle_inventory_supply_systems(),
+                                                   sheet_name='HEATING').set_index('code')['scale_hs']
+            cooling_infrastructure = pd.read_excel(self.locator.get_life_cycle_inventory_supply_systems(),
+                                                   sheet_name='COOLING').set_index('code')['scale_cs']
+            building_connectivity = supply_systems[['Name']].copy()
+            building_connectivity['DH_connectivity'] = (
+                    supply_systems['type_hs'].map(heating_infrastructure) == 'DISTRICT').astype(int)
+            building_connectivity['DC_connectivity'] = (
+                    supply_systems['type_cs'].map(cooling_infrastructure) == 'DISTRICT').astype(int)
+
+            network_name = "base"
 
         # FOR DISTRICT HEATING NETWORK
         if building_connectivity[
@@ -107,7 +126,6 @@ class SupplySystemMapPlot(cea.plots.supply_system.SupplySystemPlotBase):
             disconnected_buildings_DH = [x for x in building_connectivity['Name'].values if
                                          x not in connected_buildings_DH]
             network_type = "DH"
-            network_name = "gen_" + str(self.generation) + "_ind_" + str(self.individual)
             path_output_edges_DH, path_output_nodes_DH = self.create_network_layout(connected_buildings_DH,
                                                                                     network_type, network_name)
         else:
@@ -124,7 +142,6 @@ class SupplySystemMapPlot(cea.plots.supply_system.SupplySystemPlotBase):
             disconnected_buildings_DC = [x for x in building_connectivity['Name'].values if
                                          x not in connected_buildings_DC]
             network_type = "DC"
-            network_name = "gen_" + str(self.generation) + "_ind_" + str(self.individual)
             path_output_edges_DC, path_output_nodes_DC = self.create_network_layout(connected_buildings_DC,
                                                                                     network_type, network_name)
         else:


### PR DESCRIPTION
This PR is a first step in solving #2279. The supply map plot is now able to generate a network based on the `supply-system` databases from building properties.

The connectivity of the network would be determined by `supply-system.dbf` with reference to `LCD_infrastructure.xlsx` based on the code e.g. `T1`. It will be connected if the `scale_hs`/`scale_cs` value is equal to `DISTRICT`

Testing
-
- Set the `generation` parameter in `plots-supply-system` to null(empty)
- Run `supply_system_map.py` from plots
  - It should open up a new window showing the supply system map with the correct connectivity.
