### PR TITLE
Allow importing scripts.py from the Grasshopper interface

### DIFF
--- a/cea/scripts.py
+++ b/cea/scripts.py
@@ -85,12 +85,11 @@ class CeaScript(object):
 def _get_categories_dict():
     """Load the categories -> [script] mapping either from the YAML file or, in the case of arcgis / grasshopper,
     which don't support YAML, load from a pickled version generated on the call to ``cea install-toolbox``."""
-    import yaml
-    from cea.utilities.yaml_ordered_dict import OrderedDictYAMLLoader
-
     scripts_yml = os.path.join(os.path.dirname(__file__), 'scripts.yml')
     scripts_pickle = os.path.join(os.path.dirname(__file__), 'scripts.pickle')
     try:
+        import yaml
+        from cea.utilities.yaml_ordered_dict import OrderedDictYAMLLoader
         categories = yaml.load(open(scripts_yml), OrderedDictYAMLLoader)
     except ImportError:
         import pickle


### PR DESCRIPTION
This PR addresses #2375 (CEA failure on Grasshopper) - changes were made to `cea.scripts._get_categories_dict` that made it non-importable in Grasshopper.

Grasshopper runs on an IronPython version that does not have access to pip libraries. That's why `cea.scripts._get_gategories_dict` falls back to `scripts.pickle` to load the categories.

@reyery would you mind testing this, please? It touches code you wrote...