### PR TITLE
Release 2.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+2020-01-10 - 2.27.0 - #2517 2511 solar plots
+2020-01-10 - 2.27.0 - #2499 @daren-thomas well as soon as this fixes the problem of #2502
+2020-01-09 - 2.27.0 - #2503 Fix for scenario creation
+2020-01-09 - 2.27.0 - #2412 Simplify environment.ubuntu.yml
+2020-01-09 - 2.27.0 - #2492 Fixing plots nyc
+2020-01-08 - 2.27.0 - #2497 Rtd build errors
+2020-01-07 - 2.27.0 - #2498 Missing input files should create an error, not a success in the jobs list
+2019-12-10 - 2.27.0 - #2495 Release 2.27.0
 2019-12-06 - 2.26.0a0 - #2481 Show plot input files
 2019-12-06 - 2.26.0a0 - #2462 Test epanet - simple thermal model Merging!! wihuu
 2019-12-04 - 2.26.0 - #2467 1777 optimize decentralized script for speed

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -9,6 +9,42 @@ The CEA team
 Starting from version 2.9.1 the credits are structured alphabetically (surname) and split into the categories of developers,
 scrum master, project owner, project sponsor and collaborators.
 
+- Version 2.28.0 - January 2020
+
+    Developers:
+    * [Amr Elesawy](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/amr-elesawy.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+    * [Gabriel Happle](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/gabriel-happle.html)
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+    * [Reynold Mok](http://https://cityenergyanalyst.com/community)
+    * [Martín Mosteiro Romero](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/martin-mosteiro-romero.html)
+    * [Zhongming Shi](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/zhongming-shi.html)
+    * [Bhargava Krishna Sreepathi ](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/sreepathi-bhargava-krishna.html)
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Scrum master:
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Project owner:
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+
+    Project sponsor:
+    * [Arno Schlueter](http://www.systems.arch.ethz.ch/about-us/team/arno-schlueter.html)
+
+    Collaborators:
+    * Sebastian Troiztsch
+    * Jose Bello
+    * Kian Wee Chen
+    * Jack Hawthorne
+    * Fazel Khayatian
+    * Victor Marty
+    * Paul Neitzel
+    * Thuy-An Nguyen
+    * Bo Lie Ong
+    * Lennart Rogenhofer
+    * Toivo Säwén
+    * Tim Vollrath
+
 - Version 2.27.0 - November 2019
 
     Developers:

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.28.0a4"
+__version__ = "2.28.0"
 
 
 class ConfigError(Exception):

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.28.0"
+__version__ = "2.28.1"
 
 
 class ConfigError(Exception):

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.28.0a1"
+__version__ = "2.28.0a2"
 
 
 class ConfigError(Exception):

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.28.0a2"
+__version__ = "2.28.0a4"
 
 
 class ConfigError(Exception):

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.27.0"
+__version__ = "2.28.0a1"
 
 
 class ConfigError(Exception):

--- a/docs/how-to-create-a-new-release.rst
+++ b/docs/how-to-create-a-new-release.rst
@@ -160,20 +160,18 @@ Uploading to PyPI
 
 .. _twine: https://pypi.python.org/pypi/twine
 
-Updating the CEA Electron interface
------------------------------------
+Updating the CEA GUI interface
+------------------------------
 
-For the installer to be able to pick up the newest version of the CEA Electron interface, you need to build it,
+For the installer to be able to pick up the newest version of the CEA GUI interface, you need to build it,
 create a release and attach a ``win-unpacked.7z`` to the release. Here are the steps:
 
-- pull the newest version of the ``cea-electron`` repository
-- open CEA Console, navigate to the GitHub repo of the ``cea-electron`` repository
+- pull the newest version of the ``CityEnergyAnalyst-GUI`` repository
+- open CEA Console, navigate to the GitHub repo of the ``CityEnergyAnalyst-GUI`` repository
 - type ``yarn dist:dir``, wait for the command to complete
 - the subfolder ``dist`` will contain a folder ``win-unpacked``
 - compress the folder ``win-unpacked`` to ``win-unpacked.7z``
-- open https://github.com/architecture-building-systems/cea-electron/releases in the browser
-- Draft a new release, use a tag corresponding to the CEA version number (e.g. ``v2.23``)
-- Attach the ``win-unpacked.7z`` file to the release (the installer will automatically use the latest release on installation)
+- attach the ``win-unpacked.7z`` file to the CityEnergyAnalyst release
 
 
 Updating Link in www.cityenergyanalyst.com/tryit

--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -15,11 +15,11 @@ ${StrRep}
 
 
 # download CEA conda env from here
-!define CEA_ENV_URL "https://github.com/architecture-building-systems/CityEnergyAnalyst/releases/download/v2.26.0/Dependencies.7z"
+!define CEA_ENV_URL "https://github.com/architecture-building-systems/CityEnergyAnalyst/releases/download/v2.27.0/Dependencies.7z"
 !define CEA_ENV_FILENAME "Dependencies.7z"
 !define RELATIVE_GIT_PATH "Dependencies\cmder\vendor\git-for-windows\bin\git.exe"
 !define CEA_REPO_URL "https://github.com/architecture-building-systems/CityEnergyAnalyst.git"
-!define CEA_ELECTRON_URL "https://github.com/architecture-building-systems/CityEnergyAnalyst-GUI/releases/download/v${VER}/win-unpacked.7z"
+!define CEA_ELECTRON_URL "https://github.com/architecture-building-systems/CityEnergyAnalyst/releases/download/v${VER}/win-unpacked.7z"
 
 !define CEA_TITLE "City Energy Analyst"
 
@@ -175,6 +175,8 @@ Section "Base Installation" Base_Installation_Section
 
     DetailPrint "Updating Pip"
     nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip install -U --force-reinstall pip'
+    DetailPrint "Pip uninstalling previous CityEnergyAnalyst"
+    nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip uninstall -y cityenergyanalyst'
     DetailPrint "Pip installing CityEnergyAnalyst==${VER}"
     nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip install -U cityenergyanalyst==${VER}'
 

--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -175,8 +175,6 @@ Section "Base Installation" Base_Installation_Section
 
     DetailPrint "Updating Pip"
     nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip install -U --force-reinstall pip'
-    DetailPrint "Pip uninstalling previous CityEnergyAnalyst"
-    nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip uninstall -y cityenergyanalyst'
     DetailPrint "Pip installing CityEnergyAnalyst==${VER}"
     nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip install -U cityenergyanalyst==${VER}'
 


### PR DESCRIPTION
This is the result of the M2.28 sprint. We worked mainly on fixing bugs.

To install it on windows, download and run the attached Setup_CityEnergyAnalyst_2.28.1.exe. [See the guide for more options](https://city-energy-analyst.readthedocs.io/en/latest/getting-started.html#install-and-set-up).

From the CHANGELOG:

2020-01-14 - 2.27.0 - #2516 fixing small bugs i2512 and i2509
2020-01-14 - 2.27.0 - #2513 fix nominal cap
2020-01-10 - 2.27.0 - #2517 2511 solar plots
2020-01-10 - 2.27.0 - #2499 @daren-thomas well as soon as this fixes the problem of #2502
2020-01-09 - 2.27.0 - #2503 Fix for scenario creation
2020-01-09 - 2.27.0 - #2412 Simplify environment.ubuntu.yml
2020-01-09 - 2.27.0 - #2492 Fixing plots nyc
2020-01-08 - 2.27.0 - #2497 Rtd build errors
2020-01-07 - 2.27.0 - #2498 Missing input files should create an error, not a success in the jobs list
2019-12-10 - 2.27.0 - #2495 Release 2.27.0