### PR TITLE
Bugfix: BooleanParameter can now decode bool values

### DIFF
--- a/cea/config.py
+++ b/cea/config.py
@@ -484,7 +484,7 @@ class BooleanParameter(Parameter):
         return 'true' if value else 'false'
 
     def decode(self, value):
-        return self._boolean_states[value.lower()]
+        return self._boolean_states[str(value).lower()]
 
 
 class IntegerParameter(Parameter):


### PR DESCRIPTION
This PR resolves #2293 by casting value to a `str` before using lower() when decoding using `BooleanParameter`.