### PR TITLE
Window to wall ratio and envelope properties

### DIFF
--- a/cea/demand/building_properties.py
+++ b/cea/demand/building_properties.py
@@ -880,16 +880,16 @@ def get_envelope_properties(locator, prop_architecture):
             print('WARNING: Invalid construction type found in architecture inputs. The following buildings will not be modeled: {}.'.format(list(df_construction.loc[df_shading['code'].isna()]['Name'])))
         if len(df_leakage.loc[df_leakage['code'].isna()]) > 0:
             print('WARNING: Invalid leakage type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
-                list(df_leakage.loc[df_shading['code'].isna()]['Name'])))
+                list(df_leakage.loc[df_leakage['code'].isna()]['Name'])))
         if len(df_roof[df_roof['code'].isna()]) > 0:
             print('WARNING: Invalid roof type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
-                list(df_roof.loc[df_shading['code'].isna()]['Name'])))
+                list(df_roof.loc[df_roof['code'].isna()]['Name'])))
         if len(df_wall.loc[df_wall['code'].isna()]) > 0:
             print('WARNING: Invalid wall type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
-                list(df_wall.loc[df_shading['code'].isna()]['Name'])))
+                list(df_wall.loc[df_wall['code'].isna()]['Name'])))
         if len(df_win.loc[df_win['code'].isna()]) > 0:
             print('WARNING: Invalid window type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
-                list(df_win.loc[df_shading['code'].isna()]['Name'])))
+                list(df_win.loc[df_win['code'].isna()]['Name'])))
         if len(df_shading.loc[df_shading['code'].isna()]) > 0:
             print('WARNING: Invalid shading type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
                 list(df_shading.loc[df_shading['code'].isna()]['Name'])))

--- a/cea/demand/building_properties.py
+++ b/cea/demand/building_properties.py
@@ -629,7 +629,7 @@ class EnvelopeProperties(object):
     def __init__(self, envelope):
         self.a_roof = envelope['a_roof']
         self.n50 = envelope['n50']
-        self.win_wall = envelope['wwr_south']
+        self.win_wall = envelope['Awin'] / (envelope['Awin'] + envelope['Awall'])
         self.a_wall = envelope['a_wall']
         self.rf_sh = envelope['rf_sh']
         self.e_wall = envelope['e_wall']

--- a/cea/demand/building_properties.py
+++ b/cea/demand/building_properties.py
@@ -874,6 +874,26 @@ def get_envelope_properties(locator, prop_architecture):
     :rtype: DataFrame
 
     """
+
+    def check_successful_merge(df_construction, df_leakage, df_roof, df_wall, df_win, df_shading):
+        if len(df_construction.loc[df_construction['code'].isna()]) > 0:
+            print('WARNING: Invalid construction type found in architecture inputs. The following buildings will not be modeled: {}.'.format(list(df_construction.loc[df_shading['code'].isna()]['Name'])))
+        if len(df_leakage.loc[df_leakage['code'].isna()]) > 0:
+            print('WARNING: Invalid leakage type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
+                list(df_leakage.loc[df_shading['code'].isna()]['Name'])))
+        if len(df_roof[df_roof['code'].isna()]) > 0:
+            print('WARNING: Invalid roof type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
+                list(df_roof.loc[df_shading['code'].isna()]['Name'])))
+        if len(df_wall.loc[df_wall['code'].isna()]) > 0:
+            print('WARNING: Invalid wall type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
+                list(df_wall.loc[df_shading['code'].isna()]['Name'])))
+        if len(df_win.loc[df_win['code'].isna()]) > 0:
+            print('WARNING: Invalid window type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
+                list(df_win.loc[df_shading['code'].isna()]['Name'])))
+        if len(df_shading.loc[df_shading['code'].isna()]) > 0:
+            print('WARNING: Invalid shading type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
+                list(df_shading.loc[df_shading['code'].isna()]['Name'])))
+
     prop_roof = pd.read_excel(locator.get_database_envelope_systems(), 'ROOF')
     prop_wall = pd.read_excel(locator.get_database_envelope_systems(), 'WALL')
     prop_win = pd.read_excel(locator.get_database_envelope_systems(), 'WINDOW')
@@ -881,12 +901,14 @@ def get_envelope_properties(locator, prop_architecture):
     prop_construction = pd.read_excel(locator.get_database_envelope_systems(), 'CONSTRUCTION')
     prop_leakage = pd.read_excel(locator.get_database_envelope_systems(), 'LEAKAGE')
 
-    df_construction = prop_architecture.merge(prop_construction, left_on='type_cons', right_on='code')
-    df_leakage = prop_architecture.merge(prop_leakage, left_on='type_leak', right_on='code')
-    df_roof = prop_architecture.merge(prop_roof, left_on='type_roof', right_on='code')
-    df_wall = prop_architecture.merge(prop_wall, left_on='type_wall', right_on='code')
-    df_win = prop_architecture.merge(prop_win, left_on='type_win', right_on='code')
-    df_shading = prop_architecture.merge(prop_shading, left_on='type_shade', right_on='code')
+    df_construction = prop_architecture.merge(prop_construction, left_on='type_cons', right_on='code', how='left')
+    df_leakage = prop_architecture.merge(prop_leakage, left_on='type_leak', right_on='code', how='left')
+    df_roof = prop_architecture.merge(prop_roof, left_on='type_roof', right_on='code', how='left')
+    df_wall = prop_architecture.merge(prop_wall, left_on='type_wall', right_on='code', how='left')
+    df_win = prop_architecture.merge(prop_win, left_on='type_win', right_on='code', how='left')
+    df_shading = prop_architecture.merge(prop_shading, left_on='type_shade', right_on='code', how='left')
+
+    check_successful_merge(df_construction, df_leakage, df_roof, df_wall, df_win, df_shading)
 
     fields_construction = ['Name', 'Cm_Af', 'void_deck', 'Hs_ag', 'Hs_bg', 'Ns', 'Es']
     fields_leakage = ['Name', 'n50']

--- a/cea/demand/building_properties.py
+++ b/cea/demand/building_properties.py
@@ -877,21 +877,22 @@ def get_envelope_properties(locator, prop_architecture):
 
     def check_successful_merge(df_construction, df_leakage, df_roof, df_wall, df_win, df_shading):
         if len(df_construction.loc[df_construction['code'].isna()]) > 0:
-            print('WARNING: Invalid construction type found in architecture inputs. The following buildings will not be modeled: {}.'.format(list(df_construction.loc[df_shading['code'].isna()]['Name'])))
+            raise ValueError('WARNING: Invalid construction type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
+                list(df_construction.loc[df_shading['code'].isna()]['Name'])))
         if len(df_leakage.loc[df_leakage['code'].isna()]) > 0:
-            print('WARNING: Invalid leakage type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
+            raise ValueError('WARNING: Invalid leakage type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
                 list(df_leakage.loc[df_leakage['code'].isna()]['Name'])))
         if len(df_roof[df_roof['code'].isna()]) > 0:
-            print('WARNING: Invalid roof type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
+            raise ValueError('WARNING: Invalid roof type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
                 list(df_roof.loc[df_roof['code'].isna()]['Name'])))
         if len(df_wall.loc[df_wall['code'].isna()]) > 0:
-            print('WARNING: Invalid wall type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
+            raise ValueError('WARNING: Invalid wall type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
                 list(df_wall.loc[df_wall['code'].isna()]['Name'])))
         if len(df_win.loc[df_win['code'].isna()]) > 0:
-            print('WARNING: Invalid window type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
+            raise ValueError('WARNING: Invalid window type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
                 list(df_win.loc[df_win['code'].isna()]['Name'])))
         if len(df_shading.loc[df_shading['code'].isna()]) > 0:
-            print('WARNING: Invalid shading type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
+            raise ValueError('WARNING: Invalid shading type found in architecture inputs. The following buildings will not be modeled: {}.'.format(
                 list(df_shading.loc[df_shading['code'].isna()]['Name'])))
 
     prop_roof = pd.read_excel(locator.get_database_envelope_systems(), 'ROOF')


### PR DESCRIPTION
This PR solves issues #2473 and #2474, namely:
1-The wrong window to wall ratio was being used in one calculation in CEA. This has been changed from `bpr.architecture.win_wall=wwr_south` to `bpr.architecture.win_wall=A_win / (A_win + A_wall)`
2-Specifying an incorrect material in the architecture inputs (e.g., `type_shade` 'T4') made buildings be skipped entirely, such that if all buildings had such an incorrect parameter, no architecture parameters would be passed to the demand calculation at all. This has been solved by adding an error message that warns the user which buildings have incorrect input parameters of which type.