### PR TITLE
Clarify main-use determination of buildings with exactly equal use mix

### DIFF
--- a/cea/datamanagement/data_helper.py
+++ b/cea/datamanagement/data_helper.py
@@ -219,7 +219,7 @@ def calc_mainuse(uses_df, uses):
         mainuses = [use for use in uses if
                     (indexed_df.loc[building, use] == indexed_df.max(axis=1)[building]) and (use != 'PARKING')]
         if len(mainuses) > 1:
-            print '%s has equal share of %s; the construction properties and systems for %s will be used' % (
+            print '%s has equal share of %s; the construction properties and systems for %s will be used.' % (
             building, ' and '.join(mainuses), mainuses[0])
 
     # get array of main use for each building

--- a/cea/datamanagement/data_helper.py
+++ b/cea/datamanagement/data_helper.py
@@ -212,6 +212,17 @@ def calc_mainuse(uses_df, uses):
     :rtype mainuse: ndarray
 
     """
+
+    # print a warning if there are equal shares of more than one "main" use
+    indexed_df = uses_df.set_index('Name')
+    for building in indexed_df.index:
+        mainuses = [use for use in uses if
+                    (indexed_df.loc[building, use] == indexed_df.max(axis=1)[building]) and (use != 'PARKING')]
+        if len(mainuses) > 1:
+            print '%s has equal share of %s; the construction properties and systems for %s will be used' % (
+            building, ' and '.join(mainuses), mainuses[0])
+
+    # get array of main use for each building
     databaseclean = uses_df[uses].transpose()
     array_max = np.array(databaseclean[databaseclean[:] > 0].idxmax(skipna=True), dtype='S10')
     for i in range(len(array_max)):


### PR DESCRIPTION
Added a warning for buildings that have equal shares of more than one occupancy type that are bigger than any other occupancy type (i.e., they have more than one "main" use). The warning prints out the following message:
```
B02 has equal share of GYM and HOTEL; the construction properties and systems for GYM will be used.
```
The solution is not as elegant as the original code to define the main use (it iterates through the dataframe instead of using arrays), but it is functional.