### PR TITLE
Update geometry_generator.py

### DIFF
--- a/cea/resources/radiation_daysim/geometry_generator.py
+++ b/cea/resources/radiation_daysim/geometry_generator.py
@@ -146,7 +146,7 @@ class BuildingData(object):
 
         self.surroundings_buildings_df = self.surroundings_building_records().set_index('Name')
         self.surroundings_building_names = self.surroundings_buildings_df.index.values
-        self.surroundings_building_solid_list = np.vectorize(self.calc_surrounding_building_solids)(
+        self.surroundings_building_solid_list = np.vectorize(self.calc_surrounding_building_solids, otypes=[object])(
             self.surroundings_building_names)
 
         self.district_building_names = np.append(self.zone_building_names, self.surroundings_building_names)


### PR DESCRIPTION
- adding otypes parameter ot np.vectorize call in surrounding geometry calculation.
This fixes #2432.
How to test:
- try running radiation with identical `zone` and `district` geometries, i.e. no surrounding buildings in master vs. in this branch.