### PR TITLE
2019.09.16 run radiation daysim from pycharm

### DIFF
--- a/cea/resources/radiation_daysim/radiation_main.py
+++ b/cea/resources/radiation_daysim/radiation_main.py
@@ -3,6 +3,8 @@ Radiation engine and geometry handler for CEA
 """
 from __future__ import print_function
 from __future__ import division
+
+import os
 import pandas as pd
 import time
 import math
@@ -182,6 +184,9 @@ def main(config):
     #  the selected buildings are the ones for which the individual radiation script is run for
     #  this is only activated when in default.config, run_all_buildings is set as 'False'
     settings = config.radiation_daysim
+
+    # BUGFIX for PyCharm: the PATH variable might not include the daysim-bin-directory, so we add it here
+    os.environ["PATH"] = settings.daysim_bin_directory + os.pathsep + os.environ["PATH"]
 
     print("verifying geometry files")
     print(locator.get_zone_geometry())

--- a/cea/resources/radiation_daysim/radiation_main.py
+++ b/cea/resources/radiation_daysim/radiation_main.py
@@ -114,7 +114,7 @@ def buildings2radiance(rad, building_surface_properties, geometry_3D_zone, geome
         ## for the surrounding buildings only, walls and roofs
         id = 0
         for pypolygon in building_surfaces['walls']:
-            create_radiance_srf(pypolygon, "surroundingbuildings" + str(id), "reflectance0.2" , rad)
+            create_radiance_srf(pypolygon, "surroundingbuildings" + str(id), "reflectance0.2", rad)
             id += 1
         for pypolygon in building_surfaces['roofs']:
             create_radiance_srf(pypolygon, "surroundingbuildings" + str(id), "reflectance0.2", rad)
@@ -148,6 +148,7 @@ def reader_surface_properties(locator, input_shp):
 
     return surface_properties.set_index('Name').round(decimals=2)
 
+
 def radiation_singleprocessing(rad, geometry_3D_zone, locator, settings):
     if settings.buildings == []:
         # get chunks of buildings to iterate
@@ -163,6 +164,7 @@ def radiation_singleprocessing(rad, geometry_3D_zone, locator, settings):
 
     for chunk_n, building_dict in enumerate(chunks):
         daysim_main.isolation_daysim(chunk_n, rad, building_dict, locator, settings)
+
 
 def main(config):
     """
@@ -215,6 +217,6 @@ def main(config):
 
     print("Daysim simulation finished in %.2f mins" % ((time.time() - time1) / 60.0))
 
+
 if __name__ == '__main__':
     main(cea.config.Configuration())
-


### PR DESCRIPTION
This PR adds a little fix to the `radiation-daysim` script that allows it to be run from PyCharm even if the Daysim binaries aren't in the PATH variable yet - as long as the `cea.config` file points to the correct folder you're good to go.

To test this, 
- make sure the Daysim binaries are not in your PATH variable (e.g., run radiation_main from PyCharm - if it doesn't run through, you should be good for testing)
- make sure `{radiation-daysim:daysim-bin-directory}` is set to a folder containing Daysim binaries (if you installed with the CEA installer, this is given)
- run `radiation_main` from PyCharm. it should now run through.