### PR TITLE
Release 2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+2019-10-02 - 2.22 - #2338 Moving flexibility (concept project) to legacy
+2019-10-02 - 2.22 - #2353 Project api for electron application
+2019-10-02 - 2.22 - #2337 fix to network layout script (EL is not implemented yet) @daren-thomas thanks for checking this out
 2019-09-24 - 2.21 - #2335 Bugfix: Edit selection in input editor does not work if some old values is equal to the new value
 2019-09-24 - 2.21 - #2334 Show Es and Ns variable for architecture in dashboard
 2019-09-24 - 2.21 - #2320 BUG: fixed default value for workflow parameter

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -9,6 +9,41 @@ The CEA team
 Starting from version 2.9.1 the credits are structured alphabetically (surname) and split into the categories of developers,
 scrum master, project owner, project sponsor and collaborators.
 
+- Version 2.23 - October 2019
+
+    Developers:
+    * [Amr Elesawy](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/amr-elesawy.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+    * [Gabriel Happle](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/gabriel-happle.html)
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+    * [Reynold Mok](http://https://cityenergyanalyst.com/community)
+    * [Martín Mosteiro Romero](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/martin-mosteiro-romero.html)
+    * [Zhongming Shi](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/zhongming-shi.html)
+    * [Bhargava Krishna Sreepathi ](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/sreepathi-bhargava-krishna.html)
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Scrum master:
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Project owner:
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+
+    Project sponsor:
+    * [Arno Schlueter](http://www.systems.arch.ethz.ch/about-us/team/arno-schlueter.html)
+
+    Collaborators:
+    * Sebastian Troiztsch
+    * Jose Bello
+    * Kian Wee Chen
+    * Jack Hawthorne
+    * Fazel Khayatian
+    * Victor Marty
+    * Paul Neitzel
+    * Thuy-An Nguyen
+    * Lennart Rogenhofer
+    * Bo Lie Ong
+    * Tim Vollrath
+
 - Version 2.22 - September 2019
 
     Developers:

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "2.22"
+__version__ = "2.23"
 
 
 class ConfigError(Exception):

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,5 +1,3 @@
-import logging
-
 __version__ = "2.23"
 
 
@@ -29,7 +27,8 @@ class InvalidOccupancyNameException(Exception):
 
 
 def suppres_3rd_party_debug_loggers():
-    # set logging level to WARN for fiona and shapely and others
+    """set logging level to WARN for fiona and shapely and others"""
+    import logging
     loggers_to_silence = ["shapely", "Fiona", "fiona", "urllib3.connectionpool"]
     for log_name in loggers_to_silence:
         log = logging.getLogger(log_name)

--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -111,7 +111,7 @@ Section "Base Installation" Base_Installation_Section
     FileWrite $0 "$\r$\n" ; we write a new line
     FileWrite $0 "SET RAYPATH=$INSTDIR\Dependencies\Daysim"
     FileWrite $0 "$\r$\n" ; we write a new line
-    FileWrite $0 "$\"$INSTDIR\Dependencies\Python\python.exe$\" -m cea.interfaces.cli.cli dashboard"
+    FileWrite $0 "$\"$INSTDIR\Dependencies\Python\python.exe$\" -u -m cea.interfaces.cli.cli dashboard"
     FileClose $0
 
 


### PR DESCRIPTION
This is the result of the M2.23 sprint which focused mainly on the (upcoming) Electron interface and testing the optimization refactoring - both topics will only be released in the next

To install it on windows, download and run the attached Setup_CityEnergyAnalyst_2.23.exe. See the guide for more options.

From the CHANGELOG:

2019-10-02 - 2.22 - #2338 Moving flexibility (concept project) to legacy
2019-10-02 - 2.22 - #2353 Project api for electron application
2019-10-02 - 2.22 - #2337 fix to network layout script (EL is not implemented yet) @daren-thomas thanks for checking this out
