### PR TITLE
Terminate running cea worker processes when closing the GUI

### DIFF
--- a/cea/interfaces/dashboard/server/__init__.py
+++ b/cea/interfaces/dashboard/server/__init__.py
@@ -9,6 +9,7 @@ from flask import Blueprint, current_app
 from flask_restplus import Api, Resource
 from .jobs import api as jobs
 from .streams import api as streams
+from ..tools.routes import shutdown_worker_processes
 
 __author__ = "Daren Thomas"
 __copyright__ = "Copyright 2019, Architecture and Building Systems - ETH Zurich"
@@ -37,5 +38,6 @@ class ServerAlive(Resource):
 @api.route("/shutdown")
 class ServerShutdown(Resource):
     def post(self):
+        shutdown_worker_processes()
         current_app.socketio.stop()
         return {'message': 'Shutting down...'}

--- a/cea/interfaces/dashboard/tools/routes.py
+++ b/cea/interfaces/dashboard/tools/routes.py
@@ -14,6 +14,15 @@ blueprint = Blueprint(
     static_folder='static',
 )
 
+# maintain a list of all subprocess.Popen objects created
+worker_processes = []
+
+
+def shutdown_worker_processes():
+    """When shutting down the flask server, make sure any subprocesses are also terminated. See issue #2408."""
+    for process in worker_processes:
+        process.terminate()
+
 
 @blueprint.route("/")
 def route_index():
@@ -24,7 +33,7 @@ def route_index():
 def route_start(jobid):
     """Start a ``cea-worker`` subprocess for the script. (FUTURE: add support for cloud-based workers"""
     print("tools/route_start: {jobid}".format(**locals()))
-    subprocess.Popen(["python", "-m", "cea.worker", jobid])
+    worker_processes.append(subprocess.Popen(["python", "-m", "cea.worker", jobid]))
     return jsonify(jobid)
 
 

--- a/cea/interfaces/dashboard/tools/routes.py
+++ b/cea/interfaces/dashboard/tools/routes.py
@@ -5,6 +5,7 @@ import cea.scripts
 import cea.inputlocator
 import cea.config
 import os
+import psutil
 
 blueprint = Blueprint(
     'tools_blueprint',
@@ -20,13 +21,31 @@ worker_processes = []
 
 def shutdown_worker_processes():
     """When shutting down the flask server, make sure any subprocesses are also terminated. See issue #2408."""
-    for process in worker_processes:
-        process.terminate()
+    for popen in worker_processes:
+        # using code from here: https://stackoverflow.com/a/4229404/2260
+        # to terminate child processes too
+        print("SHUTDOWN: killing child processes of {pid}".format(pid=popen.pid))
+        process = psutil.Process(popen.pid)
+        children = process.children(recursive=True)
+        for child in children:
+            print("-- killing child {pid}".format(pid=child.pid))
+            child.kill()
+        process.kill()
 
 
 @blueprint.route("/")
 def route_index():
     return render_template("job_table.html")
+
+
+@blueprint.route("/workers", methods=["GET"])
+def route_workers():
+    """Return a list of worker processes"""
+    processes = []
+    for worker in worker_processes:
+        processes.append(worker.pid)
+        processes.extend(child.pid for child in psutil.Process(worker.pid).children(recursive=True))
+    return jsonify(sorted(processes))
 
 
 @blueprint.route('/start/<jobid>', methods=['POST'])

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ INSTALL_REQUIRES = ['SALib==1.2',  # last version to work with python2
                     'mock',
                     'numba',
                     'plotly',
+                    'psutil',
                     'py4design==0.27',
                     'pymc3==3.6',  # last version known to work with python2
                     'pysal',


### PR DESCRIPTION
This PR solves #2408 - when closing the CEA GUI, running cea worker processes continued running. With the PR, they are terminated on shutdown of the cea flask server.

To test:

- run the CEA GUI
- open project / scenario
- run a bunch of long-running processes (like `demand` or `thermal-network`)
- observe them in the Task Manager (look for python processes)
- close the CEA GUI
- note the python processes are terminated