### PR TITLE
Update URL for CityEnergyAnalyst-GUI

### DIFF
--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -17,7 +17,7 @@ ${StrRep}
 !define CEA_ENV_FILENAME "Dependencies.7z"
 !define RELATIVE_GIT_PATH "Dependencies\cmder\vendor\git-for-windows\bin\git.exe"
 !define CEA_REPO_URL "https://github.com/architecture-building-systems/CityEnergyAnalyst.git"
-!define CEA_ELECTRON_URL "https://github.com/architecture-building-systems/cea-electron/releases/latest/download/win-unpacked.7z"
+!define CEA_ELECTRON_URL "https://github.com/architecture-building-systems/CityEnergyAnalyst-GUI/releases/latest/download/win-unpacked.7z"
 
 !define CEA_TITLE "City Energy Analyst"
 


### PR DESCRIPTION
This PR is a _tiny_ update to the installer to use the newest URL for the CityEnergyAnalyst-GUI. The old URL should still work, but it's better to stay up-to-date.