### PR TITLE
Data validation for inputs in front end

### DIFF
--- a/cea/glossary.csv
+++ b/cea/glossary.csv
@@ -798,16 +798,16 @@ data-helper,get_building_comfort,inputs/building-properties/indoor_comfort.dbf,T
 data-helper,get_building_comfort,inputs/building-properties/indoor_comfort.dbf,Ve_lpspax,Indoor quality requirements of indoor ventilation per person,[l/s],{0.0...n},float,black
 data-helper,get_building_comfort,inputs/building-properties/indoor_comfort.dbf,RH_max_pc,Upper bound of relative humidity,[%],{0.0...n},float,black
 data-helper,get_building_comfort,inputs/building-properties/indoor_comfort.dbf,RH_min_pc,Lower_bound of relative humidity,[%],{0.0...n},float,black
-data-helper,get_building_air_conditioning,inputs/building-properties/technical_systems.dbf,Name,Unique building ID. It must start with a letter.,[-],alphanumeric,string,black
-data-helper,get_building_air_conditioning,inputs/building-properties/technical_systems.dbf,type_cs,Type of cooling supply system,[code],{T0...Tn},string,black
-data-helper,get_building_air_conditioning,inputs/building-properties/technical_systems.dbf,type_ctrl,Type of heating and cooling control systems (relates to values in Default Database HVAC Properties),[code],{T1...Tn},string,black
-data-helper,get_building_air_conditioning,inputs/building-properties/technical_systems.dbf,type_dhw,Type of hot water supply system,[code],{T0...Tn},string,black
-data-helper,get_building_air_conditioning,inputs/building-properties/technical_systems.dbf,type_hs,Type of heating supply system,[code],{T0...Tn},string,black
-data-helper,get_building_air_conditioning,inputs/building-properties/technical_systems.dbf,type_vent,Type of ventilation strategy (relates to values in Default Database HVAC Properties),[code],{T1...Tn},string,black
-data-helper,get_building_air_conditioning,inputs/building-properties/technical_systems.dbf,heat_starts,Start of the heating season - use 00|00 when there is none,[DD|MM],{00|00...31|12},string,black
-data-helper,get_building_air_conditioning,inputs/building-properties/technical_systems.dbf,heat_ends,End of the heating season - use 00|00 when there is none,[DD|MM],{00|00...31|12},string,black
-data-helper,get_building_air_conditioning,inputs/building-properties/technical_systems.dbf,cool_starts,Start of the cooling season - use 00|00 when there is none,[DD|MM],{00|00...31|12},string,black
-data-helper,get_building_air_conditioning,inputs/building-properties/technical_systems.dbf,cool_ends,End of the cooling season - use 00|00 when there is none,[DD|MM],{00|00...31|12},string,black
+data-helper,get_building_air_conditioning,inputs/building-properties/air_conditioning_systems.dbf,Name,Unique building ID. It must start with a letter.,[-],alphanumeric,string,black
+data-helper,get_building_air_conditioning,inputs/building-properties/air_conditioning_systems.dbf,type_cs,Type of cooling supply system,[code],{T0...Tn},string,black
+data-helper,get_building_air_conditioning,inputs/building-properties/air_conditioning_systems.dbf,type_ctrl,Type of heating and cooling control systems (relates to values in Default Database HVAC Properties),[code],{T1...Tn},string,black
+data-helper,get_building_air_conditioning,inputs/building-properties/air_conditioning_systems.dbf,type_dhw,Type of hot water supply system,[code],{T0...Tn},string,black
+data-helper,get_building_air_conditioning,inputs/building-properties/air_conditioning_systems.dbf,type_hs,Type of heating supply system,[code],{T0...Tn},string,black
+data-helper,get_building_air_conditioning,inputs/building-properties/air_conditioning_systems.dbf,type_vent,Type of ventilation strategy (relates to values in Default Database HVAC Properties),[code],{T1...Tn},string,black
+data-helper,get_building_air_conditioning,inputs/building-properties/air_conditioning_systems.dbf,heat_starts,Start of the heating season - use 00|00 when there is none,[DD|MM],{00|00...31|12},string,black
+data-helper,get_building_air_conditioning,inputs/building-properties/air_conditioning_systems.dbf,heat_ends,End of the heating season - use 00|00 when there is none,[DD|MM],{00|00...31|12},string,black
+data-helper,get_building_air_conditioning,inputs/building-properties/air_conditioning_systems.dbf,cool_starts,Start of the cooling season - use 00|00 when there is none,[DD|MM],{00|00...31|12},string,black
+data-helper,get_building_air_conditioning,inputs/building-properties/air_conditioning_systems.dbf,cool_ends,End of the cooling season - use 00|00 when there is none,[DD|MM],{00|00...31|12},string,black
 data-helper,get_building_internal,inputs/building-properties/internal_loads.dbf,Ea_Wm2,Peak specific electrical load due to computers and devices,[W/m2],{0.0...n},float,black
 data-helper,get_building_internal,inputs/building-properties/internal_loads.dbf,Ed_Wm2,Peak specific electrical load due to servers/data centres,[W/m2],{0.0...n},float,black
 data-helper,get_building_internal,inputs/building-properties/internal_loads.dbf,El_Wm2,Peak specific electrical load due to artificial lighting,[W/m2],{0.0...n},float,black

--- a/cea/interfaces/dashboard/api/inputs.py
+++ b/cea/interfaces/dashboard/api/inputs.py
@@ -196,7 +196,7 @@ class AllInputs(Resource):
 def get_building_properties():
     import cea.glossary
     # FIXME: Find a better way to ensure order of tabs
-    tabs = ['zone', 'age', 'occupancy', 'architecture', 'internal-loads', 'indoor-comfort', 'technical-systems',
+    tabs = ['zone', 'age', 'occupancy', 'architecture', 'internal-loads', 'indoor-comfort', 'air-conditioning-systems',
             'supply-systems', 'surroundings']
 
     config = current_app.cea_config

--- a/cea/interfaces/dashboard/inputs/inputs.yml
+++ b/cea/interfaces/dashboard/inputs/inputs.yml
@@ -65,38 +65,72 @@ occupancy:
     type: str
   - name: SINGLE_RES
     type: float
+    constraints:
+      max: 1
   - name: MULTI_RES
     type: float
+    constraints:
+      max: 1
   - name: OFFICE
     type: float
+    constraints:
+      max: 1
   - name: RETAIL
     type: float
+    constraints:
+      max: 1
   - name: SCHOOL
     type: float
+    constraints:
+      max: 1
   - name: RESTAURANT
     type: float
+    constraints:
+      max: 1
   - name: FOODSTORE
     type: float
+    constraints:
+      max: 1
   - name: GYM
     type: float
+    constraints:
+      max: 1
   - name: HOSPITAL
     type: float
+    constraints:
+      max: 1
   - name: HOTEL
     type: float
+    constraints:
+      max: 1
   - name: INDUSTRIAL
     type: float
+    constraints:
+      max: 1
   - name: LIBRARY
     type: float
+    constraints:
+      max: 1
   - name: SWIMMING
     type: float
+    constraints:
+      max: 1
   - name: COOLROOM
     type: float
+    constraints:
+      max: 1
   - name: SERVERROOM
     type: float
+    constraints:
+      max: 1
   - name: PARKING
     type: float
+    constraints:
+      max: 1
   - name: REFERENCE
     type: str
+    constraints:
+      max: 1
 internal-loads:
   parent: zone
   pk: Name
@@ -138,13 +172,33 @@ supply-systems:
   - name: Name
     type: str
   - name: type_cs
-    type: str
+    type: choice
+    location:
+      path: get_database_supply_systems
+      sheet: ALL_IN_ONE_SYSTEMS
+      column: code
+      filter: system=='COOLING' or system=='NONE'
   - name: type_dhw
-    type: str
+    type: choice
+    location:
+      path: get_database_supply_systems
+      sheet: ALL_IN_ONE_SYSTEMS
+      column: code
+      filter: system=='HEATING' or system=='NONE'
   - name: type_el
-    type: str
+    type: choice
+    location:
+      path: get_database_supply_systems
+      sheet: ALL_IN_ONE_SYSTEMS
+      column: code
+      filter: system=='ELECTRICITY' or system=='NONE'
   - name: type_hs
-    type: str
+    type: choice
+    location:
+      path: get_database_supply_systems
+      sheet: ALL_IN_ONE_SYSTEMS
+      column: code
+      filter: system=='HEATING' or system=='NONE'
 architecture:
   parent: zone
   pk: Name
@@ -157,32 +211,72 @@ architecture:
     type: int
   - name: Es
     type: float
+    constraints:
+      max: 1
   - name: Hs_ag
     type: float
+    constraints:
+      max: 1
   - name: Hs_bg
     type: float
+    constraints:
+      max: 1
   - name: Ns
     type: float
+    constraints:
+      max: 1
   - name: wwr_north
     type: float
+    constraints:
+      max: 1
   - name: wwr_east
     type: float
+    constraints:
+      max: 1
   - name: wwr_south
     type: float
+    constraints:
+      max: 1
   - name: wwr_west
     type: float
+    constraints:
+      max: 1
   - name: type_cons
-    type: str
+    type: choice
+    location:
+      path: get_database_envelope_systems
+      sheet: CONSTRUCTION
+      column: code
   - name: type_leak
-    type: str
+    type: choice
+    location:
+      path: get_database_envelope_systems
+      sheet: LEAKAGE
+      column: code
   - name: type_roof
-    type: str
+    type: choice
+    location:
+      path: get_database_envelope_systems
+      sheet: ROOF
+      column: code
   - name: type_shade
-    type: str
+    type: choice
+    location:
+      path: get_database_envelope_systems
+      sheet: SHADING
+      column: code
   - name: type_wall
-    type: str
+    type: choice
+    location:
+      path: get_database_envelope_systems
+      sheet: WALL
+      column: code
   - name: type_win
-    type: str
+    type: choice
+    location:
+      path: get_database_envelope_systems
+      sheet: WINDOW
+      column: code
 indoor-comfort:
   parent: zone
   pk: Name
@@ -214,23 +308,43 @@ air-conditioning-systems:
     - name: Name
       type: str
     - name: type_cs
-      type: str
+      type: choice
+      location:
+        path: get_database_air_conditioning_systems
+        sheet: cooling
+        column: code
     - name: type_hs
-      type: str
+      type: choice
+      location:
+        path: get_database_air_conditioning_systems
+        sheet: heating
+        column: code
     - name: type_dhw
-      type: str
+      type: choice
+      location:
+        path: get_database_air_conditioning_systems
+        sheet: dhw
+        column: code
     - name: type_ctrl
-      type: str
+      type: choice
+      location:
+        path: get_database_air_conditioning_systems
+        sheet: controller
+        column: code
     - name: type_vent
-      type: str
+      type: choice
+      location:
+        path: get_database_air_conditioning_systems
+        sheet: ventilation
+        column: code
     - name: heat_starts
-      type: str
+      type: date
     - name: heat_ends
-      type: str
+      type: date
     - name: cool_starts
-      type: str
+      type: date
     - name: cool_ends
-      type: str
+      type: date
 
 
 

--- a/cea/interfaces/dashboard/inputs/inputs.yml
+++ b/cea/interfaces/dashboard/inputs/inputs.yml
@@ -205,7 +205,7 @@ indoor-comfort:
     type: float
   - name: Ve_lpspax
     type: float
-technical-systems:
+air-conditioning-systems:
   parent: zone
   pk: Name
   type: dbf

--- a/cea/interfaces/dashboard/inputs/routes.py
+++ b/cea/interfaces/dashboard/inputs/routes.py
@@ -28,6 +28,8 @@ def read_inputs_field_types():
         'float': float,
         'str': str,
         'year': int,
+        'choice': str,
+        'date': str
     }
 
     for db in inputs.keys():


### PR DESCRIPTION
This PR provides a way to implement input validation for the front end, which helps with #2310 and #2141

It introduces a new property **_constraints_** for fields in _input.yaml_, which could be used to specify the range of the field i.e. **_max_**.

A new field type **_choice_** is also added to restrict users to only select values found in a list. 
A property **_location_** is used to extract this list of values from a database.

Other Changes:
Update `technical_systems` to `air_conditioning_systems`
