### PR TITLE
Show plot input files

### DIFF
--- a/cea/interfaces/dashboard/api/dashboard.py
+++ b/cea/interfaces/dashboard/api/dashboard.py
@@ -208,3 +208,19 @@ class DashboardPlotParameters(Resource):
         plot = dashboard.plots[plot_index]
 
         return get_plot_parameters(config, plot)
+
+
+@api.route('/<int:dashboard_index>/plots/<int:plot_index>/input-files')
+class DashboardPlotInputFiles(Resource):
+    def get(self, dashboard_index, plot_index):
+        """
+        Get input files of Plot
+        """
+        config = current_app.cea_config
+        plot_cache = cea.plots.cache.PlotCache(config)
+        dashboards = cea.plots.read_dashboards(config, plot_cache)
+
+        dashboard = dashboards[dashboard_index]
+        plot = dashboard.plots[plot_index]
+
+        return [locator_method(*args) for locator_method, args in plot.input_files]

--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -127,6 +127,7 @@ class PlotBase(object):
         FIXME: what about columns with negative values?
         """
         import numpy as np
+        fields = [field for field in fields if field in data.columns]
         return [field for field in fields if np.isclose(data[field].sum(), 1e-8)==False]
 
     def calc_graph(self):

--- a/cea/plots/demand/__init__.py
+++ b/cea/plots/demand/__init__.py
@@ -102,6 +102,9 @@ class DemandPlotBase(cea.plots.PlotBase):
                                        'E_cre_kWh']
 
         self.input_files = [(self.locator.get_total_demand, [])]  # all these scripts depend on demand
+        # Add building to input files if buildings are selected
+        if self.buildings:
+            self.input_files += [(self.locator.get_demand_results_file, [building]) for building in self.buildings]
 
     @property
     def hourly_loads(self):


### PR DESCRIPTION
This PR helps with #2393 and adds an endpoint to the api to return an array of input files used for a plot in the dashboard.

Other changes:
- Add buildings to input files of demand plots if buildings are selected