### PR TITLE
Show Es and Ns variable for architecture in dashboard 

### DIFF
--- a/cea/interfaces/dashboard/inputs/inputs.yml
+++ b/cea/interfaces/dashboard/inputs/inputs.yml
@@ -146,7 +146,11 @@ architecture:
     type: str
   - name: void_deck
     type: float
+  - name: Es
+    type: float
   - name: Hs
+    type: float
+  - name: Ns
     type: float
   - name: wwr_north
     type: float


### PR DESCRIPTION
This PR solves part of #2322.

The variables are now added to the inputs.yml file, which decides which columns are shown in the dashboard input editor.