### PR TITLE
Glossary api for electron

### DIFF
--- a/cea/interfaces/dashboard/api/__init__.py
+++ b/cea/interfaces/dashboard/api/__init__.py
@@ -4,6 +4,7 @@ from .tools import api as tools
 from .project import api as project
 from .inputs import api as inputs
 from .dashboard import api as dashboard
+from .glossary import api as glossary
 
 
 blueprint = Blueprint('api', __name__, url_prefix='/api')
@@ -13,8 +14,4 @@ api.add_namespace(tools, path='/tools')
 api.add_namespace(project, path='/project')
 api.add_namespace(inputs, path='/inputs')
 api.add_namespace(dashboard, path='/dashboard')
-
-
-# @api.errorhandler(InvalidPathException)
-# def handle_path_exception(error):
-#     return {'message': 'Invalid Path given'}, 400
+api.add_namespace(glossary, path='/glossary')

--- a/cea/interfaces/dashboard/api/glossary.py
+++ b/cea/interfaces/dashboard/api/glossary.py
@@ -1,0 +1,18 @@
+from flask_restplus import Namespace, Resource
+
+from cea.glossary import read_glossary_df
+
+api = Namespace('Glossary', description='Glossary for variables used in CEA')
+
+
+@api.route('/')
+class Glossary(Resource):
+    def get(self):
+        glossary = read_glossary_df()
+        groups = glossary.groupby('SCRIPT')
+        data = []
+        for group in groups.groups:
+            df = groups.get_group(group)
+            result = df[~df.index.duplicated(keep='first')].fillna('-')
+            data.append({'script': group if group != '-' else 'inputs', 'variables': result.to_dict(orient='records')})
+        return data

--- a/cea/interfaces/dashboard/base/routes.py
+++ b/cea/interfaces/dashboard/base/routes.py
@@ -18,11 +18,6 @@ def route_default():
     return redirect(url_for('landing_blueprint.index'))
 
 
-@blueprint.route('/alive')
-def route_alive():
-    return jsonify({'success': True})
-
-
 @blueprint.route('/glossary_search')
 def route_glossary_search():
     query = request.args.get('query')

--- a/cea/interfaces/dashboard/base/routes.py
+++ b/cea/interfaces/dashboard/base/routes.py
@@ -13,56 +13,6 @@ blueprint = Blueprint(
 )
 
 
-@blueprint.route('/get-tools')
-def route_get_tools():
-    import cea.scripts
-    from itertools import groupby
-
-    tools = sorted(cea.scripts.for_interface('dashboard'), key=lambda t: t.category)
-    result = {}
-    for category, group in groupby(tools, lambda t: t.category):
-        result[category] = [{t.name: {'label': t.label, 'description': t.description}} for t in group]
-
-    return jsonify(result)
-
-
-@blueprint.route('get-tools/<script_name>')
-def route_get_tools_parameters(script_name):
-    config = current_app.cea_config
-    script = cea.scripts.by_name(script_name)
-
-    parameters = []
-    categories = {}
-    for _, parameter in config.matching_parameters(script.parameters):
-        if parameter.category:
-            if parameter.category not in categories:
-                categories[parameter.category] = []
-            categories[parameter.category].append(deconstruct_parameters(parameter))
-        else:
-            parameters.append(deconstruct_parameters(parameter))
-
-    out = {
-        'label': script.label,
-        'category': script.category,
-        'parameters': parameters,
-        'categorical_parameters': categories,
-    }
-    return jsonify(out)
-
-
-def deconstruct_parameters(p):
-    params = {'name': p.name, 'type': p.typename, 'value': p.get(), 'help': p.help}
-    try:
-        params['choices'] = p._choices
-    except AttributeError:
-        pass
-    if p.typename == 'WeatherPathParameter':
-        config = current_app.cea_config
-        locator = cea.inputlocator.InputLocator(config.scenario)
-        params['choices'] = {wn: locator.get_weather(wn) for wn in locator.get_weather_names()}
-    return params
-
-
 @blueprint.route('/')
 def route_default():
     return redirect(url_for('landing_blueprint.index'))

--- a/cea/interfaces/dashboard/base/routes.py
+++ b/cea/interfaces/dashboard/base/routes.py
@@ -18,6 +18,11 @@ def route_default():
     return redirect(url_for('landing_blueprint.index'))
 
 
+@blueprint.route('/alive')
+def route_alive():
+    return jsonify({'success': True})
+
+
 @blueprint.route('/glossary_search')
 def route_glossary_search():
     query = request.args.get('query')

--- a/cea/interfaces/dashboard/dashboard.py
+++ b/cea/interfaces/dashboard/dashboard.py
@@ -141,8 +141,12 @@ def main(config):
     # the protocol for the Connection messages is tuples ('stdout'|'stderr', str)
     app.workers = {}  # script-name -> (Process, Connection)
 
+    print("starting webbrowser timer")
+    threading.Timer(0.5, lambda: webbrowser.open('http://localhost:5050')).start()
+    print("started webbrowser timer")
     print("start socketio.run")
     socketio.run(app, host='localhost', port=5050)
+    print("done socketio.run")
 
 if __name__ == '__main__':
     main(cea.config.Configuration())

--- a/cea/interfaces/dashboard/dashboard.py
+++ b/cea/interfaces/dashboard/dashboard.py
@@ -141,14 +141,8 @@ def main(config):
     # the protocol for the Connection messages is tuples ('stdout'|'stderr', str)
     app.workers = {}  # script-name -> (Process, Connection)
 
-    # FIXME: this needs to be replaced with a better solution
-    print("starting webbrowser timer")
-    threading.Timer(0.5, lambda: webbrowser.open('http://localhost:5050')).start()
-    print("started webbrowser timer")
     print("start socketio.run")
     socketio.run(app, host='localhost', port=5050)
-    print("done socketio.run")
-
 
 if __name__ == '__main__':
     main(cea.config.Configuration())

--- a/cea/interfaces/dashboard/server/__init__.py
+++ b/cea/interfaces/dashboard/server/__init__.py
@@ -5,8 +5,8 @@ The /server api blueprint is used by cea-worker processes to manage jobs and fil
 from __future__ import print_function
 from __future__ import division
 
-from flask import Blueprint
-from flask_restplus import Api
+from flask import Blueprint, current_app
+from flask_restplus import Api, Resource
 from .jobs import api as jobs
 from .streams import api as streams
 
@@ -26,3 +26,16 @@ api = Api(blueprint)
 # there might potentially be more namespaces added in the future, e.g. a method for locating files etc.
 api.add_namespace(jobs, path='/jobs')
 api.add_namespace(streams, path='/streams')
+
+
+@api.route("/alive")
+class ServerAlive(Resource):
+    def get(self):
+        return {'success': True}
+
+
+@api.route("/shutdown")
+class ServerShutdown(Resource):
+    def post(self):
+        current_app.socketio.stop()
+        return {'message': 'Shutting down...'}


### PR DESCRIPTION
This PR resolves #2358 and resolves #2357

Added
-
- Endpoint `/api/glossary`  to get glossary data
- Endpoint `/server/alive` to check that the flask server is running when launching the electron app
- Endpoint `/server/shutdown` to shutdown the flask server after quitting the electron app

