### PR TITLE
Raise an error for false weather files

### DIFF
--- a/cea/config.py
+++ b/cea/config.py
@@ -465,7 +465,7 @@ class WeatherPathParameter(Parameter):
 
     @property
     def default(self):
-        # override base default, since in decode we've banned empty weather file parameters
+        """override base default, since in decode we've banned empty weather file parameters"""
         return ""
 
 

--- a/cea/config.py
+++ b/cea/config.py
@@ -456,9 +456,9 @@ class WeatherPathParameter(Parameter):
             weather_path = self.locator.get_weather(value)
         elif os.path.exists(value) and value.endswith('.epw'):
             weather_path = value
-        elif any(w.lower().startswith(value.lower()) for w in self.locator.get_weather_names()):
+        elif any(w.lower().startswith(value.lower()) for w in self.locator.get_weather_names()) and value.strip():
             # allow using shortcuts
-            weather_path = [w for w in self.locator.get_weather_names() if w.lower().startswith(value.lower())][0]
+            weather_path = self.locator.get_weather([w for w in self.locator.get_weather_names() if w.lower().startswith(value.lower())][0])
         else:
             raise cea.ConfigError("Invalid weather path: {}".format(value))
         return weather_path

--- a/cea/config.py
+++ b/cea/config.py
@@ -456,8 +456,11 @@ class WeatherPathParameter(Parameter):
             weather_path = self.locator.get_weather(value)
         elif os.path.exists(value) and value.endswith('.epw'):
             weather_path = value
+        elif any(w.lower().startswith(value.lower()) for w in self.locator.get_weather_names()):
+            # allow using shortcuts
+            weather_path = [w for w in self.locator.get_weather_names() if w.lower().startswith(value.lower())][0]
         else:
-            weather_path = self.locator.get_weather(self.locator.get_weather_names()[0])
+            raise cea.ConfigError("Invalid weather path: {}".format(value))
         return weather_path
 
 

--- a/cea/config.py
+++ b/cea/config.py
@@ -463,6 +463,11 @@ class WeatherPathParameter(Parameter):
             raise cea.ConfigError("Invalid weather path: {}".format(value))
         return weather_path
 
+    @property
+    def default(self):
+        # override base default, since in decode we've banned empty weather file parameters
+        return ""
+
 
 class WorkflowParameter(Parameter):
     typename = "WorkflowParameter"

--- a/cea/datamanagement/weather_helper.py
+++ b/cea/datamanagement/weather_helper.py
@@ -24,7 +24,7 @@ def copy_weather_file(source_weather_file, locator):
 
     :param string source_weather_file: path to a weather file (``*.epw``)
     :param cea.inputlocator.InputLocator locator: use the InputLocator to find output path
-    :return:
+    :return: (this script doesn't return anything)
     """
     from shutil import copyfile
     assert os.path.exists(source_weather_file), "Could not find weather file: {source_weather_file}".format(
@@ -35,6 +35,7 @@ def copy_weather_file(source_weather_file, locator):
         scenario=os.path.basename(locator.scenario),
         source_weather_file=source_weather_file
     ))
+
 
 def main(config):
     """

--- a/cea/default.config
+++ b/cea/default.config
@@ -108,7 +108,7 @@ occupancy-type.help = Predominant occupancy type of all buildings. Use "Get it f
 
 
 [weather-helper]
-weather =
+weather = Zuerich-Kloten_1990_2010_TMY
 weather.type = WeatherPathParameter
 weather.help = Either a full path to a weather file or the name of one of the weather files contained within the CEA.
 

--- a/cea/default.config
+++ b/cea/default.config
@@ -108,7 +108,7 @@ occupancy-type.help = Predominant occupancy type of all buildings. Use "Get it f
 
 
 [weather-helper]
-weather = Zuerich-Kloten_1990_2010_TMY
+weather =
 weather.type = WeatherPathParameter
 weather.help = Either a full path to a weather file or the name of one of the weather files contained within the CEA.
 


### PR DESCRIPTION
This PR addresses #2333 - basically, if the user manually edited the config file to set the `{weather-helper:weather}` to an invalid value, the CEA was just taking the first valid weather file name from its database and working with that.

The new behavior: Raise an error to make it obvious that the config file has a false value.