### PR TITLE
BUGFIX: UnboundLocalError: local variable 'number_of_occupants' referenced before assignment

### DIFF
--- a/cea/datamanagement/schedule_helper.py
+++ b/cea/datamanagement/schedule_helper.py
@@ -140,7 +140,7 @@ def calc_mixed_schedule(locator,
         schedule_new_data.update(DAY)
         schedule_new_data.update(HOUR)
 
-        # calcualate complementary_data
+        # calculate complementary_data
         schedule_complementary_data = {'METADATA': metadata, 'MONTHLY_MULTIPLIER': monthly_multiplier}
 
         # save cea schedule format

--- a/cea/demand/electrical_loads.py
+++ b/cea/demand/electrical_loads.py
@@ -113,6 +113,16 @@ def calc_Ef(bpr, tsd):
             raise Exception('check potential error in input database of LCA infrastructure / ELECTRICITY')
     elif scale_technology == "NONE":
         tsd['GRID'] = np.zeros(HOURS_IN_YEAR)
+        tsd['GRID_a'] = np.zeros(HOURS_IN_YEAR)
+        tsd['GRID_l'] = np.zeros(HOURS_IN_YEAR)
+        tsd['GRID_data'] = np.zeros(HOURS_IN_YEAR)
+        tsd['GRID_pro'] = np.zeros(HOURS_IN_YEAR)
+        tsd['GRID_aux'] = np.zeros(HOURS_IN_YEAR)
+        tsd['GRID_ww'] = np.zeros(HOURS_IN_YEAR)
+        tsd['GRID_cs'] = np.zeros(HOURS_IN_YEAR)
+        tsd['GRID_hs'] = np.zeros(HOURS_IN_YEAR)
+        tsd['GRID_cdata'] = np.zeros(HOURS_IN_YEAR)
+        tsd['GRID_cre'] = np.zeros(HOURS_IN_YEAR)
         tsd['PV'] = np.zeros(HOURS_IN_YEAR)
     else:
         raise Exception('check potential error in input database of LCA infrastructure / ELECTRICITY')

--- a/cea/demand/schedule_maker/schedule_maker.py
+++ b/cea/demand/schedule_maker/schedule_maker.py
@@ -142,9 +142,9 @@ def calc_schedules(locator,
             for occupant in range(number_of_occupants):
                 final_schedule['Occ_m2pax'] += calc_individual_occupant_schedule(yearly_array)
         else:
-            number_of_occupants = 0
             final_schedule['Occ_m2pax'] = np.round(yearly_array * number_of_occupants)
     else:
+        number_of_occupants = 0
         final_schedule['Occ_m2pax'] = np.zeros(HOURS_IN_YEAR)
 
     # HEAT AND HUMIDITY GAINS FROM OCCUPANTS

--- a/cea/demand/schedule_maker/schedule_maker.py
+++ b/cea/demand/schedule_maker/schedule_maker.py
@@ -142,6 +142,7 @@ def calc_schedules(locator,
             for occupant in range(number_of_occupants):
                 final_schedule['Occ_m2pax'] += calc_individual_occupant_schedule(yearly_array)
         else:
+            number_of_occupants = 0
             final_schedule['Occ_m2pax'] = np.round(yearly_array * number_of_occupants)
     else:
         final_schedule['Occ_m2pax'] = np.zeros(HOURS_IN_YEAR)


### PR DESCRIPTION
This PR fixes an issue with the `schedule_maker` whereby the variable `number_of_occupants` for the case where the number of occupants should be 0 was never assigned. As a result, buildings with no occupants could not be run.