### PR TITLE
Rename calls to inexistent variable `RH_max_pc`

### DIFF
--- a/cea/datamanagement/data_helper.py
+++ b/cea/datamanagement/data_helper.py
@@ -167,8 +167,8 @@ def data_helper(locator, region, overwrite_technology_folder,
                   'Tcs_setb_C',
                   'Ths_setb_C',
                   'Ve_lpspax',
-                  'RH_min_pc',
-                  'RH_max_pc']
+                  'rhum_min_pc',
+                  'rhum_max_pc']
         prop_comfort_df_merged = names_df.merge(prop_comfort_df, on="Name")
         prop_comfort_df_merged = calculate_average_multiuse(fields,
                                                             prop_comfort_df_merged,

--- a/cea/demand/latent_loads.py
+++ b/cea/demand/latent_loads.py
@@ -130,7 +130,7 @@ def calc_min_moisture_set_point(bpr, tsd, t):
     """
 
     # from bpr get set point for humidification
-    phi_int_set_hu = bpr.comfort['RH_min_pc']
+    phi_int_set_hu = bpr.comfort['rhum_min_pc']
 
     t_int = tsd['T_int'][t]
 
@@ -159,7 +159,7 @@ def calc_max_moisture_set_point(bpr, tsd, t):
     """
 
     # from bpr get set point for humidification
-    phi_int_set_dhu = bpr.comfort['RH_max_pc']
+    phi_int_set_dhu = bpr.comfort['rhum_max_pc']
 
     t_int = tsd['T_int'][t]
 


### PR DESCRIPTION
Someone selectively renamed `rhum_max_pc` and `rhum_min_pc` to `RH_max_pc` and `RH_min_pc` but didn't rename every call to that variable and didn't rename the variables in the databases, so *thermal_loads.py* was broken.

I have reverted both variables to the old naming convention since it's not clear to me that this was an intentional change. Now thermal_loads works correctly again.