### PR TITLE
Missing input files should create an error, not a success in the jobs list

### DIFF
--- a/cea/api.py
+++ b/cea/api.py
@@ -26,7 +26,7 @@ def register_scripts():
             cea_script.print_script_configuration(config)
             if list(cea_script.missing_input_files(config)):
                 cea_script.print_missing_input_files(config)
-                return
+                raise cea.MissingInputDataException()
             t0 = datetime.datetime.now()
             # run the script
             script_module.main(config)

--- a/cea/interfaces/cli/cli.py
+++ b/cea/interfaces/cli/cli.py
@@ -59,7 +59,7 @@ def main(config=None):
     cea_script.print_script_configuration(config)
     if list(cea_script.missing_input_files(config)):
         cea_script.print_missing_input_files(config)
-        return
+        sys.exit(cea.MissingInputDataException.rc)
 
     script_module = importlib.import_module(cea_script.module)
     try:


### PR DESCRIPTION
This PR addresses #2395 - Missing input files should create an error and the job info in the CEA GUI should reflect that:

![image](https://user-images.githubusercontent.com/2969564/71829789-abe6fb00-30a5-11ea-9ce0-acc8c3a71c20.png)

To test, follow steps from the issue (basically, just remove all data-helper output and run radiation)