### PR TITLE
2324 resume workflow feature

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,5 +16,5 @@ recursive-include cea/interfaces/dashboard *.html *.js *.css *.otf *.eot *.svg *
 include cea/plots/naming.csv
 include cea/glossary.csv
 
-include cea/tests/heating-case.yml
-include cea/tests/cooling-case.yml
+include cea/workflows/district_cooling_system.yml
+include cea/workflows/district_heating_system.yml

--- a/cea/config.py
+++ b/cea/config.py
@@ -109,7 +109,7 @@ class Configuration(object):
                 self.old_restrictions = None
 
             def __enter__(self):
-                print("WARNING: Ignoring config file restrictions. Consider refactoring the code.")
+                # print("WARNING: Ignoring config file restrictions. Consider refactoring the code.")
                 self.old_restrictions = self.config.restricted_to
                 self.config.restricted_to = None
 


### PR DESCRIPTION
This PR addresses #2324 (Resume workflow feature does not work).

To test it, start a workflow:

- `cea workflow --workflow district-heating-system`

Wait for some simulations to finish (e.g. after radiation, which takes a while) and kill the process. Then, restart the workflow:

- `cea workflow --resume on`

The workflow should skip script steps that already passed and continue where it left off.