### PR TITLE
Typos and nomenclature in thermal networks

### DIFF
--- a/cea/technologies/substation.py
+++ b/cea/technologies/substation.py
@@ -26,7 +26,7 @@ __status__ = "Production"
 # Substation model
 def substation_main_heating(locator, total_demand, buildings_name_with_heating, heating_configuration=7, DHN_barcode=""):
     if DHN_barcode.count("1") > 0:  # check if there are buildings connected
-        # FIRS GET THE MAXIMUM TEMPERATURE NEEDED BY THE NETWORK AT EVERY TIME STEP
+        # FIRST GET THE MAXIMUM TEMPERATURE NEEDED BY THE NETWORK AT EVERY TIME STEP
         buildings_dict = {}
         heating_system_temperatures_dict = {}
         T_DHN_supply = np.zeros(HOURS_IN_YEAR)

--- a/cea/technologies/substation.py
+++ b/cea/technologies/substation.py
@@ -33,7 +33,7 @@ def substation_main_heating(locator, total_demand, buildings_name_with_heating, 
         for name in buildings_name_with_heating:
             buildings_dict[name] = pd.read_csv(locator.get_demand_results_file(name))
             print(name)
-            ## calculates the building side supply and return temperatures for each units
+            ## calculates the building side supply and return temperatures for each unit
             Ths_supply_C, Ths_re_C = calc_temp_hex_building_side_heating(buildings_dict[name],
                                                                          heating_configuration)
 
@@ -107,7 +107,7 @@ def substation_main_cooling(locator, total_demand, buildings_name_with_cooling, 
             Tcs_return_C, Tcs_supply_C = calc_temp_hex_building_side_cooling(buildings_dict[name],
                                                                              cooling_configuration)
 
-            # calculates the building side supply and return temperatures for each units
+            # calculates the building side supply and return temperatures for each unit
             T_DC_supply_to_cs_ref, T_DC_supply_to_cs_ref_data = calc_temp_this_building_cooling(T_supply_to_cs_ref,
                                                                                                 T_supply_to_cs_ref_data)
 
@@ -144,7 +144,7 @@ def substation_main_cooling(locator, total_demand, buildings_name_with_cooling, 
             T_supply_to_cs_ref, T_supply_to_cs_ref_data, \
             Tcs_return_C, Tcs_supply_C = calc_temp_hex_building_side_cooling(substation_demand, cooling_configuration)
 
-            # calculates the building side supply and return temperatures for each units
+            # calculates the building side supply and return temperatures for each unit
             T_DC_supply_to_cs_ref, T_DC_supply_to_cs_ref_data = calc_temp_this_building_cooling(T_supply_to_cs_ref,
                                                                                                 T_supply_to_cs_ref_data)
 

--- a/cea/technologies/substation.py
+++ b/cea/technologies/substation.py
@@ -34,11 +34,11 @@ def substation_main_heating(locator, total_demand, buildings_name_with_heating, 
             buildings_dict[name] = pd.read_csv(locator.get_demand_results_file(name))
             print(name)
             ## calculates the building side supply and return temperatures for each units
-            Ths_supply_C, Ths_re_C = calc_temp_hex_building_side(buildings_dict[name],
-                                                                 heating_configuration)
+            Ths_supply_C, Ths_re_C = calc_temp_hex_building_side_heating(buildings_dict[name],
+                                                                         heating_configuration)
 
             # compare and get the minimum tempearture of the DH plant
-            T_DH_supply = calc_temp_this_building(Ths_supply_C)
+            T_DH_supply = calc_temp_this_building_heating(Ths_supply_C)
             T_DHN_supply = np.vectorize(calc_DH_supply)(T_DH_supply, T_DHN_supply)
 
             # Create two vectors for doing the calculation
@@ -63,8 +63,8 @@ def substation_main_heating(locator, total_demand, buildings_name_with_heating, 
         # CALCULATE SUBSTATIONS DURING DECENTRALIZED OPTIMIZATION
         for name in buildings_name_with_heating:
             substation_demand = pd.read_csv(locator.get_demand_results_file(name))
-            Ths_supply_C, Ths_return_C = calc_temp_hex_building_side(substation_demand, heating_configuration)
-            T_heating_system_supply = calc_temp_this_building(Ths_supply_C)
+            Ths_supply_C, Ths_return_C = calc_temp_hex_building_side_heating(substation_demand, heating_configuration)
+            T_heating_system_supply = calc_temp_this_building_heating(Ths_supply_C)
             substation_model_heating(name,
                                      substation_demand,
                                      T_heating_system_supply,
@@ -76,12 +76,12 @@ def substation_main_heating(locator, total_demand, buildings_name_with_heating, 
     return
 
 
-def calc_temp_this_building(Tww_Ths_supply_C):
+def calc_temp_this_building_heating(Tww_Ths_supply_C):
     T_DH_supply = np.where(Tww_Ths_supply_C > 0, Tww_Ths_supply_C + DT_HEAT, Tww_Ths_supply_C)
     return T_DH_supply
 
 
-def calc_temp_hex_building_side(building_demand_df, heating_configuration):
+def calc_temp_hex_building_side_heating(building_demand_df, heating_configuration):
     # space heating
 
     Ths_return, Ths_supply = calc_compound_Ths(building_demand_df, heating_configuration)

--- a/cea/technologies/thermal_network/simplified_thermal_network.py
+++ b/cea/technologies/thermal_network/simplified_thermal_network.py
@@ -171,7 +171,7 @@ def thermal_network_simplified(locator, config, network_name):
     network_type = config.thermal_network.network_type
     min_head_substation_kPa = config.thermal_network.min_head_susbstation
     thermal_transfer_unit_design_head_m = min_head_substation_kPa * 1000 / M_WATER_TO_PA
-    coefficient_friction_hanzen_williams = config.thermal_network.hw_friction_coefficient
+    coefficient_friction_hazen_williams = config.thermal_network.hw_friction_coefficient
     velocity_ms = config.thermal_network.peak_load_velocity
     fraction_equivalent_length = config.thermal_network.equivalent_length_factor
     peak_load_percentage = config.thermal_network.peak_load_percentage
@@ -275,7 +275,7 @@ def thermal_network_simplified(locator, config, network_name):
         wn.add_pipe(edge_name, edge[1]["start node"],
                     edge[1]["end node"],
                     length=length_m * (1 + fraction_equivalent_length),
-                    roughness=coefficient_friction_hanzen_williams,
+                    roughness=coefficient_friction_hazen_williams,
                     minor_loss=0.0,
                     status='OPEN')
 


### PR DESCRIPTION
- The Hazen-Williams coefficient was wrongly named "Hanzen-Williams"
- "First" was misspelled as "Firs"
- Two pairs functions were named inconsistently with one another