### PR TITLE
2360 create installer for electron interface

### DIFF
--- a/cea/interfaces/dashboard/dashboard.py
+++ b/cea/interfaces/dashboard/dashboard.py
@@ -141,12 +141,10 @@ def main(config):
     # the protocol for the Connection messages is tuples ('stdout'|'stderr', str)
     app.workers = {}  # script-name -> (Process, Connection)
 
-    print("starting webbrowser timer")
-    threading.Timer(0.5, lambda: webbrowser.open('http://localhost:5050')).start()
-    print("started webbrowser timer")
     print("start socketio.run")
     socketio.run(app, host='localhost', port=5050)
     print("done socketio.run")
+
 
 if __name__ == '__main__':
     main(cea.config.Configuration())

--- a/docs/how-to-create-a-new-release.rst
+++ b/docs/how-to-create-a-new-release.rst
@@ -160,11 +160,26 @@ Uploading to PyPI
 
 .. _twine: https://pypi.python.org/pypi/twine
 
+Updating the CEA Electron interface
+-----------------------------------
+
+For the installer to be able to pick up the newest version of the CEA Electron interface, you need to build it,
+create a release and attach a ``win-unpacked.7z`` to the release. Here are the steps:
+
+- pull the newest version of the ``cea-electron`` repository
+- open CEA Console, navigate to the GitHub repo of the ``cea-electron`` repository
+- type ``yarn dist:dir``, wait for the command to complete
+- the subfolder ``dist`` will contain a folder ``win-unpacked``
+- compress the folder ``win-unpacked`` to ``win-unpacked.7z``
+- open https://github.com/architecture-building-systems/cea-electron/releases in the browser
+- Draft a new release, use a tag corresponding to the CEA version number (e.g. ``v2.23``)
+- Attach the ``win-unpacked.7z`` file to the release (the installer will automatically use the latest release on installation)
+
 
 Updating Link in www.cityenergyanalyst.com/tryit
 --------------------------------------------------
 
-- go to www.cityenergyanalyst.com
+- go to http://www.cityenergyanalyst.com
 - press Esc and try logging into squarespace (the credentials are here_)
 - go to Pages/Try CEA  (it is the last page in the list)
 - go to edit 'Page content'

--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -193,7 +193,7 @@ Section "Create Start menu shortcuts" Create_Start_Menu_Shortcuts_Section
         "$INSTDIR\cea-icon.ico" 0 SW_SHOWNORMAL CONTROL|SHIFT|F10 "Launch the CEA Console"
 
     CreateShortcut "$SMPROGRAMS\${CEA_TITLE}\CEA Dashboard.lnk" "$INSTDIR\win-unpacked\CityEnergyAnalyst.exe" "" \
-        "$INSTDIR\cea-icon.ico" 0 SW_SHOWMAXIMIZED "" "Launch the CEA"
+        "$INSTDIR\cea-icon.ico" 0 SW_SHOWMAXIMIZED "" "Launch the CEA Dashboard"
 
     CreateShortcut "$SMPROGRAMS\${CEA_TITLE}\cea.config.lnk" "$WINDIR\notepad.exe" "$PROFILE\cea.config" \
         "$INSTDIR\cea-icon.ico" 0 SW_SHOWNORMAL "" "Open CEA Configuration file"
@@ -219,8 +219,8 @@ Section /o "Create Desktop shortcuts" Create_Desktop_Shortcuts_Section
     CreateShortCut '$DESKTOP\CEA Console.lnk' '$INSTDIR\Dependencies\cmder\cmder.exe' '/single' \
         "$INSTDIR\cea-icon.ico" 0 SW_SHOWNORMAL CONTROL|SHIFT|F10 "Launch the CEA Console"
 
-    CreateShortcut "$DESKTOP\CEA Dashboard.lnk" "cmd" "/c $INSTDIR\dashboard.bat" \
-        "$INSTDIR\cea-icon.ico" 0 SW_SHOWMINIMIZED "" "Launch the CEA Dashboard"
+    CreateShortcut "$DESKTOP\CEA Dashboard.lnk" "$INSTDIR\win-unpacked\CityEnergyAnalyst.exe" "" \
+        "$INSTDIR\cea-icon.ico" 0 SW_SHOWMAXIMIZED "" "Launch the CEA Dashboard"
 
     CreateShortcut "$DESKTOP\cea.config.lnk" "$WINDIR\notepad.exe" "$PROFILE\cea.config" \
         "$INSTDIR\cea-icon.ico" 0 SW_SHOWNORMAL "" "Open CEA Configuration file"

--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -17,6 +17,7 @@ ${StrRep}
 !define CEA_ENV_FILENAME "Dependencies.7z"
 !define RELATIVE_GIT_PATH "Dependencies\cmder\vendor\git-for-windows\bin\git.exe"
 !define CEA_REPO_URL "https://github.com/architecture-building-systems/CityEnergyAnalyst.git"
+!define CEA_ELECTRON_URL "https://github.com/architecture-building-systems/cea-electron/releases/latest/download/win-unpacked.7z"
 
 !define CEA_TITLE "City Energy Analyst"
 
@@ -128,14 +129,31 @@ Section "Base Installation" Base_Installation_Section
         "$INSTDIR\cea-icon.ico" 0 SW_SHOWNORMAL "" "Open CEA Configuration file"
 
 
-    ;Download the CityEnergyAnalyst conda environment
-    DetailPrint "Downloading ${CEA_ENV_FILENAME}"
-    inetc::get ${CEA_ENV_URL} ${CEA_ENV_FILENAME}
-    Pop $R0 ;Get the return value
-    StrCmp $R0 "OK" download_ok
+
+
+    # Download the CEA Electron interface
+    DetailPrint "Downloading CEA Electron interface"
+    inetc::get ${CEA_ELECTRON_URL} "win-unpacked.7z"
+    Pop $R0  # get the return value
+    StrCmp $R0 "OK" download_electron_ok
         MessageBox MB_OK "Download failed: $R0"
         Quit
-    download_ok:
+    download_electron_ok:
+        # get on with life...
+
+    # unzip the electron interface
+    DetailPrint "Extracting win-unpacked.7z"
+    Nsis7z::ExtractWithDetails "win-unpacked.7z" "Extracting Electron interface %s..."
+    Delete "win-unpacked.7z"
+
+    # Download the CityEnergyAnalyst conda environment
+    DetailPrint "Downloading ${CEA_ENV_FILENAME}"
+    inetc::get ${CEA_ENV_URL} ${CEA_ENV_FILENAME}
+    Pop $R0  # Get the return value
+    StrCmp $R0 "OK" download_python_ok
+        MessageBox MB_OK "Download failed: $R0"
+        Quit
+    download_python_ok:
         # get on with life...
 
     # unzip python environment to ${INSTDIR}\Dependencies
@@ -174,8 +192,8 @@ Section "Create Start menu shortcuts" Create_Start_Menu_Shortcuts_Section
     CreateShortCut '$SMPROGRAMS\${CEA_TITLE}\CEA Console.lnk' '$INSTDIR\Dependencies\cmder\cmder.exe' '/single' \
         "$INSTDIR\cea-icon.ico" 0 SW_SHOWNORMAL CONTROL|SHIFT|F10 "Launch the CEA Console"
 
-    CreateShortcut "$SMPROGRAMS\${CEA_TITLE}\CEA Dashboard.lnk" "cmd" "/c $INSTDIR\dashboard.bat" \
-        "$INSTDIR\cea-icon.ico" 0 SW_SHOWMINIMIZED "" "Launch the CEA Dashboard"
+    CreateShortcut "$SMPROGRAMS\${CEA_TITLE}\CEA Dashboard.lnk" "$INSTDIR\win-unpacked\CityEnergyAnalyst.exe" "" \
+        "$INSTDIR\cea-icon.ico" 0 SW_SHOWNORMAL "" "Launch the CEA"
 
     CreateShortcut "$SMPROGRAMS\${CEA_TITLE}\cea.config.lnk" "$WINDIR\notepad.exe" "$PROFILE\cea.config" \
         "$INSTDIR\cea-icon.ico" 0 SW_SHOWNORMAL "" "Open CEA Configuration file"

--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -193,7 +193,7 @@ Section "Create Start menu shortcuts" Create_Start_Menu_Shortcuts_Section
         "$INSTDIR\cea-icon.ico" 0 SW_SHOWNORMAL CONTROL|SHIFT|F10 "Launch the CEA Console"
 
     CreateShortcut "$SMPROGRAMS\${CEA_TITLE}\CEA Dashboard.lnk" "$INSTDIR\win-unpacked\CityEnergyAnalyst.exe" "" \
-        "$INSTDIR\cea-icon.ico" 0 SW_SHOWNORMAL "" "Launch the CEA"
+        "$INSTDIR\cea-icon.ico" 0 SW_SHOWMAXIMIZED "" "Launch the CEA"
 
     CreateShortcut "$SMPROGRAMS\${CEA_TITLE}\cea.config.lnk" "$WINDIR\notepad.exe" "$PROFILE\cea.config" \
         "$INSTDIR\cea-icon.ico" 0 SW_SHOWNORMAL "" "Open CEA Configuration file"


### PR DESCRIPTION
This PR creates an installer for the CEA Electron interface and updates the notes on creating a new release to include providing the CEA Electron interface - which, for now, lives in its own repository and will be developed in lock-step with the rest of the CEA code.

A test-version of the installer can be found here: https://www.dropbox.com/s/nukficzmvq64hyf/Setup_CityEnergyAnalyst_2.23.exe?dl=0

After installation, use the "CEA Dashboard" link from the start menu to open the Electron interface.