### PR TITLE
Release 2.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+2019-11-15 - 2.25.2 - #2455 2349 suspend simulations
+2019-11-14 - 2.25.1 - #2448 Ventilation to avoid unrealistically high temperatures during heating season
+2019-11-12 - 2.25.1 - #2452 Update epwreader.py
+2019-11-11 - 2.25.1 - #2439 Databases major refactoring
+2019-11-07 - 2.25.1 - #2444 Update input api
+2019-11-06 - 2.25.1 - #2420 I1633 gains and losses proportional to conditioned area
+2019-11-05 - 2.25.1 - #2441 Release 2.25, I also updated the CEA website to reflect this
+2019-11-04 - 2.24 - #2434 Delete converter_old_schedules_to_csv.py
 2019-11-04 - 2.24 - #2437 Update input api
 2019-11-04 - 2.24 - #2354 2082 add remaining network plots to dashboard
 2019-11-04 - 2.24 - #2431 Update scripts.yml

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -9,6 +9,42 @@ The CEA team
 Starting from version 2.9.1 the credits are structured alphabetically (surname) and split into the categories of developers,
 scrum master, project owner, project sponsor and collaborators.
 
+- Version 2.26.0 - November 2019
+
+    Developers:
+    * [Amr Elesawy](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/amr-elesawy.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+    * [Gabriel Happle](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/gabriel-happle.html)
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+    * [Reynold Mok](http://https://cityenergyanalyst.com/community)
+    * [Martín Mosteiro Romero](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/martin-mosteiro-romero.html)
+    * [Zhongming Shi](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/zhongming-shi.html)
+    * [Bhargava Krishna Sreepathi ](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/sreepathi-bhargava-krishna.html)
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Scrum master:
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Project owner:
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+
+    Project sponsor:
+    * [Arno Schlueter](http://www.systems.arch.ethz.ch/about-us/team/arno-schlueter.html)
+
+    Collaborators:
+    * Sebastian Troiztsch
+    * Jose Bello
+    * Kian Wee Chen
+    * Jack Hawthorne
+    * Fazel Khayatian
+    * Victor Marty
+    * Paul Neitzel
+    * Thuy-An Nguyen
+    * Bo Lie Ong
+    * Lennart Rogenhofer
+    * Toivo Säwén
+    * Tim Vollrath
+
 - Version 2.25 - November 2019
 
     Developers:

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.26.0a0"
+__version__ = "2.26"
 
 
 class ConfigError(Exception):

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.26"
+__version__ = "2.26.0"
 
 
 class ConfigError(Exception):

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.25.1"
+__version__ = "2.26.0a0"
 
 
 class ConfigError(Exception):

--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -189,6 +189,9 @@ Section "Base Installation" Base_Installation_Section
     DetailPrint "Pip installing Jupyter"
     nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip install --force-reinstall jupyter ipython'
 
+    DetailPrint "Pip installing Sphinx"
+    nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip install --force-reinstall --no-deps sphinx'
+
     # create cea.config file in the %userprofile% directory by calling `cea --help` and set daysim paths
     nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\Scripts\cea.exe" --help'
     WriteINIStr "$PROFILE\cea.config" radiation daysim-bin-directory "$INSTDIR\Dependencies\Daysim"

--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -17,7 +17,7 @@ ${StrRep}
 !define CEA_ENV_FILENAME "Dependencies.7z"
 !define RELATIVE_GIT_PATH "Dependencies\cmder\vendor\git-for-windows\bin\git.exe"
 !define CEA_REPO_URL "https://github.com/architecture-building-systems/CityEnergyAnalyst.git"
-!define CEA_ELECTRON_URL "https://github.com/architecture-building-systems/CityEnergyAnalyst-GUI/releases/latest/download/win-unpacked.7z"
+!define CEA_ELECTRON_URL "https://github.com/architecture-building-systems/CityEnergyAnalyst-GUI/releases/download/v${VER}/win-unpacked.7z"
 
 !define CEA_TITLE "City Energy Analyst"
 
@@ -141,9 +141,9 @@ Section "Base Installation" Base_Installation_Section
     download_electron_ok:
         # get on with life...
 
-    # unzip the electron interface
+    # unzip the electron interface (note, expect a subdirectory called win-unpacked inside the archive)
     DetailPrint "Extracting win-unpacked.7z"
-    SetOutPath "$INSTDIR\win-unpacked"
+    SetOutPath "$INSTDIR"
     Nsis7z::ExtractWithDetails "$INSTDIR\win-unpacked.7z" "Extracting Electron interface %s..."
     Delete "$INSTDIR\win-unpacked.7z"
     SetOutPath "$INSTDIR"


### PR DESCRIPTION
This is the result of the M2.26 sprint which includes a major refactoring of the databases. You'll need to re-run the `data-helper` tool after installing it. We improved the ventilation strategy to avoid unrealistically high temperatures during the heating season, added gains and losses proportional to the conditioned area and added a feature to cancel simulations in the GUI.

To install it on windows, download and run the attached Setup_CityEnergyAnalyst_2.26.0.exe. [See the guide for more options](https://city-energy-analyst.readthedocs.io/en/latest/getting-started.html#install-and-set-up).

From the CHANGELOG:

2019-11-15 - 2.25.2 - #2455 2349 suspend simulations
2019-11-14 - 2.25.1 - #2448 Ventilation to avoid unrealistically high temperatures during heating season
2019-11-12 - 2.25.1 - #2452 Update epwreader.py
2019-11-11 - 2.25.1 - #2439 Databases major refactoring
2019-11-07 - 2.25.1 - #2444 Update input api
2019-11-06 - 2.25.1 - #2420 I1633 gains and losses proportional to conditioned area
2019-11-05 - 2.25.1 - #2441 Release 2.25, I also updated the CEA website to reflect this
2019-11-04 - 2.24 - #2434 Delete converter_old_schedules_to_csv.py