### PR TITLE
2356 Update environment.ubuntu.yml

### DIFF
--- a/environment.ubuntu.yml
+++ b/environment.ubuntu.yml
@@ -4,6 +4,8 @@ channels:
   - dlr-sc
   - https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main
   - conda-forge
+  - conda-forge/label/gcc7
+  - conda-forge/label/broken
   - defaults
 dependencies:
   - attrs=19.1.0=py_0
@@ -155,7 +157,7 @@ dependencies:
     - ipython==5.8.0
     - ipython-genutils==0.2.0
     - ipywidgets==7.4.2
-    - jinja2==2.10
+    - jinja2==2.10.1
     - joblib==0.12.5
     - jsonschema==3.0.1
     - jupyter==1.0.0


### PR DESCRIPTION
Some of the dependencies of Ubuntu CEA have been changed to a `broken` state at `conda-forge`. This change means CEA can be installed, but the dependencies should really be updated.

Additionally, `flask` requires `jinja2=2.10.1` to work. I have not checked what the implications of this are.