### PR TITLE
updated schemas.yml with trace-inputlocator output

### DIFF
--- a/cea/schemas.yml
+++ b/cea/schemas.yml
@@ -1,20 +1,19 @@
 PVT_metadata_results:
-  created_by: [photovoltaic-thermal]
-  description: scenario/outputs/data/potentials/solar/{building_name}_SC_sensors.csv
-  file_path: outputs/data/potentials/solar/b001_pvt_sensors.csv
+  created_by: [photovoltaic_thermal]
+  file_path: outputs/data/potentials/solar/B001_PVT_sensors.csv
   file_type: csv
   schema:
     AREA_m2:
-      sample_data: 4.89
+      sample_data: 27.42
       types_found: [float]
     BUILDING:
-      sample_data: B001
+      sample_data: B01
       types_found: [string]
     B_deg:
-      sample_data: 0.38
+      sample_data: 15.34
       types_found: [float]
     CATB:
-      sample_data: !!python/long '3'
+      sample_data: !!python/long '6'
       types_found: [long]
     CATGB:
       sample_data: !!python/long '10'
@@ -23,40 +22,43 @@ PVT_metadata_results:
       sample_data: !!python/long '5'
       types_found: [long]
     SURFACE:
-      sample_data: srf809
+      sample_data: srf260
       types_found: [string]
     TYPE:
       sample_data: roofs
       types_found: [string]
     Xcoor:
-      sample_data: 371706.17
+      sample_data: 463133.44
       types_found: [float]
     Xdir:
       sample_data: 0.0
       types_found: [float]
     Ycoor:
-      sample_data: 140269.48
+      sample_data: 5225373.99
       types_found: [float]
     Ydir:
       sample_data: 0.0
       types_found: [float]
     Zcoor:
-      sample_data: 29.01
+      sample_data: 447.2
       types_found: [float]
     Zdir:
       sample_data: 1.0
       types_found: [float]
     area_installed_module_m2:
-      sample_data: 4.87
+      sample_data: 14.61
       types_found: [float]
     array_spacing_m:
-      sample_data: 0.01
+      sample_data: 1.82
       types_found: [float]
+    intersection:
+      sample_data: !!python/long '0'
+      types_found: [long]
     orientation:
       sample_data: top
       types_found: [string]
     surface:
-      sample_data: srf809
+      sample_data: srf260
       types_found: [string]
     surface_azimuth_deg:
       sample_data: 0.0
@@ -65,23 +67,22 @@ PVT_metadata_results:
       sample_data: 0.0
       types_found: [float]
     total_rad_Whm2:
-      sample_data: !!python/long '1445247'
+      sample_data: !!python/long '1104715'
       types_found: [long]
     type_orientation:
       sample_data: roofs_top
       types_found: [string]
   used_by: []
 PVT_results:
-  created_by: [photovoltaic-thermal]
-  description: scenario/outputs/data/potentials/solar/{building_name}_SC.csv
-  file_path: outputs/data/potentials/solar/b001_pvt.csv
+  created_by: [photovoltaic_thermal]
+  file_path: outputs/data/potentials/solar/B001_PVT.csv
   file_type: csv
   schema:
     Area_PVT_m2:
-      sample_data: 5636.54
+      sample_data: 801.49
       types_found: [float]
     Date:
-      sample_data: '2005-12-31 23:00:00+08:00'
+      sample_data: '2005-12-31 23:00:00+01:00'
       types_found: [date]
     E_PVT_gen_kWh:
       sample_data: 0.0
@@ -96,7 +97,7 @@ PVT_results:
       sample_data: 0.0
       types_found: [float]
     PVT_roofs_top_m2:
-      sample_data: 5636.54
+      sample_data: 332.87
       types_found: [float]
     PVT_walls_east_E_kWh:
       sample_data: 0.0
@@ -123,7 +124,7 @@ PVT_results:
       sample_data: 0.0
       types_found: [float]
     PVT_walls_south_m2:
-      sample_data: 0.0
+      sample_data: 468.62
       types_found: [float]
     PVT_walls_west_E_kWh:
       sample_data: 0.0
@@ -141,7 +142,7 @@ PVT_results:
       sample_data: 0.0
       types_found: [float]
     T_PVT_re_C:
-      sample_data: 35.27
+      sample_data: 38.26
       types_found: [float, null]
     T_PVT_sup_C:
       sample_data: 35.0
@@ -154,28 +155,27 @@ PVT_results:
       types_found: [float]
   used_by: []
 PVT_total_buildings:
-  created_by: [photovoltaic-thermal]
-  description: scenario/outputs/data/potentials/solar/{building_name}_PV.csv
-  file_path: outputs/data/potentials/solar/pvt_total_buildings.csv
+  created_by: [photovoltaic_thermal]
+  file_path: outputs/data/potentials/solar/PVT_total_buildings.csv
   file_type: csv
   schema:
     Area_PVT_m2:
-      sample_data: 4063.77
+      sample_data: 707.77
       types_found: [float]
     E_PVT_gen_kWh:
-      sample_data: 528845.12
+      sample_data: 90782.1
       types_found: [float]
     Eaux_PVT_kWh:
-      sample_data: 1218.06
+      sample_data: 411.88
       types_found: [float]
     PVT_roofs_top_E_kWh:
-      sample_data: 528845.12
+      sample_data: 45622.6
       types_found: [float]
     PVT_roofs_top_Q_kWh:
-      sample_data: 1866927.14
+      sample_data: 150641.31
       types_found: [float]
     PVT_roofs_top_m2:
-      sample_data: 4063.77
+      sample_data: 332.87
       types_found: [float]
     PVT_walls_east_E_kWh:
       sample_data: 0.0
@@ -196,13 +196,13 @@ PVT_total_buildings:
       sample_data: 0.0
       types_found: [float]
     PVT_walls_south_E_kWh:
-      sample_data: 0.0
+      sample_data: 45159.12
       types_found: [float]
     PVT_walls_south_Q_kWh:
-      sample_data: 0.0
+      sample_data: 121839.6
       types_found: [float]
     PVT_walls_south_m2:
-      sample_data: 0.0
+      sample_data: 374.9
       types_found: [float]
     PVT_walls_west_E_kWh:
       sample_data: 0.0
@@ -214,32 +214,30 @@ PVT_total_buildings:
       sample_data: 0.0
       types_found: [float]
     Q_PVT_gen_kWh:
-      sample_data: 1866927.14
+      sample_data: 272480.38
       types_found: [float]
     Q_PVT_l_kWh:
-      sample_data: 40665.72
+      sample_data: 11207.15
       types_found: [float]
     'Unnamed: 0':
-      sample_data: B010
+      sample_data: B09
       types_found: [string]
     radiation_kWh:
-      sample_data: 5979301.61
+      sample_data: 689935.18
       types_found: [float]
   used_by: []
 PVT_totals:
-  created_by: [photovoltaic-thermal]
-  description: scenario/outputs/data/potentials/solar/{building_name}_PV.csv
-  file_path: outputs/data/potentials/solar/pvt_total.csv
+  created_by: [photovoltaic_thermal]
+  file_path: outputs/data/potentials/solar/PVT_total.csv
   file_type: csv
   schema:
     Area_PVT_m2:
-      sample_data: 54100.05
+      sample_data: 7050.96
       types_found: [float]
     Date:
-      sample_data: 2005-12-31 23:00:00+08:002005-12-31 23:00:00+08:002005-12-31 23:00:00+08:002005-12-31
-        23:00:00+08:002005-12-31 23:00:00+08:002005-12-31 23:00:00+08:002005-12-31
-        23:00:00+08:002005-12-31 23:00:00+08:002005-12-31 23:00:00+08:002005-12-31
-        23:00:00+08:00
+      sample_data: 2005-12-31 23:00:00+01:002005-12-31 23:00:00+01:002005-12-31 23:00:00+01:002005-12-31
+        23:00:00+01:002005-12-31 23:00:00+01:002005-12-31 23:00:00+01:002005-12-31
+        23:00:00+01:002005-12-31 23:00:00+01:002005-12-31 23:00:00+01:00
       types_found: [date]
     E_PVT_gen_kWh:
       sample_data: 0.0
@@ -254,7 +252,7 @@ PVT_totals:
       sample_data: 0.0
       types_found: [float]
     PVT_roofs_top_m2:
-      sample_data: 36080.73
+      sample_data: 2995.83
       types_found: [float]
     PVT_walls_east_E_kWh:
       sample_data: 0.0
@@ -263,7 +261,7 @@ PVT_totals:
       sample_data: 0.0
       types_found: [float]
     PVT_walls_east_m2:
-      sample_data: 3425.3
+      sample_data: 0.0
       types_found: [float]
     PVT_walls_north_E_kWh:
       sample_data: 0.0
@@ -272,7 +270,7 @@ PVT_totals:
       sample_data: 0.0
       types_found: [float]
     PVT_walls_north_m2:
-      sample_data: 1964.11
+      sample_data: 0.0
       types_found: [float]
     PVT_walls_south_E_kWh:
       sample_data: 0.0
@@ -281,7 +279,7 @@ PVT_totals:
       sample_data: 0.0
       types_found: [float]
     PVT_walls_south_m2:
-      sample_data: 6772.26
+      sample_data: 4055.15
       types_found: [float]
     PVT_walls_west_E_kWh:
       sample_data: 0.0
@@ -290,7 +288,7 @@ PVT_totals:
       sample_data: 0.0
       types_found: [float]
     PVT_walls_west_m2:
-      sample_data: 5857.65
+      sample_data: 0.0
       types_found: [float]
     Q_PVT_gen_kWh:
       sample_data: 0.0
@@ -299,7 +297,7 @@ PVT_totals:
       sample_data: 0.0
       types_found: [float]
     T_PVT_re_C:
-      sample_data: 35.46
+      sample_data: 38.64
       types_found: [float, null]
     T_PVT_sup_C:
       sample_data: 35.0
@@ -310,24 +308,23 @@ PVT_totals:
     radiation_kWh:
       sample_data: 0.0
       types_found: [float]
-  used_by: []
+  used_by: [optimization]
 PV_metadata_results:
   created_by: [photovoltaic]
-  description: scenario/outputs/data/potentials/solar/{building_name}_PV_sensors.csv
-  file_path: outputs/data/potentials/solar/b001_pv_sensors.csv
+  file_path: outputs/data/potentials/solar/B001_PV_sensors.csv
   file_type: csv
   schema:
     AREA_m2:
-      sample_data: 4.89
+      sample_data: 27.42
       types_found: [float]
     BUILDING:
-      sample_data: B001
+      sample_data: B01
       types_found: [string]
     B_deg:
-      sample_data: 0.38
+      sample_data: 15.34
       types_found: [float]
     CATB:
-      sample_data: !!python/long '3'
+      sample_data: !!python/long '6'
       types_found: [long]
     CATGB:
       sample_data: !!python/long '10'
@@ -336,40 +333,43 @@ PV_metadata_results:
       sample_data: !!python/long '5'
       types_found: [long]
     SURFACE:
-      sample_data: srf809
+      sample_data: srf260
       types_found: [string]
     TYPE:
       sample_data: roofs
       types_found: [string]
     Xcoor:
-      sample_data: 371706.17
+      sample_data: 463133.44
       types_found: [float]
     Xdir:
       sample_data: 0.0
       types_found: [float]
     Ycoor:
-      sample_data: 140269.48
+      sample_data: 5225373.99
       types_found: [float]
     Ydir:
       sample_data: 0.0
       types_found: [float]
     Zcoor:
-      sample_data: 29.01
+      sample_data: 447.2
       types_found: [float]
     Zdir:
       sample_data: 1.0
       types_found: [float]
     area_installed_module_m2:
-      sample_data: 4.87
+      sample_data: 14.61
       types_found: [float]
     array_spacing_m:
-      sample_data: 0.01
+      sample_data: 1.82
       types_found: [float]
+    intersection:
+      sample_data: !!python/long '0'
+      types_found: [long]
     orientation:
       sample_data: top
       types_found: [string]
     surface:
-      sample_data: srf809
+      sample_data: srf260
       types_found: [string]
     surface_azimuth_deg:
       sample_data: 0.0
@@ -378,7 +378,7 @@ PV_metadata_results:
       sample_data: 0.0
       types_found: [float]
     total_rad_Whm2:
-      sample_data: !!python/long '1445247'
+      sample_data: !!python/long '1104715'
       types_found: [long]
     type_orientation:
       sample_data: roofs_top
@@ -386,15 +386,14 @@ PV_metadata_results:
   used_by: []
 PV_results:
   created_by: [photovoltaic]
-  description: scenario/outputs/data/potentials/solar/{building_name}_PV.csv
-  file_path: outputs/data/potentials/solar/b001_pv.csv
+  file_path: outputs/data/potentials/solar/B001_PV.csv
   file_type: csv
   schema:
     Area_PV_m2:
-      sample_data: 5636.54
+      sample_data: 801.49
       types_found: [float]
     Date:
-      sample_data: '2005-12-31 23:00:00+08:00'
+      sample_data: '2005-12-31 23:00:00+01:00'
       types_found: [date]
     E_PV_gen_kWh:
       sample_data: 0.0
@@ -403,7 +402,7 @@ PV_results:
       sample_data: 0.0
       types_found: [float]
     PV_roofs_top_m2:
-      sample_data: 5636.54
+      sample_data: 332.87
       types_found: [float]
     PV_walls_east_E_kWh:
       sample_data: !!python/long '0'
@@ -418,11 +417,11 @@ PV_results:
       sample_data: !!python/long '0'
       types_found: [long]
     PV_walls_south_E_kWh:
-      sample_data: !!python/long '0'
-      types_found: [long]
+      sample_data: 0.0
+      types_found: [float]
     PV_walls_south_m2:
-      sample_data: !!python/long '0'
-      types_found: [long]
+      sample_data: 468.62
+      types_found: [float]
     PV_walls_west_E_kWh:
       sample_data: !!python/long '0'
       types_found: [long]
@@ -435,21 +434,20 @@ PV_results:
   used_by: []
 PV_total_buildings:
   created_by: [photovoltaic]
-  description: scenario/outputs/data/potentials/solar/{building_name}_PV.csv
-  file_path: outputs/data/potentials/solar/pv_total_buildings.csv
+  file_path: outputs/data/potentials/solar/PV_total_buildings.csv
   file_type: csv
   schema:
     Area_PV_m2:
-      sample_data: 4063.77
+      sample_data: 707.77
       types_found: [float]
     E_PV_gen_kWh:
-      sample_data: 524685.94
+      sample_data: 92349.69
       types_found: [float]
     PV_roofs_top_E_kWh:
-      sample_data: 524685.94
+      sample_data: 46817.3
       types_found: [float]
     PV_roofs_top_m2:
-      sample_data: 4063.77
+      sample_data: 332.87
       types_found: [float]
     PV_walls_east_E_kWh:
       sample_data: 0.0
@@ -464,10 +462,10 @@ PV_total_buildings:
       sample_data: 0.0
       types_found: [float]
     PV_walls_south_E_kWh:
-      sample_data: 0.0
+      sample_data: 45532.05
       types_found: [float]
     PV_walls_south_m2:
-      sample_data: 0.0
+      sample_data: 374.9
       types_found: [float]
     PV_walls_west_E_kWh:
       sample_data: 0.0
@@ -476,26 +474,24 @@ PV_total_buildings:
       sample_data: 0.0
       types_found: [float]
     'Unnamed: 0':
-      sample_data: B010
+      sample_data: B09
       types_found: [string]
     radiation_kWh:
-      sample_data: 5979301.61
+      sample_data: 689935.18
       types_found: [float]
   used_by: []
 PV_totals:
   created_by: [photovoltaic]
-  description: scenario/outputs/data/potentials/solar/{building_name}_PV.csv
-  file_path: outputs/data/potentials/solar/pv_total.csv
+  file_path: outputs/data/potentials/solar/PV_total.csv
   file_type: csv
   schema:
     Area_PV_m2:
-      sample_data: 54100.05
+      sample_data: 7050.96
       types_found: [float]
     Date:
-      sample_data: 2005-12-31 23:00:00+08:002005-12-31 23:00:00+08:002005-12-31 23:00:00+08:002005-12-31
-        23:00:00+08:002005-12-31 23:00:00+08:002005-12-31 23:00:00+08:002005-12-31
-        23:00:00+08:002005-12-31 23:00:00+08:002005-12-31 23:00:00+08:002005-12-31
-        23:00:00+08:00
+      sample_data: 2005-12-31 23:00:00+01:002005-12-31 23:00:00+01:002005-12-31 23:00:00+01:002005-12-31
+        23:00:00+01:002005-12-31 23:00:00+01:002005-12-31 23:00:00+01:002005-12-31
+        23:00:00+01:002005-12-31 23:00:00+01:002005-12-31 23:00:00+01:00
       types_found: [date]
     E_PV_gen_kWh:
       sample_data: 0.0
@@ -504,95 +500,97 @@ PV_totals:
       sample_data: 0.0
       types_found: [float]
     PV_roofs_top_m2:
-      sample_data: 36080.73
+      sample_data: 2995.83
       types_found: [float]
     PV_walls_east_E_kWh:
-      sample_data: 0.0
-      types_found: [float]
+      sample_data: !!python/long '0'
+      types_found: [long]
     PV_walls_east_m2:
-      sample_data: 3425.3
-      types_found: [float]
+      sample_data: !!python/long '0'
+      types_found: [long]
     PV_walls_north_E_kWh:
-      sample_data: 0.0
-      types_found: [float]
+      sample_data: !!python/long '0'
+      types_found: [long]
     PV_walls_north_m2:
-      sample_data: 1964.11
-      types_found: [float]
+      sample_data: !!python/long '0'
+      types_found: [long]
     PV_walls_south_E_kWh:
       sample_data: 0.0
       types_found: [float]
     PV_walls_south_m2:
-      sample_data: 6772.26
+      sample_data: 4055.15
       types_found: [float]
     PV_walls_west_E_kWh:
-      sample_data: 0.0
-      types_found: [float]
+      sample_data: !!python/long '0'
+      types_found: [long]
     PV_walls_west_m2:
-      sample_data: 5857.65
-      types_found: [float]
+      sample_data: !!python/long '0'
+      types_found: [long]
     radiation_kWh:
       sample_data: 0.0
       types_found: [float]
-  used_by: []
+  used_by: [optimization]
 SC_metadata_results:
-  created_by: [solar-collector]
-  description: scenario/outputs/data/potentials/solar/{building_name}_SC_sensors.csv
-  file_path: outputs/data/potentials/solar/b001_sc_et_sensors.csv
+  created_by: [solar_collector]
+  file_path: outputs/data/potentials/solar/B001_SC_ET_sensors.csv
   file_type: csv
   schema:
     AREA_m2:
-      sample_data: 0.32
+      sample_data: 27.42
       types_found: [float]
     BUILDING:
-      sample_data: B001
+      sample_data: B01
       types_found: [string]
     B_deg:
-      sample_data: 0.38
+      sample_data: 15.34
       types_found: [float]
     CATB:
-      sample_data: !!python/long '3'
+      sample_data: !!python/long '6'
       types_found: [long]
     CATGB:
-      sample_data: !!python/long '9'
+      sample_data: !!python/long '10'
       types_found: [long]
     CATteta_z:
       sample_data: !!python/long '5'
       types_found: [long]
     SURFACE:
-      sample_data: srf808
+      sample_data: srf260
       types_found: [string]
     TYPE:
       sample_data: roofs
       types_found: [string]
     Xcoor:
-      sample_data: 371606.94
+      sample_data: 463133.44
       types_found: [float]
     Xdir:
       sample_data: 0.0
       types_found: [float]
     Ycoor:
-      sample_data: 140248.07
+      sample_data: 5225373.99
       types_found: [float]
     Ydir:
       sample_data: 0.0
       types_found: [float]
     Zcoor:
-      sample_data: 29.01
+      sample_data: 447.2
       types_found: [float]
     Zdir:
       sample_data: 1.0
       types_found: [float]
     area_installed_module_m2:
-      sample_data: 0.32
+      sample_data: 14.61
       types_found: [float]
     array_spacing_m:
-      sample_data: 0.01
+      sample_data: 3.65
       types_found: [float]
+    intersection:
+      sample_data: !!python/long '0'
+      types_found: [long]
     orientation:
       sample_data: top
       types_found: [string]
     surface:
-      sample_data: srf808
+      sample_data: srf260
       types_found: [string]
     surface_azimuth_deg:
       sample_data: 0.0
@@ -601,23 +599,22 @@ SC_metadata_results:
       sample_data: 0.0
       types_found: [float]
     total_rad_Whm2:
-      sample_data: !!python/long '1260149'
+      sample_data: !!python/long '1104715'
       types_found: [long]
     type_orientation:
       sample_data: roofs_top
       types_found: [string]
   used_by: []
 SC_results:
-  created_by: [solar-collector]
-  description: scenario/outputs/data/potentials/solar/{building_name}_SC.csv
-  file_path: outputs/data/potentials/solar/b001_sc_et.csv
+  created_by: [solar_collector]
+  file_path: outputs/data/potentials/solar/B001_SC_ET.csv
   file_type: csv
   schema:
     Area_SC_m2:
-      sample_data: 5636.54
+      sample_data: 801.49
       types_found: [float]
     Date:
-      sample_data: '2005-12-31 23:00:00+08:00'
+      sample_data: '2005-12-31 23:00:00+01:00'
       types_found: [date]
     Eaux_SC_kWh:
       sample_data: 0.0
@@ -628,41 +625,41 @@ SC_results:
     Q_SC_l_kWh:
       sample_data: 0.0
       types_found: [float]
-    SC_roofs_top_Q_kWh:
+    SC_ET_roofs_top_Q_kWh:
       sample_data: 0.0
       types_found: [float]
-    SC_roofs_top_m2:
-      sample_data: 5636.54
+    SC_ET_roofs_top_m2:
+      sample_data: 332.87
       types_found: [float]
-    SC_walls_east_Q_kWh:
+    SC_ET_walls_east_Q_kWh:
       sample_data: !!python/long '0'
       types_found: [long]
-    SC_walls_east_m2:
+    SC_ET_walls_east_m2:
       sample_data: !!python/long '0'
       types_found: [long]
-    SC_walls_north_Q_kWh:
+    SC_ET_walls_north_Q_kWh:
       sample_data: !!python/long '0'
       types_found: [long]
-    SC_walls_north_m2:
+    SC_ET_walls_north_m2:
       sample_data: !!python/long '0'
       types_found: [long]
-    SC_walls_south_Q_kWh:
+    SC_ET_walls_south_Q_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    SC_ET_walls_south_m2:
+      sample_data: 468.62
+      types_found: [float]
+    SC_ET_walls_west_Q_kWh:
       sample_data: !!python/long '0'
       types_found: [long]
-    SC_walls_south_m2:
-      sample_data: !!python/long '0'
-      types_found: [long]
-    SC_walls_west_Q_kWh:
-      sample_data: !!python/long '0'
-      types_found: [long]
-    SC_walls_west_m2:
+    SC_ET_walls_west_m2:
       sample_data: !!python/long '0'
       types_found: [long]
     T_SC_re_C:
-      sample_data: 100.83
+      sample_data: 75.94
       types_found: [float, null]
     T_SC_sup_C:
-      sample_data: 100.0
+      sample_data: 75.0
       types_found: [float]
     mcp_SC_kWperC:
       sample_data: 0.0
@@ -670,76 +667,73 @@ SC_results:
     radiation_kWh:
       sample_data: 0.0
       types_found: [float]
-  used_by: []
+  used_by: [decentralized]
 SC_total_buildings:
-  created_by: [solar-collector]
-  description: scenario/outputs/data/potentials/solar/{building_name}_PV.csv
-  file_path: outputs/data/potentials/solar/sc_et_total_buildings.csv
+  created_by: [solar_collector]
+  file_path: outputs/data/potentials/solar/SC_ET_total_buildings.csv
   file_type: csv
   schema:
     Area_SC_m2:
-      sample_data: 4063.77
+      sample_data: 707.77
       types_found: [float]
     Eaux_SC_kWh:
-      sample_data: 8188.86
+      sample_data: 811.63
       types_found: [float]
     Q_SC_gen_kWh:
-      sample_data: 1614530.65
+      sample_data: 167087.97
       types_found: [float]
     Q_SC_l_kWh:
-      sample_data: 102001.68
+      sample_data: 7652.68
       types_found: [float]
-    SC_roofs_top_Q_kWh:
-      sample_data: 1614530.65
+    SC_ET_roofs_top_Q_kWh:
+      sample_data: 97290.18
       types_found: [float]
-    SC_roofs_top_m2:
-      sample_data: 4063.77
+    SC_ET_roofs_top_m2:
+      sample_data: 332.87
       types_found: [float]
-    SC_walls_east_Q_kWh:
+    SC_ET_walls_east_Q_kWh:
       sample_data: 0.0
       types_found: [float]
-    SC_walls_east_m2:
+    SC_ET_walls_east_m2:
       sample_data: 0.0
       types_found: [float]
-    SC_walls_north_Q_kWh:
+    SC_ET_walls_north_Q_kWh:
       sample_data: 0.0
       types_found: [float]
-    SC_walls_north_m2:
+    SC_ET_walls_north_m2:
       sample_data: 0.0
       types_found: [float]
-    SC_walls_south_Q_kWh:
+    SC_ET_walls_south_Q_kWh:
+      sample_data: 69797.68
+      types_found: [float]
+    SC_ET_walls_south_m2:
+      sample_data: 374.9
+      types_found: [float]
+    SC_ET_walls_west_Q_kWh:
       sample_data: 0.0
       types_found: [float]
-    SC_walls_south_m2:
-      sample_data: 0.0
-      types_found: [float]
-    SC_walls_west_Q_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    SC_walls_west_m2:
+    SC_ET_walls_west_m2:
       sample_data: 0.0
       types_found: [float]
     'Unnamed: 0':
-      sample_data: B010
+      sample_data: B09
       types_found: [string]
     radiation_kWh:
-      sample_data: 6014465.91
+      sample_data: 689935.18
       types_found: [float]
   used_by: []
 SC_totals:
-  created_by: [solar-collector]
-  description: scenario/outputs/data/potentials/solar/{building_name}_PV.csv
-  file_path: outputs/data/potentials/solar/sc_et_total.csv
+  created_by: [solar_collector]
+  file_path: outputs/data/potentials/solar/SC_FP_total.csv
   file_type: csv
   schema:
     Area_SC_m2:
-      sample_data: 48048.36
+      sample_data: 7050.96
       types_found: [float]
     Date:
-      sample_data: 2005-12-31 23:00:00+08:002005-12-31 23:00:00+08:002005-12-31 23:00:00+08:002005-12-31
-        23:00:00+08:002005-12-31 23:00:00+08:002005-12-31 23:00:00+08:002005-12-31
-        23:00:00+08:002005-12-31 23:00:00+08:002005-12-31 23:00:00+08:002005-12-31
-        23:00:00+08:00
+      sample_data: 2005-12-31 23:00:00+01:002005-12-31 23:00:00+01:002005-12-31 23:00:00+01:002005-12-31
+        23:00:00+01:002005-12-31 23:00:00+01:002005-12-31 23:00:00+01:002005-12-31
+        23:00:00+01:002005-12-31 23:00:00+01:002005-12-31 23:00:00+01:00
       types_found: [date]
     Eaux_SC_kWh:
       sample_data: 0.0
@@ -750,41 +744,41 @@ SC_totals:
     Q_SC_l_kWh:
       sample_data: 0.0
       types_found: [float]
-    SC_roofs_top_Q_kWh:
+    SC_FP_roofs_top_Q_kWh:
       sample_data: 0.0
       types_found: [float]
-    SC_roofs_top_m2:
-      sample_data: 36080.73
+    SC_FP_roofs_top_m2:
+      sample_data: 2995.83
       types_found: [float]
-    SC_walls_east_Q_kWh:
+    SC_FP_walls_east_Q_kWh:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    SC_FP_walls_east_m2:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    SC_FP_walls_north_Q_kWh:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    SC_FP_walls_north_m2:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    SC_FP_walls_south_Q_kWh:
       sample_data: 0.0
       types_found: [float]
-    SC_walls_east_m2:
-      sample_data: 2152.08
+    SC_FP_walls_south_m2:
+      sample_data: 4055.15
       types_found: [float]
-    SC_walls_north_Q_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    SC_walls_north_m2:
-      sample_data: 1327.11
-      types_found: [float]
-    SC_walls_south_Q_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    SC_walls_south_m2:
-      sample_data: 4535.57
-      types_found: [float]
-    SC_walls_west_Q_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    SC_walls_west_m2:
-      sample_data: 3952.89
-      types_found: [float]
+    SC_FP_walls_west_Q_kWh:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    SC_FP_walls_west_m2:
+      sample_data: !!python/long '0'
+      types_found: [long]
     T_SC_re_C:
-      sample_data: 101.12
+      sample_data: 60.18
       types_found: [float, null]
     T_SC_sup_C:
-      sample_data: 100.0
+      sample_data: 60.0
       types_found: [float, null]
     mcp_SC_kWperC:
       sample_data: 0.0
@@ -792,27 +786,27 @@ SC_totals:
     radiation_kWh:
       sample_data: 0.0
       types_found: [float]
-  used_by: []
+  used_by: [optimization]
 get_archetypes_properties:
   created_by: []
-  description: "Returns the database of construction properties to be used by the\
-    \ data-helper. These are copied\n        to the scenario if they are not yet present,\
-    \ based on the configured region for the scenario."
-  file_path: databases/ch/archetypes/construction_properties.xlsx
+  file_path: inputs/technology/archetypes/construction_properties.xlsx
   file_type: xlsx
   schema:
     ARCHITECTURE:
       Es:
         sample_data: 0.9
         types_found: [float]
-      Hs:
+      Hs_ag:
         sample_data: 0.9
         types_found: [float]
+      Hs_bg:
+        sample_data: !!python/long '0'
+        types_found: [long]
       Ns:
         sample_data: 0.9
         types_found: [float]
       building_use:
-        sample_data: LIBRARY
+        sample_data: UNIVERSITY
         types_found: [string]
       standard:
         sample_data: R
@@ -836,8 +830,8 @@ get_archetypes_properties:
         sample_data: T4
         types_found: [string]
       void_deck:
-        sample_data: 0
-        types_found: [int]
+        sample_data: !!python/long '0'
+        types_found: [long]
       wwr_east:
         sample_data: 0.31
         types_found: [float]
@@ -858,7 +852,19 @@ get_archetypes_properties:
         types_found: [long]
     HVAC:
       building_use:
-        sample_data: LIBRARY
+        sample_data: UNIVERSITY
+        types_found: [string]
+      cool_ends:
+        sample_data: 15|09
+        types_found: [string]
+      cool_starts:
+        sample_data: 15|05
+        types_found: [string]
+      heat_ends:
+        sample_data: 14|05
+        types_found: [string]
+      heat_starts:
+        sample_data: 16|09
         types_found: [string]
       standard:
         sample_data: R
@@ -876,7 +882,7 @@ get_archetypes_properties:
         sample_data: T3
         types_found: [string]
       type_vent:
-        sample_data: T1
+        sample_data: T2
         types_found: [string]
       year_end:
         sample_data: !!python/long '2030'
@@ -886,8 +892,14 @@ get_archetypes_properties:
         types_found: [long]
     INDOOR_COMFORT:
       Code:
-        sample_data: LIBRARY
+        sample_data: UNIVERSITY
         types_found: [string]
+      RH_max_pc:
+        sample_data: !!python/long '60'
+        types_found: [long]
+      RH_min_pc:
+        sample_data: !!python/long '30'
+        types_found: [long]
       Tcs_set_C:
         sample_data: !!python/long '26'
         types_found: [long]
@@ -901,34 +913,31 @@ get_archetypes_properties:
         sample_data: !!python/long '12'
         types_found: [long]
       Ve_lpspax:
-        sample_data: 10.0
+        sample_data: 8.333333333333334
         types_found: [float]
-      RH_max_pc:
-        sample_data: !!python/long '70'
-        types_found: [long]
-      RH_min_pc:
-        sample_data: !!python/long '30'
-        types_found: [long]
     INTERNAL_LOADS:
       Code:
-        sample_data: LIBRARY
+        sample_data: UNIVERSITY
         types_found: [string]
       Ea_Wm2:
-        sample_data: 2.0
+        sample_data: 4.0
         types_found: [float]
       Ed_Wm2:
         sample_data: !!python/long '0'
         types_found: [long]
       El_Wm2:
-        sample_data: 6.9
+        sample_data: 12.5
         types_found: [float]
       Epro_Wm2:
         sample_data: 0.0
         types_found: [float]
-      Qcre_Wm2:
+      Occ_m2pax:
+        sample_data: 10.0
+        types_found: [float]
+      Qcpro_Wm2:
         sample_data: !!python/long '0'
         types_found: [long]
-      Qcpro_Wm2:
+      Qcre_Wm2:
         sample_data: !!python/long '0'
         types_found: [long]
       Qhpro_Wm2:
@@ -938,29 +947,29 @@ get_archetypes_properties:
         sample_data: !!python/long '70'
         types_found: [long]
       Vw_lpdpax:
-        sample_data: !!python/long '4'
-        types_found: [long]
+        sample_data: 30.0
+        types_found: [float]
       Vww_lpdpax:
-        sample_data: !!python/long '2'
-        types_found: [long]
+        sample_data: 2.0
+        types_found: [float]
       X_ghpax:
         sample_data: !!python/long '80'
         types_found: [long]
     SUPPLY:
       building_use:
-        sample_data: LIBRARY
+        sample_data: UNIVERSITY
         types_found: [string]
       standard:
         sample_data: R
         types_found: [string]
       type_cs:
-        sample_data: T3
+        sample_data: T19
         types_found: [string]
       type_dhw:
         sample_data: T3
         types_found: [string]
       type_el:
-        sample_data: T1
+        sample_data: T24
         types_found: [string]
       type_hs:
         sample_data: T3
@@ -971,687 +980,9 @@ get_archetypes_properties:
       year_start:
         sample_data: !!python/long '2021'
         types_found: [long]
-  used_by: [data-helper, demand]
-get_archetypes_schedules:
-  created_by: []
-  description: "Returns the database of schedules to be used by the data-helper. These\
-    \ are copied\n        to the scenario if they are not yet present, based on the\
-    \ configured region for the scenario."
-  file_path: databases/ch/archetypes/occupancy_schedules.xlsx
-  file_type: xlsx
-  schema:
-    COOLROOM:
-      Saturday_1:
-        sample_data: 0.2
-        types_found: [float]
-      Saturday_2:
-        sample_data: 0.2
-        types_found: [float]
-      Saturday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_1:
-        sample_data: 0.2
-        types_found: [float]
-      Sunday_2:
-        sample_data: 0.2
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_1:
-        sample_data: 0.2
-        types_found: [float]
-      Weekday_2:
-        sample_data: 0.2
-        types_found: [float]
-      Weekday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      density:
-        sample_data: 0
-        types_found: [int, null]
-      month:
-        sample_data: 1.0
-        types_found: [float, null]
-    FOODSTORE:
-      Saturday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Saturday_2:
-        sample_data: 0.1
-        types_found: [int, float]
-      Saturday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_2:
-        sample_data: 0.1
-        types_found: [int, float]
-      Weekday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      density:
-        sample_data: 3
-        types_found: [int, null]
-      month:
-        sample_data: 0.6
-        types_found: [float, null]
-    GYM:
-      Saturday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Saturday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Saturday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Weekday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      density:
-        sample_data: 5
-        types_found: [int, null]
-      month:
-        sample_data: 1.0
-        types_found: [float, null]
-    HOSPITAL:
-      Saturday_1:
-        sample_data: 0.44000000000000006
-        types_found: [float]
-      Saturday_2:
-        sample_data: 0.16000000000000003
-        types_found: [float]
-      Saturday_3:
-        sample_data: 0.055932203389830536
-        types_found: [float]
-      Saturday_4:
-        sample_data: 0.04814408381660312
-        types_found: [float]
-      Sunday_1:
-        sample_data: 0.44000000000000006
-        types_found: [float]
-      Sunday_2:
-        sample_data: 0.16000000000000003
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.055932203389830536
-        types_found: [float]
-      Sunday_4:
-        sample_data: 0.04814408381660312
-        types_found: [float]
-      Weekday_1:
-        sample_data: 0.44000000000000006
-        types_found: [float]
-      Weekday_2:
-        sample_data: 0.16000000000000003
-        types_found: [float]
-      Weekday_3:
-        sample_data: 0.055932203389830536
-        types_found: [float]
-      Weekday_4:
-        sample_data: 0.24835995322162058
-        types_found: [float]
-      density:
-        sample_data: 8
-        types_found: [int, null]
-      month:
-        sample_data: 1.0
-        types_found: [int, float, null]
-    HOTEL:
-      Saturday_1:
-        sample_data: 0.91
-        types_found: [float]
-      Saturday_2:
-        sample_data: 0.91
-        types_found: [float]
-      Saturday_3:
-        sample_data: 0.91
-        types_found: [float]
-      Sunday_1:
-        sample_data: 0.91
-        types_found: [float]
-      Sunday_2:
-        sample_data: 0.91
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.91
-        types_found: [float]
-      Weekday_1:
-        sample_data: 0.91
-        types_found: [float]
-      Weekday_2:
-        sample_data: 0.91
-        types_found: [float]
-      Weekday_3:
-        sample_data: 0.91
-        types_found: [float]
-      density:
-        sample_data: 10
-        types_found: [int, null]
-      month:
-        sample_data: 0.6
-        types_found: [float, null]
-    INDUSTRIAL:
-      Saturday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Saturday_2:
-        sample_data: 0.2
-        types_found: [float]
-      Saturday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Saturday_4:
-        sample_data: 0.04814408381660312
-        types_found: [float]
-      Sunday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_2:
-        sample_data: 0.2
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_4:
-        sample_data: 0.03426676492262343
-        types_found: [float]
-      Weekday_1:
-        sample_data: 0.2
-        types_found: [float]
-      Weekday_2:
-        sample_data: 0.2
-        types_found: [float]
-      Weekday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_4:
-        sample_data: 0.24835995322162058
-        types_found: [float]
-      density:
-        sample_data: 10
-        types_found: [int, null]
-      month:
-        sample_data: 1.0
-        types_found: [float, null]
-    LAB:
-      Saturday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Saturday_2:
-        sample_data: 0.2
-        types_found: [float]
-      Saturday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Saturday_4:
-        sample_data: 0.04814408381660312
-        types_found: [float]
-      Sunday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_2:
-        sample_data: 0.2
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_4:
-        sample_data: 0.03426676492262343
-        types_found: [float]
-      Weekday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_2:
-        sample_data: 0.2
-        types_found: [float]
-      Weekday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_4:
-        sample_data: 0.24835995322162058
-        types_found: [float]
-      density:
-        sample_data: 20
-        types_found: [int, null]
-      month:
-        sample_data: 0.8
-        types_found: [float, null]
-    LIBRARY:
-      Saturday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Saturday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Saturday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Weekday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      density:
-        sample_data: 5
-        types_found: [int, null]
-      month:
-        sample_data: 0.6
-        types_found: [float, null]
-    MULTI_RES:
-      Saturday_1:
-        sample_data: 1.0
-        types_found: [int, float]
-      Saturday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Saturday_3:
-        sample_data: 0.20930232558139536
-        types_found: [float]
-      Sunday_1:
-        sample_data: 1.0
-        types_found: [int, float]
-      Sunday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.18947368421052632
-        types_found: [float]
-      Weekday_1:
-        sample_data: 1.0
-        types_found: [int, float]
-      Weekday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Weekday_3:
-        sample_data: 0.1919191919191919
-        types_found: [float]
-      density:
-        sample_data: 40
-        types_found: [int, null]
-      month:
-        sample_data: 0.6
-        types_found: [float, null]
-    MUSEUM:
-      Saturday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Saturday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Saturday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Weekday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      density:
-        sample_data: 10
-        types_found: [int, null]
-      month:
-        sample_data: 0.8
-        types_found: [float, null]
-    OFFICE:
-      Saturday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Saturday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Saturday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Weekday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      density:
-        sample_data: 14
-        types_found: [int, null]
-      month:
-        sample_data: 0.6
-        types_found: [float, null]
-    PARKING:
-      Saturday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Saturday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Saturday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Weekday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      density:
-        sample_data: 0
-        types_found: [int, null]
-      month:
-        sample_data: 0.6
-        types_found: [float, null]
-    RESTAURANT:
-      Saturday_1:
-        sample_data: 0.17
-        types_found: [int, float]
-      Saturday_2:
-        sample_data: 0.35500000000000004
-        types_found: [float]
-      Saturday_3:
-        sample_data: 0.17
-        types_found: [int, float]
-      Sunday_1:
-        sample_data: 0.17
-        types_found: [int, float]
-      Sunday_2:
-        sample_data: 0.35500000000000004
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.17
-        types_found: [int, float]
-      Weekday_1:
-        sample_data: 0.17
-        types_found: [int, float]
-      Weekday_2:
-        sample_data: 0.35500000000000004
-        types_found: [float]
-      Weekday_3:
-        sample_data: 0.17
-        types_found: [int, float]
-      density:
-        sample_data: 2
-        types_found: [int, null]
-      month:
-        sample_data: 0.6
-        types_found: [float, null]
-    RETAIL:
-      Saturday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Saturday_2:
-        sample_data: 0.1
-        types_found: [int, float]
-      Saturday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_2:
-        sample_data: 0.1
-        types_found: [int, float]
-      Weekday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      density:
-        sample_data: 5
-        types_found: [int, null]
-      month:
-        sample_data: 0.6
-        types_found: [float, null]
-    SCHOOL:
-      Saturday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Saturday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Saturday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Weekday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      density:
-        sample_data: 10
-        types_found: [int, null]
-      month:
-        sample_data: 1.0
-        types_found: [float, null]
-    SERVERROOM:
-      Saturday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Saturday_2:
-        sample_data: 1.0
-        types_found: [int, float]
-      Saturday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_2:
-        sample_data: 1.0
-        types_found: [int, float]
-      Sunday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_2:
-        sample_data: 1.0
-        types_found: [int, float]
-      Weekday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      density:
-        sample_data: 0
-        types_found: [int, null]
-      month:
-        sample_data: 1.0
-        types_found: [int, float, null]
-    SINGLE_RES:
-      Saturday_1:
-        sample_data: 1.0
-        types_found: [int, float]
-      Saturday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Saturday_3:
-        sample_data: 0.20930232558139536
-        types_found: [float]
-      Sunday_1:
-        sample_data: 1.0
-        types_found: [int, float]
-      Sunday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.18947368421052632
-        types_found: [float]
-      Weekday_1:
-        sample_data: 1.0
-        types_found: [int, float]
-      Weekday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Weekday_3:
-        sample_data: 0.1919191919191919
-        types_found: [float]
-      density:
-        sample_data: 60
-        types_found: [int, null]
-      month:
-        sample_data: 0.6
-        types_found: [float, null]
-    SWIMMING:
-      Saturday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Saturday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Saturday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Sunday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Sunday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_1:
-        sample_data: 0.0
-        types_found: [int, float]
-      Weekday_2:
-        sample_data: 0.1
-        types_found: [float]
-      Weekday_3:
-        sample_data: 0.0
-        types_found: [int, float]
-      density:
-        sample_data: 20
-        types_found: [int, null]
-      month:
-        sample_data: 1.0
-        types_found: [float, null]
-  used_by: [data-helper, demand]
-get_archetypes_system_controls:
-  created_by: []
-  description: " Returns the database of region-specific system control parameters.\
-    \ These are copied\n        to the scenario if they are not yet present, based\
-    \ on the configured region for the scenario.\n\n        :param region:\n     \
-    \   :return:\n        "
-  file_path: databases/ch/archetypes/system_controls.xlsx
-  file_type: xlsx
-  schema:
-    heating_cooling:
-      cooling-season-end:
-        sample_data: !!python/unicode '09-15'
-        types_found: [date]
-      cooling-season-start:
-        sample_data: !!python/unicode '05-15'
-        types_found: [date]
-      has-cooling-season:
-        sample_data: true
-        types_found: [bool]
-      has-heating-season:
-        sample_data: true
-        types_found: [bool]
-      heating-season-end:
-        sample_data: !!python/unicode '05-14'
-        types_found: [date]
-      heating-season-start:
-        sample_data: !!python/unicode '09-16'
-        types_found: [date]
-  used_by: [demand]
+  used_by: [data_helper]
 get_building_age:
   created_by: []
-  description: scenario/inputs/building-properties/age.dbf
   file_path: inputs/building-properties/age.dbf
   file_type: dbf
   schema:
@@ -1659,13 +990,13 @@ get_building_age:
       sample_data: 0
       types_found: [int]
     Name:
-      sample_data: B010
+      sample_data: B09
       types_found: [string]
     basement:
       sample_data: 0
       types_found: [int]
     built:
-      sample_data: 2018
+      sample_data: 2016
       types_found: [int]
     envelope:
       sample_data: 0
@@ -1679,100 +1010,26 @@ get_building_age:
     windows:
       sample_data: 0
       types_found: [int]
-  used_by: [data-helper, emissions, demand]
-get_building_architecture:
-  created_by: [data-helper]
-  description: "scenario/inputs/building-properties/architecture.dbf\n        This\
-    \ file is generated by the data-helper script.\n        This file is used in the\
-    \ embodied energy script (cea/embodied.py)\n        and the demand script (cea/demand_main.py)"
-  file_path: inputs/building-properties/architecture.dbf
-  file_type: dbf
-  schema:
-    Es:
-      sample_data: 0.9
-      types_found: [float]
-    Hs:
-      sample_data: 0.84
-      types_found: [float]
-    Name:
-      sample_data: B010
-      types_found: [string]
-    Ns:
-      sample_data: 1.0
-      types_found: [float]
-    type_cons:
-      sample_data: T2
-      types_found: [string]
-    type_leak:
-      sample_data: T1
-      types_found: [string]
-    type_roof:
-      sample_data: T7
-      types_found: [string]
-    type_shade:
-      sample_data: T1
-      types_found: [string]
-    type_wall:
-      sample_data: T7
-      types_found: [string]
-    type_win:
-      sample_data: T10
-      types_found: [string]
-    void_deck:
-      sample_data: 0
-      types_found: [int]
-    wwr_east:
-      sample_data: 0.59
-      types_found: [float]
-    wwr_north:
-      sample_data: 0.59
-      types_found: [float]
-    wwr_south:
-      sample_data: 0.59
-      types_found: [float]
-    wwr_west:
-      sample_data: 0.59
-      types_found: [float]
-  used_by: [radiation, emissions, demand]
-get_building_comfort:
-  created_by: [data-helper]
-  description: scenario/inputs/building-properties/indoor_comfort.dbf
-  file_path: inputs/building-properties/indoor_comfort.dbf
-  file_type: dbf
-  schema:
-    Name:
-      sample_data: B010
-      types_found: [string]
-    Tcs_set_C:
-      sample_data: 24
-      types_found: [int]
-    Tcs_setb_C:
-      sample_data: 37
-      types_found: [int]
-    Ths_set_C:
-      sample_data: 10
-      types_found: [int]
-    Ths_setb_C:
-      sample_data: 10
-      types_found: [int]
-    Ve_lpspax:
-      sample_data: 13.528116605751025
-      types_found: [float]
-    RH_max_pc:
-      sample_data: 70
-      types_found: [int]
-    RH_min_pc:
-      sample_data: 30
-      types_found: [int]
-  used_by: [demand]
+  used_by: [data_helper, emissions, demand]
 get_building_air_conditioning:
-  created_by: [data-helper]
-  description: scenario/inputs/building-properties/air_conditioning_systems.dbf
+  created_by: [data_helper]
   file_path: inputs/building-properties/air_conditioning_systems.dbf
   file_type: dbf
   schema:
     Name:
-      sample_data: B010
+      sample_data: B09
+      types_found: [string]
+    cool_ends:
+      sample_data: 15|09
+      types_found: [string]
+    cool_starts:
+      sample_data: 15|05
+      types_found: [string]
+    heat_ends:
+      sample_data: 14|05
+      types_found: [string]
+    heat_starts:
+      sample_data: 16|09
       types_found: [string]
     type_cs:
       sample_data: T3
@@ -1781,144 +1038,242 @@ get_building_air_conditioning:
       sample_data: T2
       types_found: [string]
     type_dhw:
-      sample_data: T0
-      types_found: [string]
-    type_hs:
-      sample_data: T0
-      types_found: [string]
-    type_vent:
       sample_data: T1
       types_found: [string]
+    type_hs:
+      sample_data: T2
+      types_found: [string]
+    type_vent:
+      sample_data: T2
+      types_found: [string]
   used_by: [demand]
+get_building_architecture:
+  created_by: [data_helper]
+  file_path: inputs/building-properties/architecture.dbf
+  file_type: dbf
+  schema:
+    Es:
+      sample_data: 0.9
+      types_found: [float]
+    Hs_ag:
+      sample_data: 0.45
+      types_found: [float]
+    Hs_bg:
+      sample_data: 0.0
+      types_found: [float]
+    Name:
+      sample_data: B09
+      types_found: [string]
+    Ns:
+      sample_data: 0.45
+      types_found: [float]
+    type_cons:
+      sample_data: T3
+      types_found: [string]
+    type_leak:
+      sample_data: T2
+      types_found: [string]
+    type_roof:
+      sample_data: T4
+      types_found: [string]
+    type_shade:
+      sample_data: T1
+      types_found: [string]
+    type_wall:
+      sample_data: T5
+      types_found: [string]
+    type_win:
+      sample_data: T2
+      types_found: [string]
+    void_deck:
+      sample_data: 0
+      types_found: [int]
+    wwr_east:
+      sample_data: 0.4
+      types_found: [float]
+    wwr_north:
+      sample_data: 0.4
+      types_found: [float]
+    wwr_south:
+      sample_data: 0.4
+      types_found: [float]
+    wwr_west:
+      sample_data: 0.4
+      types_found: [float]
+  used_by: [schedule_maker, radiation, emissions, demand]
+get_building_comfort:
+  created_by: [data_helper]
+  file_path: inputs/building-properties/indoor_comfort.dbf
+  file_type: dbf
+  schema:
+    Name:
+      sample_data: B09
+      types_found: [string]
+    RH_max_pc:
+      sample_data: 60
+      types_found: [int]
+    RH_min_pc:
+      sample_data: 30
+      types_found: [int]
+    Tcs_set_C:
+      sample_data: 26
+      types_found: [int]
+    Tcs_setb_C:
+      sample_data: 28
+      types_found: [int]
+    Ths_set_C:
+      sample_data: 21
+      types_found: [int]
+    Ths_setb_C:
+      sample_data: 12
+      types_found: [int]
+    Ve_lpspax:
+      sample_data: 10.0
+      types_found: [float]
+  used_by: [schedule_maker, demand]
 get_building_internal:
-  created_by: [data-helper]
-  description: scenario/inputs/building-properties/internal_loads.dbf
+  created_by: [data_helper]
   file_path: inputs/building-properties/internal_loads.dbf
   file_type: dbf
   schema:
     Ea_Wm2:
-      sample_data: 11.27
+      sample_data: 4.0
       types_found: [float]
     Ed_Wm2:
       sample_data: 0.0
       types_found: [float]
     El_Wm2:
-      sample_data: 14.485
+      sample_data: 9.4
       types_found: [float]
     Epro_Wm2:
       sample_data: 0.0
       types_found: [float]
     Name:
-      sample_data: B010
+      sample_data: B09
       types_found: [string]
-    Qcre_Wm2:
-      sample_data: 0.0
+    Occ_m2pax:
+      sample_data: 7.0
       types_found: [float]
     Qcpro_Wm2:
+      sample_data: 0.0
+      types_found: [float]
+    Qcre_Wm2:
       sample_data: 0.0
       types_found: [float]
     Qhpro_Wm2:
       sample_data: 0.0
       types_found: [float]
-    Qs_Wp:
-      sample_data: 70.79263728037344
+    Qs_Wpax:
+      sample_data: 70.0
       types_found: [float]
     Vw_lpdpax:
-      sample_data: 15.145537011757455
+      sample_data: 60.0
       types_found: [float]
     Vww_lpdpax:
-      sample_data: 2.588401074463869
+      sample_data: 3.0
       types_found: [float]
     X_ghpax:
-      sample_data: 83.69457043462945
+      sample_data: 80.0
       types_found: [float]
-  used_by: [demand]
+  used_by: [schedule_maker, demand]
 get_building_occupancy:
   created_by: []
-  description: scenario/inputs/building-properties/building_occupancy.dbf
   file_path: inputs/building-properties/occupancy.dbf
   file_type: dbf
   schema:
     COOLROOM:
-      sample_data: 0
-      types_found: [int]
+      sample_data: 0.0
+      types_found: [float]
     FOODSTORE:
-      sample_data: 0
-      types_found: [int]
+      sample_data: 0.0
+      types_found: [float]
     GYM:
-      sample_data: 0
-      types_found: [int]
+      sample_data: 0.0
+      types_found: [float]
     HOSPITAL:
-      sample_data: 0
-      types_found: [int]
+      sample_data: 0.0
+      types_found: [float]
     HOTEL:
       sample_data: 0.0
       types_found: [float]
     INDUSTRIAL:
-      sample_data: 0
-      types_found: [int]
+      sample_data: 0.0
+      types_found: [float]
     LIBRARY:
-      sample_data: 0
-      types_found: [int]
+      sample_data: 0.0
+      types_found: [float]
     MULTI_RES:
       sample_data: 0.0
       types_found: [float]
     Name:
-      sample_data: B010
+      sample_data: B09
       types_found: [string]
     OFFICE:
-      sample_data: 0.7
+      sample_data: 0.5
       types_found: [float]
     PARKING:
-      sample_data: 0
-      types_found: [int]
+      sample_data: 0.5
+      types_found: [float]
     RESTAURANT:
-      sample_data: 0.1
+      sample_data: 0.0
       types_found: [float]
     RETAIL:
-      sample_data: 0.2
+      sample_data: 0.0
       types_found: [float]
     SCHOOL:
-      sample_data: 0
-      types_found: [int]
+      sample_data: 0.0
+      types_found: [float]
     SERVERROOM:
-      sample_data: 0
-      types_found: [int]
+      sample_data: 0.0
+      types_found: [float]
     SINGLE_RES:
-      sample_data: 0
-      types_found: [int]
+      sample_data: 0.0
+      types_found: [float]
     SWIMMING:
-      sample_data: 0
-      types_found: [int]
-  used_by: [data-helper, emissions, demand]
+      sample_data: 0.0
+      types_found: [float]
+  used_by: [data_helper, emissions, demand]
 get_building_supply:
-  created_by: [data-helper]
-  description: scenario/inputs/building-properties/building_supply.dbf
+  created_by: [data_helper]
   file_path: inputs/building-properties/supply_systems.dbf
   file_type: dbf
   schema:
     Name:
-      sample_data: B010
+      sample_data: B09
       types_found: [string]
     type_cs:
-      sample_data: T3
+      sample_data: T19
       types_found: [string]
     type_dhw:
-      sample_data: T4
+      sample_data: T3
       types_found: [string]
     type_el:
-      sample_data: T6
+      sample_data: T24
       types_found: [string]
     type_hs:
-      sample_data: T0
+      sample_data: T3
       types_found: [string]
-  used_by: [demand, operation-costs, emissions]
+  used_by: [demand, decentralized, emissions, operation_costs]
+get_building_weekly_schedules:
+  created_by: [data_helper]
+  file_path: inputs/building-properties/schedules/B001.csv
+  file_type: csv
+  schema:
+    METADATA:
+      sample_data: 0.8500000000000001
+      types_found: [float, null]
+    mixed-schedule:
+      sample_data: 0.8500000000000001
+      types_found: [float, null]
+  used_by: [schedule_maker, demand]
 get_costs_operation_file:
-  created_by: [operation-costs]
-  description: scenario/outputs/data/costs/{load}_cost_operation.pdf
+  created_by: [operation_costs]
   file_path: outputs/data/costs/operation_costs.csv
   file_type: csv
   schema:
+    Aocc_m2:
+      sample_data: 2248.76
+      types_found: [float]
     COAL_hs_cost_m2yr:
       sample_data: 0.0
       types_found: [float]
@@ -1929,6 +1284,12 @@ get_costs_operation_file:
       sample_data: 0.0
       types_found: [float]
     COAL_ww_cost_yr:
+      sample_data: 0.0
+      types_found: [float]
+    Capex_a_sys_connected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Capex_a_sys_disconnected_USD:
       sample_data: 0.0
       types_found: [float]
     DC_cdata_cost_m2yr:
@@ -1962,28 +1323,25 @@ get_costs_operation_file:
       sample_data: 0.0
       types_found: [float]
     GRID_cost_m2yr:
-      sample_data: 27.24
+      sample_data: 13.04
       types_found: [float]
     GRID_cost_yr:
-      sample_data: 1332201.0
-      types_found: [float]
-    Aocc_m2:
-      sample_data: 48914.39
+      sample_data: 29315.66
       types_found: [float]
     NG_hs_cost_m2yr:
-      sample_data: 0.0
+      sample_data: 7.04
       types_found: [float]
     NG_hs_cost_yr:
-      sample_data: 0.0
+      sample_data: 15821.99
       types_found: [float]
     NG_ww_cost_m2yr:
-      sample_data: 0.0
+      sample_data: 0.72
       types_found: [float]
     NG_ww_cost_yr:
-      sample_data: 0.0
+      sample_data: 1613.98
       types_found: [float]
     Name:
-      sample_data: B010
+      sample_data: B09
       types_found: [string]
     OIL_hs_cost_m2yr:
       sample_data: 0.0
@@ -1996,6 +1354,12 @@ get_costs_operation_file:
       types_found: [float]
     OIL_ww_cost_yr:
       sample_data: 0.0
+      types_found: [float]
+    Opex_a_sys_connected_USD:
+      sample_data: 29315.66
+      types_found: [float]
+    Opex_a_sys_disconnected_USD:
+      sample_data: 17435.97
       types_found: [float]
     PV_cost_m2yr:
       sample_data: 0.0
@@ -2028,417 +1392,137 @@ get_costs_operation_file:
       sample_data: 0.0
       types_found: [float]
   used_by: []
-get_demand_results_file:
-  created_by: [demand]
-  description: scenario/outputs/data/demand/{building_name}.csv
-  file_path: outputs/data/demand/b001.csv
-  file_type: csv
-  schema:
-    COAL_hs_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    COAL_ww_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    DATE:
-      sample_data: '2005-12-31 23:00:00'
-      types_found: [date]
-    DC_cdata_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    DC_cre_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    DC_cs_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    DH_hs_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    DH_ww_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    E_cdata_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    E_cre_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    E_cs_kWh:
-      sample_data: 440.94800000000004
-      types_found: [float]
-    E_hs_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    E_sys_kWh:
-      sample_data: 148.92
-      types_found: [float]
-    E_ww_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Eal_kWh:
-      sample_data: 148.842
-      types_found: [float]
-    Eaux_kWh:
-      sample_data: 0.078
-      types_found: [float]
-    Edata_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Epro_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    GRID_kWh:
-      sample_data: 589.868
-      types_found: [float]
-    I_rad_kWh:
-      sample_data: 18.764
-      types_found: [float]
-    I_sol_and_I_rad_kWh:
-      sample_data: -18.764
-      types_found: [float]
-    I_sol_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    NG_hs_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    NG_ww_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Name:
-      sample_data: B001
-      types_found: [string]
-    OIL_hs_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    OIL_ww_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    PV_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    QC_sys_kWh:
-      sample_data: 2543.288
-      types_found: [float]
-    QH_sys_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Q_gain_lat_peop_kWh:
-      sample_data: 140.069
-      types_found: [float]
-    Q_gain_sen_app_kWh:
-      sample_data: 22.811999999999998
-      types_found: [float]
-    Q_gain_sen_base_kWh:
-      sample_data: -11.894
-      types_found: [float]
-    Q_gain_sen_data_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Q_gain_sen_light_kWh:
-      sample_data: 113.427
-      types_found: [float]
-    Q_gain_sen_peop_kWh:
-      sample_data: 171.55
-      types_found: [float]
-    Q_gain_sen_pro_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Q_gain_sen_roof_kWh:
-      sample_data: -5.0969999999999995
-      types_found: [float]
-    Q_gain_sen_vent_kWh:
-      sample_data: 4.081
-      types_found: [float]
-    Q_gain_sen_wall_kWh:
-      sample_data: -15.867
-      types_found: [float]
-    Q_gain_sen_wind_kWh:
-      sample_data: -13.807
-      types_found: [float]
-    Q_loss_sen_ref_kWh:
-      sample_data: -0.0
-      types_found: [float]
-    Qcdata_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qcdata_sys_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qcre_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qcre_sys_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qcs_dis_ls_kWh:
-      sample_data: -0.315
-      types_found: [float]
-    Qcs_em_ls_kWh:
-      sample_data: -40.324
-      types_found: [float]
-    Qcs_kWh:
-      sample_data: -2502.649
-      types_found: [float]
-    Qcs_lat_ahu_kWh:
-      sample_data: -1684.351
-      types_found: [float]
-    Qcs_lat_aru_kWh:
-      sample_data: -75.188
-      types_found: [float]
-    Qcs_lat_sys_kWh:
-      sample_data: 1759.539
-      types_found: [float]
-    Qcs_sen_ahu_kWh:
-      sample_data: -528.237
-      types_found: [float]
-    Qcs_sen_aru_kWh:
-      sample_data: -214.87400000000002
-      types_found: [float]
-    Qcs_sen_scu_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qcs_sen_sys_kWh:
-      sample_data: -743.1110000000001
-      types_found: [float]
-    Qcs_sys_ahu_kWh:
-      sample_data: -2241.475
-      types_found: [float]
-    Qcs_sys_aru_kWh:
-      sample_data: -301.813
-      types_found: [float]
-    Qcs_sys_kWh:
-      sample_data: 2543.288
-      types_found: [float]
-    Qcs_sys_scu_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qcpro_sys_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qhpro_sys_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qhs_dis_ls_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qhs_em_ls_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qhs_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qhs_lat_ahu_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qhs_lat_aru_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qhs_lat_sys_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qhs_sen_ahu_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qhs_sen_aru_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qhs_sen_shu_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qhs_sen_sys_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qhs_sys_ahu_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qhs_sys_aru_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qhs_sys_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qhs_sys_shu_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qww_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    Qww_sys_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    SOLAR_hs_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    SOLAR_ww_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    T_ext_C:
-      sample_data: 24.2
-      types_found: [float]
-    T_int_C:
-      sample_data: 24.0
-      types_found: [float]
-    Tcdata_sys_re_C:
-      sample_data: 0.0
-      types_found: [float]
-    Tcdata_sys_sup_C:
-      sample_data: 0.0
-      types_found: [float]
-    Tcre_sys_re_C:
-      sample_data: 0.0
-      types_found: [float]
-    Tcre_sys_sup_C:
-      sample_data: 0.0
-      types_found: [float]
-    Tcs_sys_re_C:
-      sample_data: 0.0
-      types_found: [float]
-    Tcs_sys_re_ahu_C:
-      sample_data: 23.855999999999998
-      types_found: [float]
-    Tcs_sys_re_aru_C:
-      sample_data: 23.359
-      types_found: [float]
-    Tcs_sys_re_scu_C:
-      sample_data: 0.0
-      types_found: [float]
-    Tcs_sys_sup_C:
-      sample_data: 0.0
-      types_found: [float]
-    Tcs_sys_sup_ahu_C:
-      sample_data: 7.5
-      types_found: [float]
-    Tcs_sys_sup_aru_C:
-      sample_data: 7.5
-      types_found: [float]
-    Tcs_sys_sup_scu_C:
-      sample_data: 0.0
-      types_found: [float]
-    Ths_sys_re_C:
-      sample_data: 0.0
-      types_found: [float]
-    Ths_sys_re_ahu_C:
-      sample_data: 0.0
-      types_found: [float]
-    Ths_sys_re_aru_C:
-      sample_data: 0.0
-      types_found: [float]
-    Ths_sys_re_shu_C:
-      sample_data: 0.0
-      types_found: [float]
-    Ths_sys_sup_C:
-      sample_data: 0.0
-      types_found: [float]
-    Ths_sys_sup_ahu_C:
-      sample_data: 0.0
-      types_found: [float]
-    Ths_sys_sup_aru_C:
-      sample_data: 0.0
-      types_found: [float]
-    Ths_sys_sup_shu_C:
-      sample_data: 0.0
-      types_found: [float]
-    Tww_sys_re_C:
-      sample_data: 0.0
-      types_found: [float]
-    Tww_sys_sup_C:
-      sample_data: 0.0
-      types_found: [float]
-    WOOD_hs_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    WOOD_ww_kWh:
-      sample_data: 0.0
-      types_found: [float]
-    mcpcdata_sys_kWperC:
-      sample_data: 0.0
-      types_found: [float]
-    mcpcre_sys_kWperC:
-      sample_data: 0.0
-      types_found: [float]
-    mcpcs_sys_ahu_kWperC:
-      sample_data: 137.041
-      types_found: [float]
-    mcpcs_sys_aru_kWperC:
-      sample_data: 19.031
-      types_found: [float]
-    mcpcs_sys_kWperC:
-      sample_data: 0.0
-      types_found: [float]
-    mcpcs_sys_scu_kWperC:
-      sample_data: 0.0
-      types_found: [float]
-    mcphs_sys_ahu_kWperC:
-      sample_data: 0.0
-      types_found: [float]
-    mcphs_sys_aru_kWperC:
-      sample_data: 0.0
-      types_found: [float]
-    mcphs_sys_kWperC:
-      sample_data: 0.0
-      types_found: [float]
-    mcphs_sys_shu_kWperC:
-      sample_data: 0.0
-      types_found: [float]
-    mcptw_kWperC:
-      sample_data: 0.0
-      types_found: [float]
-    mcpww_sys_kWperC:
-      sample_data: 0.0
-      types_found: [float]
-    people:
-      sample_data: 2350.0
-      types_found: [float]
-    theta_o_C:
-      sample_data: 24.708000000000002
-      types_found: [float]
-    x_int:
-      sample_data: 7.385
-      types_found: [float]
-  used_by: [sewage-potential, thermal-network]
-get_surroundings_geometry:
+get_database_air_conditioning_systems:
   created_by: []
-  description: scenario/inputs/building-geometry/surroundings.shp
-  file_path: inputs/building-geometry/surroundings.shp
-  file_type: shp
+  file_path: inputs/technology/systems/air_conditioning_systems.xls
+  file_type: xls
   schema:
-    Name:
-      sample_data: B019
-      types_found: [string]
-    floors_ag:
-      sample_data: !!python/long '8'
-      types_found: [long]
-    floors_bg:
-      sample_data: !!python/long '0'
-      types_found: [long]
-    geometry:
-      sample_data: ((x1 y1, x2 y2, ...))
-      types_found: [Polygon]
-    height_ag:
-      sample_data: !!python/long '28'
-      types_found: [long]
-    height_bg:
-      sample_data: !!python/long '0'
-      types_found: [long]
-  used_by: [radiation]
-get_edge_mass_flow_csv_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/optimization/network/layout/nominal_edgemassflow_at_design_dh__kgpers.csv
-  file_type: csv
-  schema:
-    PIPE0:
-      sample_value: 0.0
-      types_found: [float]
-    'Unnamed: 0':
-      sample_value: !!python/long '8759'
-      types_found: [long]
-  used_by: []
-get_envelope_systems:
+    controller:
+      Description:
+        sample_data: room temperature control (electromagnetically/electronically).
+        types_found: [string]
+      code:
+        sample_data: T4
+        types_found: [string]
+      dT_Qcs:
+        sample_data: 1.8
+        types_found: [float]
+      dT_Qhs:
+        sample_data: 1.8
+        types_found: [float]
+    cooling:
+      Description:
+        sample_data: 'floor cooling (18/21)  '
+        types_found: [string]
+      Qcsmax_Wm2:
+        sample_data: !!python/long '100'
+        types_found: [long]
+      Tc_sup_air_ahu_C:
+        sample_data: 18.0
+        types_found: [float, null]
+      Tc_sup_air_aru_C:
+        sample_data: 13.0
+        types_found: [float, null]
+      Tscs0_ahu_C:
+        sample_data: 7.5
+        types_found: [float, null]
+      Tscs0_aru_C:
+        sample_data: 7.5
+        types_found: [float, null]
+      Tscs0_scu_C:
+        sample_data: 18.0
+        types_found: [float, null]
+      code:
+        sample_data: T5
+        types_found: [string]
+      dTcs0_ahu_C:
+        sample_data: 7.0
+        types_found: [float, null]
+      dTcs0_aru_C:
+        sample_data: 4.0
+        types_found: [float, null]
+      dTcs0_scu_C:
+        sample_data: 3.0
+        types_found: [float, null]
+      dTcs_C:
+        sample_data: 0.5
+        types_found: [float]
+    dhw:
+      Description:
+        sample_data: 'High temperature in the tropics (60/25) '
+        types_found: [string]
+      Qwwmax_Wm2:
+        sample_data: !!python/long '500'
+        types_found: [long]
+      Tsww0_C:
+        sample_data: !!python/long '60'
+        types_found: [long]
+      code:
+        sample_data: T4
+        types_found: [string]
+    heating:
+      Description:
+        sample_data: 'Floor heating (40/35) '
+        types_found: [string]
+      Qhsmax_Wm2:
+        sample_data: !!python/long '150'
+        types_found: [long]
+      Th_sup_air_ahu_C:
+        sample_data: 36.0
+        types_found: [float, null]
+      Th_sup_air_aru_C:
+        sample_data: 36.0
+        types_found: [float, null]
+      Tshs0_ahu_C:
+        sample_data: 40.0
+        types_found: [float, null]
+      Tshs0_aru_C:
+        sample_data: 40.0
+        types_found: [float, null]
+      Tshs0_shu_C:
+        sample_data: 40.0
+        types_found: [float, null]
+      code:
+        sample_data: T4
+        types_found: [string]
+      dThs0_ahu_C:
+        sample_data: 20.0
+        types_found: [float, null]
+      dThs0_aru_C:
+        sample_data: 20.0
+        types_found: [float, null]
+      dThs0_shu_C:
+        sample_data: 5.0
+        types_found: [float, null]
+      dThs_C:
+        sample_data: -0.9
+        types_found: [float]
+    ventilation:
+      Description:
+        sample_data: Window ventilation - no night flushing
+        types_found: [string]
+      ECONOMIZER:
+        sample_data: false
+        types_found: [bool]
+      HEAT_REC:
+        sample_data: false
+        types_found: [bool]
+      MECH_VENT:
+        sample_data: false
+        types_found: [bool]
+      NIGHT_FLSH:
+        sample_data: false
+        types_found: [bool]
+      WIN_VENT:
+        sample_data: true
+        types_found: [bool]
+      code:
+        sample_data: T3
+        types_found: [string]
+  used_by: [demand]
+get_database_envelope_systems:
   created_by: []
-  description: databases/Systems/emission_systems.csv
-  file_path: databases/ch/systems/envelope_systems.xls
+  file_path: inputs/technology/systems/envelope_systems.xls
   file_type: xls
   schema:
     CONSTRUCTION:
@@ -2516,6 +1600,9 @@ get_envelope_systems:
       Description:
         sample_data: window - SinBERBest Office
         types_found: [string]
+      F_F:
+        sample_data: 0.2
+        types_found: [float]
       G_win:
         sample_data: 0.2
         types_found: [float]
@@ -2528,323 +1615,10 @@ get_envelope_systems:
       e_win:
         sample_data: 0.89
         types_found: [float]
-  used_by: [radiation, demand]
-get_lake_potential:
-  created_by: [lake-potential]
-  description: null
-  file_path: outputs/data/potentials/lake_potential.csv
-  file_type: csv
-  schema:
-    hour:
-      sample_data: !!python/long '8759'
-      types_found: [long]
-    lake_potential:
-      sample_data: 0.0
-      types_found: [float]
-  used_by: []
-get_lca_embodied:
-  created_by: [emissions]
-  description: scenario/outputs/data/emissions/Total_LCA_embodied.csv
-  file_path: outputs/data/emissions/total_lca_embodied.csv
-  file_type: csv
-  schema:
-    E_ghg_kgm2:
-      sample_data: 6.27
-      types_found: [float]
-    E_ghg_ton:
-      sample_data: 306.75
-      types_found: [float]
-    E_nre_pen_GJ:
-      sample_data: 3555.48
-      types_found: [float]
-    E_nre_pen_MJm2:
-      sample_data: 72.69
-      types_found: [float]
-    GFA_m2:
-      sample_data: 48914.39
-      types_found: [float]
-    Name:
-      sample_data: B010
-      types_found: [string]
-  used_by: []
-get_lca_mobility:
-  created_by: [emissions]
-  description: scenario/outputs/data/emissions/Total_LCA_mobility.csv
-  file_path: outputs/data/emissions/total_lca_mobility.csv
-  file_type: csv
-  schema:
-    GFA_m2:
-      sample_data: 48914.39
-      types_found: [float]
-    M_ghg_kgm2:
-      sample_data: 57.93
-      types_found: [float]
-    M_ghg_ton:
-      sample_data: 2833.61
-      types_found: [float]
-    M_nre_pen_GJ:
-      sample_data: 47921.42
-      types_found: [float]
-    M_nre_pen_MJm2:
-      sample_data: 979.7
-      types_found: [float]
-    Name:
-      sample_data: B010
-      types_found: [string]
-  used_by: []
-get_lca_operation:
-  created_by: [emissions]
-  description: scenario/outputs/data/emissions/Total_LCA_operation.csv
-  file_path: outputs/data/emissions/total_lca_operation.csv
-  file_type: csv
-  schema:
-    COAL_hs_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    COAL_hs_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    COAL_hs_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    COAL_hs_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-    COAL_ww_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    COAL_ww_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    COAL_ww_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    COAL_ww_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-    DC_cdata_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    DC_cdata_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    DC_cdata_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    DC_cdata_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-    DC_cre_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    DC_cre_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    DC_cre_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    DC_cre_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-    DC_cs_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    DC_cs_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    DC_cs_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    DC_cs_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-    DH_hs_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    DH_hs_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    DH_hs_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    DH_hs_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-    DH_ww_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    DH_ww_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    DH_ww_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    DH_ww_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-    GFA_m2:
-      sample_data: 48914.39
-      types_found: [float]
-    GFA_m2.1:
-      sample_data: 48914.39
-      types_found: [float]
-    GRID_ghg_kgm2:
-      sample_data: 85.63
-      types_found: [float]
-    GRID_ghg_ton:
-      sample_data: 4188.44
-      types_found: [float]
-    GRID_nre_pen_GJ:
-      sample_data: 80347.71
-      types_found: [float]
-    GRID_nre_pen_MJm2:
-      sample_data: 1642.62
-      types_found: [float]
-    NG_hs_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    NG_hs_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    NG_hs_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    NG_hs_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-    NG_ww_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    NG_ww_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    NG_ww_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    NG_ww_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-    Name:
-      sample_data: B010
-      types_found: [string]
-    Name.1:
-      sample_data: B010
-      types_found: [string]
-    OIL_hs_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    OIL_hs_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    OIL_hs_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    OIL_hs_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-    OIL_ww_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    OIL_ww_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    OIL_ww_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    OIL_ww_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-    O_ghg_kgm2:
-      sample_data: 85.63
-      types_found: [float]
-    O_ghg_ton:
-      sample_data: 4188.44
-      types_found: [float]
-    O_nre_pen_GJ:
-      sample_data: 80347.71
-      types_found: [float]
-    O_nre_pen_MJm2:
-      sample_data: 1642.62
-      types_found: [float]
-    PV_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    PV_ghg_kgm2.1:
-      sample_data: 0.0
-      types_found: [float]
-    PV_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    PV_ghg_ton.1:
-      sample_data: 0.0
-      types_found: [float]
-    PV_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    PV_nre_pen_GJ.1:
-      sample_data: 0.0
-      types_found: [float]
-    PV_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-    PV_nre_pen_MJm2.1:
-      sample_data: 0.0
-      types_found: [float]
-    SOLAR_hs_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    SOLAR_hs_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    SOLAR_hs_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    SOLAR_hs_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-    SOLAR_ww_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    SOLAR_ww_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    SOLAR_ww_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    SOLAR_ww_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-    WOOD_hs_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    WOOD_hs_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    WOOD_hs_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    WOOD_hs_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-    WOOD_ww_ghg_kgm2:
-      sample_data: 0.0
-      types_found: [float]
-    WOOD_ww_ghg_ton:
-      sample_data: 0.0
-      types_found: [float]
-    WOOD_ww_nre_pen_GJ:
-      sample_data: 0.0
-      types_found: [float]
-    WOOD_ww_nre_pen_MJm2:
-      sample_data: 0.0
-      types_found: [float]
-  used_by: []
-get_life_cycle_inventory_building_systems:
+  used_by: [schedule_maker, radiation, demand]
+get_database_lca_buildings:
   created_by: []
-  description: "Returns the database of life cycle inventory for buildings systems.\
-    \ These are copied\n        to the scenario if they are not yet present, based\
-    \ on the configured region for the scenario."
-  file_path: databases/sg/lifecycle/lca_buildings.xlsx
+  file_path: inputs/technology/lifecycle/LCA_buildings.xlsx
   file_type: xlsx
   schema:
     EMBODIED_EMISSIONS:
@@ -2934,443 +1708,70 @@ get_life_cycle_inventory_building_systems:
         sample_data: !!python/long '2021'
         types_found: [long]
   used_by: [emissions]
-get_life_cycle_inventory_supply_systems:
+get_database_lca_mobility:
   created_by: []
-  description: "Returns the database of life cycle inventory for supply systems. These\
-    \ are copied\n        to the scenario if they are not yet present, based on the\
-    \ configured region for the scenario."
-  file_path: databases/sg/lifecycle/lca_infrastructure.xlsx
-  file_type: xlsx
+  file_path: inputs/technology/lifecycle/LCA_mobility.xls
+  file_type: xls
   schema:
-    COOLING:
+    MOBILITY:
+      CO2_today:
+        sample_data: 90.0
+        types_found: [float]
       Description:
-        sample_data: district cooling - natural gas-fired boiler for absorption chiller
+        sample_data: 'Assumed: same as RETAIL'
+        types_found: [string]
+      NRE_today:
+        sample_data: 1460.0
+        types_found: [float]
+      PEN_today:
+        sample_data: !!python/long '1550'
+        types_found: [long]
+      code:
+        sample_data: MUSEUM
+        types_found: [string]
+  used_by: [emissions, operation_costs]
+get_database_standard_schedules_use:
+  created_by: []
+  file_path: inputs/technology/archetypes/schedules/RESTAURANT.csv
+  file_type: csv
+  schema:
+    CH-SIA-2014:
+      sample_data: 0.8
+      types_found: [float, null]
+    METADATA:
+      sample_data: 0.8
+      types_found: [float, null]
+    RESTAURANT:
+      sample_data: 0.8
+      types_found: [float, null]
+  used_by: [data_helper]
+get_database_supply_systems:
+  created_by: []
+  file_path: inputs/technology/systems/supply_systems.xls
+  file_type: xls
+  schema:
+    ALL_IN_ONE_SYSTEMS:
+      Description:
+        sample_data: PV panel - monocrystalline roof top
         types_found: [string]
       code:
         sample_data: T25
-        types_found: [string]
-      eff_cs:
-        sample_data: 0.8
-        types_found: [float]
-      reference:
-        sample_data: educated guess
-        types_found: [string]
-      scale_cs:
-        sample_data: DISTRICT
-        types_found: [string]
-      source_cs:
-        sample_data: NATURALGAS
-        types_found: [string]
-    DHW:
-      Description:
-        sample_data: solar collector
-        types_found: [string]
-      code:
-        sample_data: T7
-        types_found: [string]
-      eff_dhw:
-        sample_data: 0.7
-        types_found: [float]
-      reference:
-        sample_data: educated guess
-        types_found: [string]
-      scale_dhw:
-        sample_data: BUILDING
-        types_found: [string]
-      source_dhw:
-        sample_data: SOLAR
-        types_found: [string]
-    ELECTRICITY:
-      Description:
-        sample_data: Singaporean consumer mix
-        types_found: [string]
-      code:
-        sample_data: T6
-        types_found: [string]
-      eff_el:
+        types_found: [date, string]
+      efficiency:
         sample_data: 0.99
         types_found: [float]
+      feedstock:
+        sample_data: SOLAR
+        types_found: [string]
       reference:
         sample_data: educated guess
         types_found: [string]
-      scale_el:
-        sample_data: CITY
-        types_found: [string]
-      source_el:
-        sample_data: GRID
-        types_found: [string]
-    HEATING:
-      Description:
-        sample_data: solar collector
-        types_found: [string]
-      code:
-        sample_data: T7
-        types_found: [string]
-      eff_hs:
-        sample_data: 0.7
-        types_found: [float]
-      reference:
-        sample_data: educated guess
-        types_found: [string]
-      scale_hs:
+      scale:
         sample_data: BUILDING
         types_found: [string]
-      source_hs:
-        sample_data: SOLAR
+      system:
+        sample_data: ELECTRICITY
         types_found: [string]
-    RESOURCES:
-      CO2:
-        sample_data: 0.0001
-        types_found: [float]
-      Description:
-        sample_data: Solar
-        types_found: [string]
-      PEN:
-        sample_data: 0.0001
-        types_found: [float]
-      code:
-        sample_data: SOLAR
-        types_found: [string]
-      costs_kWh:
-        sample_data: 0.0001
-        types_found: [float]
-      reference:
-        sample_data: PEN and CO2 zero equivalent due to renewable technology, cost
-          from CEA, costs in USD-2015
-        types_found: [string, null]
-  used_by: [demand, operation-costs, emissions]
-get_network_layout_edges_shapefile:
-  created_by: [thermal-network, network-layout]
-  description: scenario/inputs/network/DH or DC/network-edges.shp
-  file_path: inputs/networks/dc/edges.shp
-  file_type: shp
-  schema:
-    Name:
-      sample_data: PIPE24
-      types_found: [string]
-    Pipe_DN:
-      sample_data: !!python/long '150'
-      types_found: [long]
-    Type_mat:
-      sample_data: T1
-      types_found: [string]
-    geometry:
-      sample_data: ((x1 y1, x2 y2, ...))
-      types_found: [LineString]
-    weight:
-      sample_data: 38.071335688888716
-      types_found: [float, null]
-  used_by: []
-get_network_layout_nodes_shapefile:
-  created_by: [network-layout]
-  description: scenario/inputs/network/DH or DC/network-nodes.shp
-  file_path: inputs/networks/dc/nodes.shp
-  file_type: shp
-  schema:
-    Building:
-      sample_data: NONE
-      types_found: [string]
-    Name:
-      sample_data: NODE25
-      types_found: [string]
-    Type:
-      sample_data: PLANT
-      types_found: [string]
-    geometry:
-      sample_data: ((x1 y1, x2 y2, ...))
-      types_found: [Point]
-  used_by: [thermal-network]
-get_node_mass_flow_csv_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/optimization/network/layout/nominal_nodemassflow_at_design_dh__kgpers.csv
-  file_type: csv
-  schema:
-    NODE0:
-      sample_value: 0.0
-      types_found: [float]
-    'Unnamed: 0':
-      sample_value: !!python/long '8759'
-      types_found: [long]
-  used_by: []
-get_optimization_network_edge_list_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/optimization/network/layout/dh__edges.csv
-  file_type: csv
-  schema:
-    D_ext_m:
-      sample_value: 0.1397
-      types_found: [float]
-    D_ins_m:
-      sample_value: 0.25
-      types_found: [float]
-    D_int_m:
-      sample_value: 0.1325
-      types_found: [float]
-    Name:
-      sample_value: PIPE29
-      types_found: [str]
-    Pipe_DN_x:
-      sample_value: 125.0
-      types_found: [float]
-    Pipe_DN_y:
-      sample_value: 125.0
-      types_found: [float]
-    Type_mat:
-      sample_value: T1
-      types_found: [str]
-    Vdot_max_m3s:
-      sample_value: 0.045743321706281266
-      types_found: [float]
-    Vdot_min_m3s:
-      sample_value: 0.004149258372439969
-      types_found: [float]
-    coordinates:
-      sample_value: (463249.0418, 5225404.0336)
-      types_found: [str]
-    end node:
-      sample_value: NODE5
-      types_found: [str]
-    geometry:
-      sample_value: LINESTRING (463249.0418 5225404.0336, 463248.0418 5225403.0336)
-      types_found: [str]
-    mdot_max_kgs:
-      sample_value: 45.65183506286871
-      types_found: [float]
-    mdot_min_kgs:
-      sample_value: 4.1409598556950895
-      types_found: [float]
-    pipe length:
-      sample_value: 1.4142135623730951
-      types_found: [float]
-    start node:
-      sample_value: NODE30
-      types_found: [str]
-  used_by: []
-get_optimization_network_edge_node_matrix_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/optimization/network/layout/dh__edgenode.csv
-  file_type: csv
-  schema:
-    PIPE0:
-      sample_value: -0.0
-      types_found: [float]
-    'Unnamed: 0':
-      sample_value: NODE30
-      types_found: [str]
-  used_by: []
-get_optimization_network_layout_massflow_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/optimization/network/layout/dh__massflow_kgs.csv
-  file_type: csv
-  schema:
-    PIPE0:
-      sample_value: 0.0
-      types_found: [float]
-  used_by: []
-get_optimization_network_layout_plant_heat_requirement_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/optimization/network/layout/dh__plant_heat_requirement_kw.csv
-  file_type: csv
-  schema:
-    NONE:
-      sample_value: 302.6
-      types_found: [float]
-  used_by: []
-get_optimization_network_layout_ploss_system_edges_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/optimization/network/layout/dh__ploss_system_edges_kw.csv
-  file_type: csv
-  schema:
-    PIPE0:
-      sample_value: 0.0
-      types_found: [float]
-  used_by: []
-get_optimization_network_layout_pressure_drop_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/optimization/network/layout/dh__p_deltap_pa.csv
-  file_type: csv
-  schema:
-    pressure_loss_return_Pa:
-      sample_value: 33939.863
-      types_found: [float]
-    pressure_loss_substations_Pa:
-      sample_value: 15266.503999999999
-      types_found: [float]
-    pressure_loss_supply_Pa:
-      sample_value: 31133.083
-      types_found: [float]
-    pressure_loss_total_Pa:
-      sample_value: 80339.451
-      types_found: [float]
-  used_by: []
-get_optimization_network_layout_qloss_system_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/optimization/network/layout/dh__qloss_system_kw.csv
-  file_type: csv
-  schema:
-    PIPE0:
-      sample_value: 0.0
-      types_found: [float]
-  used_by: []
-get_optimization_network_layout_return_temperature_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/optimization/network/layout/dh__t_return_k.csv
-  file_type: csv
-  schema:
-    NODE0:
-      sample_value: 309.611
-      types_found: [float]
-  used_by: []
-get_optimization_network_layout_supply_temperature_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/optimization/network/layout/dh__t_supply_k.csv
-  file_type: csv
-  schema:
-    NODE0:
-      sample_value: 341.471
-      types_found: [float]
-  used_by: []
-get_thermal_network_node_types_csv_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/optimization/network/layout/dh__nodes.csv
-  file_type: csv
-  schema:
-    Building:
-      sample_value: NONE
-      types_found: [str]
-    Name:
-      sample_value: NODE25
-      types_found: [str]
-    Q_hex_h_ahu:
-      sample_value: 223.0
-      types_found: [float, null]
-    Q_hex_h_aru:
-      sample_value: 46.0
-      types_found: [float, null]
-    Q_hex_h_shu:
-      sample_value: 0.0
-      types_found: [float, null]
-    Q_hex_h_ww:
-      sample_value: 59.0
-      types_found: [float, null]
-    Q_hex_plant_kW:
-      sample_value: 0.0
-      types_found: [float]
-    Type:
-      sample_value: NONE
-      types_found: [str]
-    'Unnamed: 0':
-      sample_value: !!python/long '30'
-      types_found: [long]
-    coordinates:
-      sample_value: (463411.2481, 5225358.972)
-      types_found: [str]
-  used_by: []
-get_optimization_network_substation_ploss_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/optimization/network/layout/dh__ploss_substations_kw.csv
-  file_type: csv
-  schema:
-    B001:
-      sample_value: 0.0
-      types_found: [float]
-  used_by: []
-get_radiation_building:
-  created_by: [radiation]
-  description: scenario/outputs/data/solar-radiation/${building_name}_insolation_Whm2.json
-  file_path: outputs/data/solar-radiation/b001_insolation_whm2.json
-  file_type: json
-  schema:
-    srf0:
-      sample_data: 0.0
-      types_found: [float]
-  used_by: [photovoltaic, photovoltaic-thermal, solar-collector, demand]
-get_radiation_metadata:
-  created_by: [radiation]
-  description: scenario/outputs/data/solar-radiation/{building_name}_geometrgy.csv
-  file_path: outputs/data/solar-radiation/b001_geometry.csv
-  file_type: csv
-  schema:
-    AREA_m2:
-      sample_data: 4.888679593457344
-      types_found: [float]
-    BUILDING:
-      sample_data: B001
-      types_found: [string]
-    SURFACE:
-      sample_data: srf809
-      types_found: [string]
-    TYPE:
-      sample_data: roofs
-      types_found: [string]
-    Xcoor:
-      sample_data: 371706.16910259466
-      types_found: [float]
-    Xdir:
-      sample_data: 0.0
-      types_found: [float]
-    Ycoor:
-      sample_data: 140269.47920131625
-      types_found: [float]
-    Ydir:
-      sample_data: 0.0
-      types_found: [float]
-    Zcoor:
-      sample_data: 29.01
-      types_found: [float]
-    Zdir:
-      sample_data: 1.0
-      types_found: [float]
-    orientation:
-      sample_data: top
-      types_found: [string]
-  used_by: [photovoltaic, photovoltaic-thermal, solar-collector, demand]
-get_sewage_heat_potential:
-  created_by: [sewage-potential]
-  description: null
-  file_path: outputs/data/potentials/swp.csv
-  file_type: csv
-  schema:
-    Qsw_kW:
-      sample_data: !!python/long '0'
-      types_found: [long]
-    tin_HP_C:
-      sample_data: 42.768
-      types_found: [float]
-    tin_sw_C:
-      sample_data: 42.768
-      types_found: [float]
-    tout_HP_C:
-      sample_data: 42.768
-      types_found: [float]
-    tout_sw_C:
-      sample_data: 42.768
-      types_found: [float]
-    ts_C:
-      sample_data: 42.768
-      types_found: [float]
-  used_by: []
-get_street_network:
-  created_by: []
-  description: null
-  file_path: inputs/networks/streets.shp
-  file_type: shp
-  schema:
-    FID:
-      sample_data: !!python/long '16'
-      types_found: [long]
-    geometry:
-      sample_data: ((x1 y1, x2 y2, ...))
-      types_found: [LineString]
-  used_by: [network-layout]
-get_supply_systems:
-  created_by: []
-  description: "Returns the database of supply systems for cost analysis. These are\
-    \ copied\n        to the scenario if they are not yet present, based on the configured\
-    \ region for the scenario."
-  file_path: databases/ch/systems/supply_systems.xls
-  file_type: xls
-  schema:
     Absorption_chiller:
       Description:
         sample_data: LiBr triple effect
@@ -3425,9 +1826,6 @@ get_supply_systems:
         types_found: [float]
       e_g:
         sample_data: 3.29
-        types_found: [float]
-      el_W:
-        sample_data: 6.55
         types_found: [float]
       m_cw:
         sample_data: 62.0
@@ -3680,6 +2078,19 @@ get_supply_systems:
       unit:
         sample_data: W
         types_found: [string]
+    DETAILED_ELEC_PRICES:
+      Opex_var_buy_USD2015perkWh:
+        sample_data: 0.04936071505496888
+        types_found: [float]
+      Opex_var_sell_USD2015perkWh:
+        sample_data: 0.04936071505496888
+        types_found: [float]
+      hour:
+        sample_data: !!python/long '8759'
+        types_found: [long]
+      year:
+        sample_data: !!python/long '2017'
+        types_found: [long]
     FC:
       ' Assumptions':
         sample_data: everything
@@ -3726,6 +2137,25 @@ get_supply_systems:
       unit:
         sample_data: W
         types_found: [string]
+    FEEDSTOCKS:
+      CO2:
+        sample_data: 0.0075
+        types_found: [float]
+      Opex_var_buy_USD2015perkWh:
+        sample_data: 0.20800000000000002
+        types_found: [float]
+      Opex_var_sell_USD2015perkWh:
+        sample_data: 0.20800000000000002
+        types_found: [float]
+      PEN:
+        sample_data: 0.116
+        types_found: [float]
+      code:
+        sample_data: DRYBIOMASS
+        types_found: [string]
+      reference:
+        sample_data: KBOB 2009/1:2016, ID 42.001 Kehrichtverbrennung, cost from CEA
+        types_found: [string, null]
     Furnace:
       Description:
         sample_data: furnace combined with ORC
@@ -3745,16 +2175,16 @@ get_supply_systems:
       assumption:
         types_found: [null]
       b:
-        sample_data: 0.7427937915742794
+        sample_data: 0.743
         types_found: [float]
       c:
         sample_data: !!python/long '1'
         types_found: [long]
       cap_max:
-        sample_data: !!python/long '10000000'
+        sample_data: !!python/long '50000000'
         types_found: [long]
       cap_min:
-        sample_data: !!python/long '1000000'
+        sample_data: !!python/long '5000000'
         types_found: [long]
       code:
         sample_data: FU1
@@ -3879,6 +2309,31 @@ get_supply_systems:
       unit:
         sample_data: W
         types_found: [string]
+    PIPING:
+      Code:
+        sample_data: DN1500
+        types_found: [string]
+      D_ext_m:
+        sample_data: 1.52869695
+        types_found: [float]
+      D_ins_m:
+        sample_data: 1.9947486772999998
+        types_found: [float]
+      D_int_m:
+        sample_data: 1.4941228500000001
+        types_found: [float]
+      Inv_USD2015perm:
+        sample_data: 9651.7762182
+        types_found: [float]
+      Pipe_DN:
+        sample_data: !!python/long '1500'
+        types_found: [long]
+      Vdot_max_m3s:
+        sample_data: 10.76274617420937
+        types_found: [float]
+      Vdot_min_m3s:
+        sample_data: 0.5169956864157574
+        types_found: [float]
     PV:
       Description:
         sample_data: generic amorphous silicon panel
@@ -4007,40 +2462,6 @@ get_supply_systems:
       unit:
         sample_data: W
         types_found: [string]
-    Piping:
-      'Currency ':
-        sample_data: USD-2015
-        types_found: [string]
-      Description:
-        sample_data: DN20
-        types_found: [string]
-      Diameter_max:
-        sample_data: !!python/long '20'
-        types_found: [long]
-      Diameter_min:
-        sample_data: !!python/long '0'
-        types_found: [long]
-      Investment:
-        sample_data: 491.5286645384411
-        types_found: [float]
-      Unit:
-        sample_data: mm
-        types_found: [string]
-      assumption:
-        sample_data: https://www.bfs.admin.ch/bfs/de/home/statistiken/preise.assetdetail.4924986.html
-        types_found: [string, null]
-    Pricing:
-      Description:
-        sample_data: mwst
-        types_found: [string]
-      assumption:
-        types_found: [null]
-      currency:
-        sample_data: USD-2015
-        types_found: [string, null]
-      value:
-        sample_data: 0.08
-        types_found: [float]
     Pump:
       Description:
         sample_data: generic pump
@@ -4233,243 +2654,2405 @@ get_supply_systems:
       'unit ':
         sample_data: m3
         types_found: [string]
-  used_by: [thermal-network, photovoltaic, photovoltaic-thermal, solar-collector]
-get_database_air_conditioning_systems:
-  created_by: []
-  description: databases/Systems/air_conditioning_systems.xls
-  file_path: databases/ch/systems/air_conditioning_systems.xls
-  file_type: xls
-  schema:
-    controller:
-      Description:
-        sample_data: room temperature control (electromagnetically/electronically).
-        types_found: [string]
-      code:
-        sample_data: T4
-        types_found: [string]
-      dT_Qcs:
-        sample_data: 1.8
-        types_found: [float]
-      dT_Qhs:
-        sample_data: 1.8
-        types_found: [float]
-    cooling:
-      Description:
-        sample_data: 'central AC (6/15) '
-        types_found: [string]
-      Qcsmax_Wm2:
-        sample_data: !!python/long '500'
-        types_found: [long]
-      Tc_sup_air_ahu_C:
-        sample_data: 16.0
-        types_found: [float, null]
-      Tc_sup_air_aru_C:
-        sample_data: 16.0
-        types_found: [float, null]
-      Tscs0_ahu_C:
-        sample_data: 7.5
-        types_found: [float, null]
-      Tscs0_aru_C:
-        sample_data: 7.5
-        types_found: [float, null]
-      Tscs0_scu_C:
-        sample_data: 18.0
-        types_found: [float, null]
-      code:
-        sample_data: T3
-        types_found: [string]
-      dTcs0_ahu_C:
-        sample_data: 7.0
-        types_found: [float, null]
-      dTcs0_aru_C:
-        sample_data: 7.0
-        types_found: [float, null]
-      dTcs0_scu_C:
-        sample_data: 3.0
-        types_found: [float, null]
-      dTcs_C:
-        sample_data: 0.5
-        types_found: [float]
-    dhw:
-      Description:
-        sample_data: 'High temperature in the tropics (60/25) '
-        types_found: [string]
-      Qwwmax_Wm2:
-        sample_data: !!python/long '500'
-        types_found: [long]
-      Tsww0_C:
-        sample_data: !!python/long '60'
-        types_found: [long]
-      code:
-        sample_data: T4
-        types_found: [string]
-    heating:
-      Description:
-        sample_data: 'Floor heating (40/35) '
-        types_found: [string]
-      Qhsmax_Wm2:
-        sample_data: !!python/long '150'
-        types_found: [long]
-      Th_sup_air_ahu_C:
-        sample_data: 36.0
-        types_found: [float, null]
-      Th_sup_air_aru_C:
-        sample_data: 36.0
-        types_found: [float, null]
-      Tshs0_ahu_C:
-        sample_data: 40.0
-        types_found: [float, null]
-      Tshs0_aru_C:
-        sample_data: 40.0
-        types_found: [float, null]
-      Tshs0_shu_C:
-        sample_data: 40.0
-        types_found: [float, null]
-      code:
-        sample_data: T4
-        types_found: [string]
-      dThs0_ahu_C:
-        sample_data: 20.0
-        types_found: [float, null]
-      dThs0_aru_C:
-        sample_data: 20.0
-        types_found: [float, null]
-      dThs0_shu_C:
-        sample_data: 5.0
-        types_found: [float, null]
-      dThs_C:
-        sample_data: -0.9
-        types_found: [float]
-    ventilation:
-      Description:
-        sample_data: Window ventilation - no night flushing
-        types_found: [string]
-      ECONOMIZER:
-        sample_data: false
-        types_found: [bool]
-      HEAT_REC:
-        sample_data: false
-        types_found: [bool]
-      MECH_VENT:
-        sample_data: false
-        types_found: [bool]
-      NIGHT_FLSH:
-        sample_data: false
-        types_found: [bool]
-      WIN_VENT:
-        sample_data: true
-        types_found: [bool]
-      code:
-        sample_data: T3
-        types_found: [string]
-  used_by: [demand]
-get_terrain:
-  created_by: []
-  description: scenario/inputs/topography/terrain.tif
-  file_path: inputs/topography/terrain.tif
-  file_type: tif
-  schema:
-    Mock_variable:
-      sample_data: pixels
-      types_found: [raster]
-  used_by: [radiation]
-get_thermal_demand_csv_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/optimization/network/layout/aggregated_demand_dh__wh.csv
+  used_by: [photovoltaic_thermal, decentralized, solar_collector, thermal_network,
+    optimization, emissions, demand, photovoltaic, operation_costs]
+get_demand_results_file:
+  created_by: [demand]
+  file_path: outputs/data/demand/B001.csv
   file_type: csv
   schema:
-    B001:
-      sample_value: 0.0
+    COAL_hs_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    COAL_ww_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    DATE:
+      sample_data: '2005-12-31 23:00:00'
+      types_found: [date]
+    DC_cdata_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cre_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cs_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    DH_hs_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    DH_ww_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    E_cdata_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    E_cre_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    E_cs_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    E_hs_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    E_sys_kWh:
+      sample_data: 18.566
+      types_found: [float]
+    E_ww_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Ea_kWh:
+      sample_data: 1.349
+      types_found: [float]
+    Eal_kWh:
+      sample_data: 18.566
+      types_found: [float]
+    Eaux_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Edata_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    El_kWh:
+      sample_data: 17.217
+      types_found: [float]
+    Epro_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_a_kWh:
+      sample_data: 1.349
+      types_found: [float]
+    GRID_aux_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_cdata_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_cre_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_cs_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_data_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_hs_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_kWh:
+      sample_data: 18.566
+      types_found: [float]
+    GRID_l_kWh:
+      sample_data: 17.217
+      types_found: [float]
+    GRID_pro_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_ww_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    I_rad_kWh:
+      sample_data: 4.5089999999999995
+      types_found: [float]
+    I_sol_and_I_rad_kWh:
+      sample_data: -4.5089999999999995
+      types_found: [float]
+    I_sol_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    NG_hs_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    NG_ww_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Name:
+      sample_data: B01
+      types_found: [string]
+    OIL_hs_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    OIL_ww_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    PV_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    QC_sys_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    QH_sys_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Q_gain_lat_peop_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Q_gain_sen_app_kWh:
+      sample_data: 1.349
+      types_found: [float]
+    Q_gain_sen_base_kWh:
+      sample_data: -3.347
+      types_found: [float]
+    Q_gain_sen_data_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Q_gain_sen_light_kWh:
+      sample_data: 15.495
+      types_found: [float]
+    Q_gain_sen_peop_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Q_gain_sen_pro_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Q_gain_sen_roof_kWh:
+      sample_data: -3.6510000000000002
+      types_found: [float]
+    Q_gain_sen_vent_kWh:
+      sample_data: -12.533
+      types_found: [float]
+    Q_gain_sen_wall_kWh:
+      sample_data: -5.478
+      types_found: [float]
+    Q_gain_sen_wind_kWh:
+      sample_data: -45.794
+      types_found: [float]
+    Q_loss_sen_ref_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcdata_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcdata_sys_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcpro_sys_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcre_kWh:
+      sample_data: -0.0
+      types_found: [float]
+    Qcre_sys_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_dis_ls_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_em_ls_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_lat_ahu_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_lat_aru_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_lat_sys_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sen_ahu_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sen_aru_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sen_scu_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sen_sys_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sys_ahu_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sys_aru_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sys_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sys_scu_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qhpro_sys_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_dis_ls_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_em_ls_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_lat_ahu_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_lat_aru_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_lat_sys_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sen_ahu_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sen_aru_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sen_shu_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sen_sys_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sys_ahu_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sys_aru_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sys_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sys_shu_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qww_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    Qww_sys_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    SOLAR_hs_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    SOLAR_ww_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    T_ext_C:
+      sample_data: -1.1
+      types_found: [float]
+    T_int_C:
+      sample_data: 17.283
+      types_found: [float]
+    Tcdata_sys_re_C:
+      sample_data: 0.0
+      types_found: [float]
+    Tcdata_sys_sup_C:
+      sample_data: 0.0
+      types_found: [float]
+    Tcre_sys_re_C:
+      sample_data: 0.0
+      types_found: [float]
+    Tcre_sys_sup_C:
+      sample_data: 0.0
+      types_found: [float]
+    Tcs_sys_re_C:
+      sample_data: 0.0
+      types_found: [float]
+    Tcs_sys_re_ahu_C:
+      sample_data: 0.0
+      types_found: [float]
+    Tcs_sys_re_aru_C:
+      sample_data: 0.0
+      types_found: [float]
+    Tcs_sys_re_scu_C:
+      sample_data: 0.0
+      types_found: [float]
+    Tcs_sys_sup_C:
+      sample_data: 0.0
+      types_found: [float]
+    Tcs_sys_sup_ahu_C:
+      sample_data: 0.0
+      types_found: [float]
+    Tcs_sys_sup_aru_C:
+      sample_data: 0.0
+      types_found: [float]
+    Tcs_sys_sup_scu_C:
+      sample_data: 0.0
+      types_found: [float]
+    Ths_sys_re_C:
+      sample_data: 0.0
+      types_found: [float]
+    Ths_sys_re_ahu_C:
+      sample_data: 0.0
+      types_found: [float]
+    Ths_sys_re_aru_C:
+      sample_data: 0.0
+      types_found: [float]
+    Ths_sys_re_shu_C:
+      sample_data: 0.0
+      types_found: [float]
+    Ths_sys_sup_C:
+      sample_data: 0.0
+      types_found: [float]
+    Ths_sys_sup_ahu_C:
+      sample_data: 0.0
+      types_found: [float]
+    Ths_sys_sup_aru_C:
+      sample_data: 0.0
+      types_found: [float]
+    Ths_sys_sup_shu_C:
+      sample_data: 0.0
+      types_found: [float]
+    Tww_sys_re_C:
+      sample_data: 0.0
+      types_found: [float]
+    Tww_sys_sup_C:
+      sample_data: 0.0
+      types_found: [float]
+    WOOD_hs_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    WOOD_ww_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    mcpcdata_sys_kWperC:
+      sample_data: 0.0
+      types_found: [float]
+    mcpcre_sys_kWperC:
+      sample_data: 0.0
+      types_found: [float]
+    mcpcs_sys_ahu_kWperC:
+      sample_data: 0.0
+      types_found: [float]
+    mcpcs_sys_aru_kWperC:
+      sample_data: 0.0
+      types_found: [float]
+    mcpcs_sys_kWperC:
+      sample_data: 0.0
+      types_found: [float]
+    mcpcs_sys_scu_kWperC:
+      sample_data: 0.0
+      types_found: [float]
+    mcphs_sys_ahu_kWperC:
+      sample_data: 0.0
+      types_found: [float]
+    mcphs_sys_aru_kWperC:
+      sample_data: 0.0
+      types_found: [float]
+    mcphs_sys_kWperC:
+      sample_data: 0.0
+      types_found: [float]
+    mcphs_sys_shu_kWperC:
+      sample_data: 0.0
+      types_found: [float]
+    mcptw_kWperC:
+      sample_data: 0.0
+      types_found: [float]
+    mcpww_sys_kWperC:
+      sample_data: 0.0
+      types_found: [float]
+    people:
+      sample_data: 0.0
+      types_found: [float]
+    theta_o_C:
+      sample_data: 17.422
+      types_found: [float]
+    x_int:
+      sample_data: 4.255
+      types_found: [float]
+  used_by: [decentralized, optimization, thermal_network, sewage_potential]
+get_geothermal_potential:
+  created_by: [shallow_geothermal_potential]
+  file_path: outputs/data/potentials/Shallow_geothermal_potential.csv
+  file_type: csv
+  schema:
+    Area_avail_m2:
+      sample_data: 5621.908
+      types_found: [float]
+    QGHP_kW:
+      sample_data: 450.0
+      types_found: [float]
+    Ts_C:
+      sample_data: 10.156
+      types_found: [float]
+  used_by: [optimization]
+get_lca_embodied:
+  created_by: [emissions]
+  file_path: outputs/data/emissions/Total_LCA_embodied.csv
+  file_type: csv
+  schema:
+    E_ghg_kgm2:
+      sample_data: 6.63
+      types_found: [float]
+    E_ghg_ton:
+      sample_data: 33.13
+      types_found: [float]
+    E_nre_pen_GJ:
+      sample_data: 384.67
+      types_found: [float]
+    E_nre_pen_MJm2:
+      sample_data: 76.98
+      types_found: [float]
+    GFA_m2:
+      sample_data: 4997.25
+      types_found: [float]
+    Name:
+      sample_data: B09
+      types_found: [string]
+  used_by: []
+get_lca_mobility:
+  created_by: [emissions]
+  file_path: outputs/data/emissions/Total_LCA_mobility.csv
+  file_type: csv
+  schema:
+    GFA_m2:
+      sample_data: 4997.25
+      types_found: [float]
+    M_ghg_kgm2:
+      sample_data: 19.95
+      types_found: [float]
+    M_ghg_ton:
+      sample_data: 99.7
+      types_found: [float]
+    M_nre_pen_GJ:
+      sample_data: 1651.59
+      types_found: [float]
+    M_nre_pen_MJm2:
+      sample_data: 330.5
+      types_found: [float]
+    Name:
+      sample_data: B09
+      types_found: [string]
+  used_by: []
+get_lca_operation:
+  created_by: [emissions]
+  file_path: outputs/data/emissions/Total_LCA_operation.csv
+  file_type: csv
+  schema:
+    COAL_hs_ghg_kgm2:
+      sample_data: 0.0
+      types_found: [float]
+    COAL_hs_ghg_ton:
+      sample_data: 0.0
+      types_found: [float]
+    COAL_hs_nre_pen_GJ:
+      sample_data: 0.0
+      types_found: [float]
+    COAL_hs_nre_pen_MJm2:
+      sample_data: 0.0
+      types_found: [float]
+    COAL_ww_ghg_kgm2:
+      sample_data: 0.0
+      types_found: [float]
+    COAL_ww_ghg_ton:
+      sample_data: 0.0
+      types_found: [float]
+    COAL_ww_nre_pen_GJ:
+      sample_data: 0.0
+      types_found: [float]
+    COAL_ww_nre_pen_MJm2:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cdata_ghg_kgm2:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cdata_ghg_ton:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cdata_nre_pen_GJ:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cdata_nre_pen_MJm2:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cre_ghg_kgm2:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cre_ghg_ton:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cre_nre_pen_GJ:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cre_nre_pen_MJm2:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cs_ghg_kgm2:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cs_ghg_ton:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cs_nre_pen_GJ:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cs_nre_pen_MJm2:
+      sample_data: 0.0
+      types_found: [float]
+    DH_hs_ghg_kgm2:
+      sample_data: 0.0
+      types_found: [float]
+    DH_hs_ghg_ton:
+      sample_data: 0.0
+      types_found: [float]
+    DH_hs_nre_pen_GJ:
+      sample_data: 0.0
+      types_found: [float]
+    DH_hs_nre_pen_MJm2:
+      sample_data: 0.0
+      types_found: [float]
+    DH_ww_ghg_kgm2:
+      sample_data: 0.0
+      types_found: [float]
+    DH_ww_ghg_ton:
+      sample_data: 0.0
+      types_found: [float]
+    DH_ww_nre_pen_GJ:
+      sample_data: 0.0
+      types_found: [float]
+    DH_ww_nre_pen_MJm2:
+      sample_data: 0.0
+      types_found: [float]
+    GFA_m2:
+      sample_data: 4997.25
+      types_found: [float]
+    GFA_m2.1:
+      sample_data: 4997.25
+      types_found: [float]
+    GRID_ghg_kgm2:
+      sample_data: 2.72
+      types_found: [float]
+    GRID_ghg_ton:
+      sample_data: 13.59
+      types_found: [float]
+    GRID_nre_pen_GJ:
+      sample_data: 1208.87
+      types_found: [float]
+    GRID_nre_pen_MJm2:
+      sample_data: 241.91
+      types_found: [float]
+    NG_hs_ghg_kgm2:
+      sample_data: 8.49
+      types_found: [float]
+    NG_hs_ghg_ton:
+      sample_data: 42.44
+      types_found: [float]
+    NG_hs_nre_pen_GJ:
+      sample_data: 710.31
+      types_found: [float]
+    NG_hs_nre_pen_MJm2:
+      sample_data: 142.14
+      types_found: [float]
+    NG_ww_ghg_kgm2:
+      sample_data: 0.87
+      types_found: [float]
+    NG_ww_ghg_ton:
+      sample_data: 4.33
+      types_found: [float]
+    NG_ww_nre_pen_GJ:
+      sample_data: 72.46
+      types_found: [float]
+    NG_ww_nre_pen_MJm2:
+      sample_data: 14.5
+      types_found: [float]
+    Name:
+      sample_data: B09
+      types_found: [string]
+    Name.1:
+      sample_data: B09
+      types_found: [string]
+    OIL_hs_ghg_kgm2:
+      sample_data: 0.0
+      types_found: [float]
+    OIL_hs_ghg_ton:
+      sample_data: 0.0
+      types_found: [float]
+    OIL_hs_nre_pen_GJ:
+      sample_data: 0.0
+      types_found: [float]
+    OIL_hs_nre_pen_MJm2:
+      sample_data: 0.0
+      types_found: [float]
+    OIL_ww_ghg_kgm2:
+      sample_data: 0.0
+      types_found: [float]
+    OIL_ww_ghg_ton:
+      sample_data: 0.0
+      types_found: [float]
+    OIL_ww_nre_pen_GJ:
+      sample_data: 0.0
+      types_found: [float]
+    OIL_ww_nre_pen_MJm2:
+      sample_data: 0.0
+      types_found: [float]
+    O_ghg_kgm2:
+      sample_data: 12.08
+      types_found: [float]
+    O_ghg_ton:
+      sample_data: 60.36
+      types_found: [float]
+    O_nre_pen_GJ:
+      sample_data: 3983.29
+      types_found: [float]
+    O_nre_pen_MJm2:
+      sample_data: 398.55
+      types_found: [float]
+    PV_ghg_kgm2:
+      sample_data: 0.0
+      types_found: [float]
+    PV_ghg_kgm2.1:
+      sample_data: 0.0
+      types_found: [float]
+    PV_ghg_ton:
+      sample_data: 0.0
+      types_found: [float]
+    PV_ghg_ton.1:
+      sample_data: 0.0
+      types_found: [float]
+    PV_nre_pen_GJ:
+      sample_data: 0.0
+      types_found: [float]
+    PV_nre_pen_GJ.1:
+      sample_data: 0.0
+      types_found: [float]
+    PV_nre_pen_MJm2:
+      sample_data: 0.0
+      types_found: [float]
+    PV_nre_pen_MJm2.1:
+      sample_data: 0.0
+      types_found: [float]
+    SOLAR_hs_ghg_kgm2:
+      sample_data: 0.0
+      types_found: [float]
+    SOLAR_hs_ghg_ton:
+      sample_data: 0.0
+      types_found: [float]
+    SOLAR_hs_nre_pen_GJ:
+      sample_data: 0.0
+      types_found: [float]
+    SOLAR_hs_nre_pen_MJm2:
+      sample_data: 0.0
+      types_found: [float]
+    SOLAR_ww_ghg_kgm2:
+      sample_data: 0.0
+      types_found: [float]
+    SOLAR_ww_ghg_ton:
+      sample_data: 0.0
+      types_found: [float]
+    SOLAR_ww_nre_pen_GJ:
+      sample_data: 0.0
+      types_found: [float]
+    SOLAR_ww_nre_pen_MJm2:
+      sample_data: 0.0
+      types_found: [float]
+    WOOD_hs_ghg_kgm2:
+      sample_data: 0.0
+      types_found: [float]
+    WOOD_hs_ghg_ton:
+      sample_data: 0.0
+      types_found: [float]
+    WOOD_hs_nre_pen_GJ:
+      sample_data: 0.0
+      types_found: [float]
+    WOOD_hs_nre_pen_MJm2:
+      sample_data: 0.0
+      types_found: [float]
+    WOOD_ww_ghg_kgm2:
+      sample_data: 0.0
+      types_found: [float]
+    WOOD_ww_ghg_ton:
+      sample_data: 0.0
+      types_found: [float]
+    WOOD_ww_nre_pen_GJ:
+      sample_data: 0.0
+      types_found: [float]
+    WOOD_ww_nre_pen_MJm2:
+      sample_data: 0.0
+      types_found: [float]
+  used_by: []
+get_multi_criteria_analysis:
+  created_by: [multi_criteria_analysis]
+  file_path: outputs/data/multicriteria/gen_2_multi_criteria_analysis.csv
+  file_type: csv
+  schema:
+    Capex_a_sys_USD:
+      sample_data: 2956564.1210000007
+      types_found: [float]
+    Capex_a_sys_connected_USD:
+      sample_data: 2916287.4060000004
+      types_found: [float]
+    Capex_a_sys_disconnected_USD:
+      sample_data: 40276.715
+      types_found: [float]
+    Capex_total_sys_USD:
+      sample_data: 37939467.308
+      types_found: [float]
+    Capex_total_sys_connected_USD:
+      sample_data: 37393157.386999995
+      types_found: [float]
+    Capex_total_sys_disconnected_USD:
+      sample_data: 546309.921
+      types_found: [float]
+    GHG_rank:
+      sample_data: 1.0
+      types_found: [float]
+    GHG_sys_connected_tonCO2:
+      sample_data: 898.086
+      types_found: [float]
+    GHG_sys_disconnected_tonCO2:
+      sample_data: 51.856
+      types_found: [float]
+    GHG_sys_tonCO2:
+      sample_data: 949.943
+      types_found: [float]
+    Opex_a_sys_USD:
+      sample_data: 2503918.819
+      types_found: [float]
+    Opex_a_sys_connected_USD:
+      sample_data: 2451130.6580000003
+      types_found: [float]
+    Opex_a_sys_disconnected_USD:
+      sample_data: 52788.16099999999
+      types_found: [float]
+    PEN_rank:
+      sample_data: 1.0
+      types_found: [float]
+    PEN_sys_MJoil:
+      sample_data: 7766635.2760000015
+      types_found: [float]
+    PEN_sys_connected_MJoil:
+      sample_data: 7034450.618
+      types_found: [float]
+    PEN_sys_disconnected_MJoil:
+      sample_data: 732184.657
+      types_found: [float]
+    TAC_rank:
+      sample_data: 3.0
+      types_found: [float]
+    TAC_sys_USD:
+      sample_data: 5460482.94
+      types_found: [float]
+    TAC_sys_connected_USD:
+      sample_data: 5367418.063
+      types_found: [float]
+    TAC_sys_disconnected_USD:
+      sample_data: 93064.877
       types_found: [float]
     'Unnamed: 0':
-      sample_value: !!python/long '8759'
+      sample_data: !!python/long '2'
       types_found: [long]
+    'Unnamed: 0.1':
+      sample_data: !!python/long '2'
+      types_found: [long]
+    generation:
+      sample_data: !!python/long '2'
+      types_found: [long]
+    individual:
+      sample_data: !!python/long '1'
+      types_found: [long]
+    individual_name:
+      sample_data: Sys 2-1
+      types_found: [string]
+    normalized_Capex_total:
+      sample_data: 1.0
+      types_found: [float]
+    normalized_Opex:
+      sample_data: 1.0
+      types_found: [float]
+    normalized_TAC:
+      sample_data: 1.0
+      types_found: [float]
+    normalized_emissions:
+      sample_data: 0.0
+      types_found: [float]
+    normalized_prim:
+      sample_data: 0.0
+      types_found: [float]
+    user_MCDA:
+      sample_data: 0.8000000000000002
+      types_found: [float]
+    user_MCDA_rank:
+      sample_data: 3.0
+      types_found: [float]
   used_by: []
-get_thermal_network_layout_pressure_drop_kw_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/thermal-network/dc__p_deltap_kw.csv
+get_network_energy_pumping_requirements_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__plant_pumping_load_kW.csv
   file_type: csv
   schema:
     pressure_loss_return_kW:
-      sample_value: NODE25
+      sample_data: 0.014075529
       types_found: [float]
     pressure_loss_substations_kW:
-      sample_value: 223.0
+      sample_data: 0.019847016999999998
       types_found: [float]
     pressure_loss_supply_kW:
-      sample_value: NONE
+      sample_data: 0.014075529
       types_found: [float]
     pressure_loss_total_kW:
-      sample_value: 46.0
+      sample_data: 0.047998074
       types_found: [float]
   used_by: []
-get_thermal_network_qloss_system_file:
-  created_by: [thermal-network]
-  file_path: outputs/data/thermal-network/dc__p_deltap_kw.csv
+get_network_layout_edges_shapefile:
+  created_by: [network_layout]
+  file_path: outputs/data/thermal-network/DH/edges.shp
+  file_type: shp
+  schema:
+    Name:
+      sample_data: PIPE29
+      types_found: [string]
+    Pipe_DN:
+      sample_data: 125.0
+      types_found: [float]
+    Type_mat:
+      sample_data: T1
+      types_found: [string]
+    geometry:
+      sample_data: ((x1 y1, x2 y2, ...))
+      types_found: [LineString]
+    length_m:
+      sample_data: 1.414213562373095
+      types_found: [float]
+  used_by: [thermal_network]
+get_network_layout_nodes_shapefile:
+  created_by: [network_layout]
+  file_path: outputs/data/thermal-network/DH/nodes.shp
+  file_type: shp
+  schema:
+    Building:
+      sample_data: NONE
+      types_found: [string]
+    Name:
+      sample_data: NODE30
+      types_found: [string]
+    Type:
+      sample_data: PLANT
+      types_found: [string]
+    geometry:
+      sample_data: ((x1 y1, x2 y2, ...))
+      types_found: [Point]
+  used_by: [thermal_network]
+get_network_linear_pressure_drop_edges:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__linear_pressure_drop_edges_Paperm.csv
   file_type: csv
   schema:
     PIPE0:
-      sample_value: 0.0
-      types_found: [float]
-    PIPE1:
-      sample_value: 0.0
-      types_found: [float]
-    PIPEN:
-      sample_value: 0.0
+      sample_data: 0.0
       types_found: [float]
   used_by: []
-get_thermal_networks:
-  created_by: []
-  file_path: databases/ch/systems/thermal_networks.xls
-  file_type: xls
+get_network_linear_thermal_loss_edges_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__linear_thermal_loss_edges_Wperm.csv
+  file_type: csv
   schema:
-    !!python/unicode 'MATERIAL PROPERTIES':
-      !!python/unicode 'Cp_JkgK':
-        sample_value: !!python/long '550'
-        types_found: [long]
-      !!python/unicode 'code':
-        sample_value: !!python/unicode 'T5'
-        types_found: [str]
-      !!python/unicode 'lambda_WmK':
-        sample_value: 0.38
-        types_found: [float]
-      !!python/unicode 'material':
-        sample_value: !!python/unicode 'PEX'
-        types_found: [str]
-      !!python/unicode 'rho_kgm3':
-        sample_value: !!python/long '938'
-        types_found: [long]
-    !!python/unicode 'PIPING CATALOG':
-      !!python/unicode 'D_ext_m':
-        sample_value: 1.52869695
-        types_found: [float]
-      !!python/unicode 'D_ins_m':
-        sample_value: 1.9947486772999998
-        types_found: [float]
-      !!python/unicode 'D_int_m':
-        sample_value: 1.4941228500000001
-        types_found: [float]
-      !!python/unicode 'Pipe_DN':
-        sample_value: !!python/long '1500'
-        types_found: [long]
-      !!python/unicode 'Vdot_max_m3s':
-        sample_value: 10.76274617420937
-        types_found: [float]
-      !!python/unicode 'Vdot_min_m3s':
-        sample_value: 0.5169956864157574
-        types_found: [float]
-  used_by: [thermal-network]
-get_total_demand:
-  created_by: [demand]
-  description: scenario/outputs/data/demand/Total_demand.csv
-  file_path: outputs/data/demand/total_demand.csv
+    PIPE0:
+      sample_data: 0.006079035138739127
+      types_found: [float]
+  used_by: []
+get_network_pressure_at_nodes:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__pressure_at_nodes_Pa.csv
+  file_type: csv
+  schema:
+    NODE0:
+      sample_data: 12883.1
+      types_found: [float]
+  used_by: []
+get_network_temperature_plant:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__temperature_plant_K.csv
+  file_type: csv
+  schema:
+    temperature_return_K:
+      sample_data: 308.1585
+      types_found: [float]
+    temperature_supply_K:
+      sample_data: 338.0
+      types_found: [float]
+  used_by: []
+get_network_temperature_return_nodes_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__temperature_return_nodes_K.csv
+  file_type: csv
+  schema:
+    NODE0:
+      sample_data: 308.1585
+      types_found: [float]
+  used_by: []
+get_network_temperature_supply_nodes_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__temperature_supply_nodes_K.csv
+  file_type: csv
+  schema:
+    NODE0:
+      sample_data: 338.0
+      types_found: [float]
+  used_by: []
+get_network_thermal_loss_edges_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__thermal_loss_edges_kW.csv
+  file_type: csv
+  schema:
+    PIPE0:
+      sample_data: 0.0002490277080987028
+      types_found: [float]
+  used_by: []
+get_network_total_pressure_drop_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__plant_pumping_pressure_loss_Pa.csv
+  file_type: csv
+  schema:
+    pressure_loss_return_Pa:
+      sample_data: 19477.127
+      types_found: [float]
+    pressure_loss_substations_Pa:
+      sample_data: 109983.14
+      types_found: [float]
+    pressure_loss_supply_Pa:
+      sample_data: 19477.127
+      types_found: [float]
+    pressure_loss_total_Pa:
+      sample_data: 148937.39
+      types_found: [float]
+  used_by: [optimization]
+get_network_total_thermal_loss_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__total_thermal_loss_edges_kW.csv
+  file_type: csv
+  schema:
+    thermal_loss_return_kW:
+      sample_data: 10.3455099323602
+      types_found: [float]
+    thermal_loss_supply_kW:
+      sample_data: 22.693202954505182
+      types_found: [float]
+    thermal_loss_total_kW:
+      sample_data: 33.038712886865376
+      types_found: [float]
+  used_by: [optimization]
+get_optimization_checkpoint:
+  created_by: [optimization, optimization]
+  file_path: outputs/data/optimization/master/CheckPoint_1
+  file_type: ''
+  schema: null
+  used_by: []
+get_optimization_connected_cooling_capacity:
+  created_by: [optimization, optimization, optimization, optimization, optimization,
+    optimization, optimization, optimization, optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_1/ind_1_connected_cooling_capacity.csv
+  file_type: csv
+  schema: null
+  used_by: []
+get_optimization_connected_electricity_capacity:
+  created_by: [optimization, optimization, optimization, optimization, optimization,
+    optimization, optimization, optimization, optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_2/ind_0_connected_electrical_capacity.csv
+  file_type: csv
+  schema:
+    Capacity_GRID_el_connected_W:
+      sample_data: 1554364.852
+      types_found: [float]
+    Capacity_PV_el_connected_W:
+      sample_data: 530232.192
+      types_found: [float]
+    Capacity_PV_el_connected_m2:
+      sample_data: 3313.9509999999996
+      types_found: [float]
+  used_by: []
+get_optimization_connected_heating_capacity:
+  created_by: [optimization, optimization, optimization, optimization, optimization,
+    optimization, optimization, optimization, optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_0/ind_2_connected_heating_capacity.csv
+  file_type: csv
+  schema:
+    Capacity_BackupBoiler_NG_heat_connected_W:
+      sample_data: 0.0
+      types_found: [float]
+    Capacity_BaseBoiler_NG_heat_connected_W:
+      sample_data: 1564801.063
+      types_found: [float]
+    Capacity_CHP_DB_el_connected_W:
+      sample_data: 0.0
+      types_found: [float]
+    Capacity_CHP_DB_heat_connected_W:
+      sample_data: 1036426.678
+      types_found: [float]
+    Capacity_CHP_NG_el_connected_W:
+      sample_data: 1521885.99
+      types_found: [float]
+    Capacity_CHP_NG_heat_connected_W:
+      sample_data: 1077070.862
+      types_found: [float]
+    Capacity_CHP_WB_el_connected_W:
+      sample_data: 0.0
+      types_found: [float]
+    Capacity_CHP_WB_heat_connected_W:
+      sample_data: 1544478.971
+      types_found: [float]
+    Capacity_HP_DS_heat_connected_W:
+      sample_data: 213957.0
+      types_found: [float]
+    Capacity_HP_GS_heat_connected_W:
+      sample_data: 1199003.412
+      types_found: [float]
+    Capacity_HP_SS_heat_connected_W:
+      sample_data: 589340.66
+      types_found: [float]
+    Capacity_HP_WS_heat_connected_W:
+      sample_data: 1239647.595
+      types_found: [float]
+    Capacity_PVT_connected_m2:
+      sample_data: 2301.272
+      types_found: [float]
+    Capacity_PVT_el_connected_W:
+      sample_data: 368203.584
+      types_found: [float]
+    Capacity_PVT_heat_connected_W:
+      sample_data: 1783486.11
+      types_found: [float]
+    Capacity_PeakBoiler_NG_heat_connected_W:
+      sample_data: 1463190.604
+      types_found: [float]
+    Capacity_SC_ET_connected_m2:
+      sample_data: 1315.013
+      types_found: [float]
+    Capacity_SC_ET_heat_connected_W:
+      sample_data: 948124.229
+      types_found: [float]
+    Capacity_SC_FP_connected_m2:
+      sample_data: 986.26
+      types_found: [float]
+    Capacity_SC_FP_heat_connected_W:
+      sample_data: 764351.19
+      types_found: [float]
+    Capacity_SeasonalStorage_WS_heat_connected_W:
+      sample_data: 113019104.381
+      types_found: [float]
+    Capacity_SeasonalStorage_WS_heat_connected_m3:
+      sample_data: 1236.0330000000001
+      types_found: [float]
+  used_by: []
+get_optimization_decentralized_folder_building_result_heating:
+  created_by: [decentralized]
+  file_path: outputs/data/optimization/decentralized/DiscOp_B001_result_heating.csv
+  file_type: csv
+  schema:
+    Best configuration:
+      sample_data: 1.0
+      types_found: [float]
+    Capacity_BaseBoiler_NG_W:
+      sample_data: 219988.82048399988
+      types_found: [float]
+    Capacity_FC_NG_W:
+      sample_data: 0.0
+      types_found: [float]
+    Capacity_GS_HP_W:
+      sample_data: 24443.202275999975
+      types_found: [float]
+    Capex_a_USD:
+      sample_data: 13969.337377773993
+      types_found: [float]
+    Capex_total_USD:
+      sample_data: 185191.50000253852
+      types_found: [float]
+    GHG_tonCO2:
+      sample_data: 18.844640882380308
+      types_found: [float]
+    Nominal heating load:
+      sample_data: 244432.02275999985
+      types_found: [float]
+    Opex_fixed_USD:
+      sample_data: 6885.5266171086205
+      types_found: [float]
+    Opex_var_USD:
+      sample_data: 9351.248183046371
+      types_found: [float]
+    PEN_MJoil:
+      sample_data: 294884.00752198393
+      types_found: [float]
+    TAC_USD:
+      sample_data: 30206.112177928986
+      types_found: [float]
+    'Unnamed: 0':
+      sample_data: !!python/long '12'
+      types_found: [long]
+  used_by: [optimization]
+get_optimization_decentralized_folder_building_result_heating_activation:
+  created_by: [decentralized]
+  file_path: outputs/data/optimization/decentralized/DiscOp_B001_result_heating_activation.csv
+  file_type: csv
+  schema:
+    BackupBoiler_Status:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    Boiler_Status:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    E_hs_ww_req_W:
+      sample_data: -0.0
+      types_found: [float]
+    GHP_Status:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    NG_BackupBoiler_req_Wh:
+      sample_data: 0.0
+      types_found: [float]
+    NG_Boiler_req_Wh:
+      sample_data: 0.0
+      types_found: [float]
+    Q_BackupBoiler_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_Boiler_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_GHP_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    'Unnamed: 0':
+      sample_data: !!python/long '8759'
+      types_found: [long]
+  used_by: [optimization]
+get_optimization_disconnected_cooling_capacity:
+  created_by: [optimization, optimization, optimization, optimization, optimization,
+    optimization, optimization, optimization, optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_1/ind_0_disconnected_cooling_capacity.csv
+  file_type: csv
+  schema: null
+  used_by: []
+get_optimization_disconnected_heating_capacity:
+  created_by: [optimization, optimization, optimization, optimization, optimization,
+    optimization, optimization, optimization, optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_0/ind_1_disconnected_heating_capacity.csv
+  file_type: csv
+  schema:
+    Capacity_BaseBoiler_NG_heat_disconnected_W:
+      sample_data: 358691.328
+      types_found: [float]
+    Capacity_FC_NG_heat_disconnected_W:
+      sample_data: 0.0
+      types_found: [float]
+    Capacity_GS_HP_heat_disconnected_W:
+      sample_data: 39854.592000000004
+      types_found: [float]
+    Name:
+      sample_data: B07
+      types_found: [string]
+  used_by: []
+get_optimization_generation_connected_performance:
+  created_by: [optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_1/gen_1_connected_performance.csv
+  file_type: csv
+  schema:
+    Capex_a_BackupBoiler_NG_connected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Capex_a_BaseBoiler_NG_connected_USD:
+      sample_data: 34634.982
+      types_found: [float]
+    Capex_a_CHP_NG_connected_USD:
+      sample_data: 177961.829
+      types_found: [float]
+    Capex_a_DHN_connected_USD:
+      sample_data: 47939.993
+      types_found: [float]
+    Capex_a_Furnace_dry_connected_USD:
+      sample_data: 59620.242
+      types_found: [float]
+    Capex_a_Furnace_wet_connected_USD:
+      sample_data: 59620.242
+      types_found: [float]
+    Capex_a_GHP_connected_USD:
+      sample_data: 74831.147
+      types_found: [float]
+    Capex_a_GRID_connected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Capex_a_HP_Lake_connected_USD:
+      sample_data: 180020.139
+      types_found: [float]
+    Capex_a_HP_Server_connected_USD:
+      sample_data: 179924.147
+      types_found: [float]
+    Capex_a_HP_Sewage_connected_USD:
+      sample_data: 179924.147
+      types_found: [float]
+    Capex_a_PVT_connected_USD:
+      sample_data: 191544.276
+      types_found: [float]
+    Capex_a_PV_connected_USD:
+      sample_data: 28230.55
+      types_found: [float]
+    Capex_a_PeakBoiler_NG_connected_USD:
+      sample_data: 7666.626999999998
+      types_found: [float]
+    Capex_a_SC_ET_connected_USD:
+      sample_data: 303085.069
+      types_found: [float]
+    Capex_a_SC_FP_connected_USD:
+      sample_data: 496890.002
+      types_found: [float]
+    Capex_a_SeasonalStorage_WS_connected_USD:
+      sample_data: 214288.928
+      types_found: [float]
+    Capex_a_SubstationsHeating_connected_USD:
+      sample_data: 7045.726
+      types_found: [float]
+    Capex_total_BackupBoiler_NG_connected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Capex_total_BaseBoiler_NG_connected_USD:
+      sample_data: 431628.437
+      types_found: [float]
+    Capex_total_CHP_NG_connected_USD:
+      sample_data: 2257646.663
+      types_found: [float]
+    Capex_total_DHN_connected_USD:
+      sample_data: 597730.201
+      types_found: [float]
+    Capex_total_Furnace_dry_connected_USD:
+      sample_data: 743000.0
+      types_found: [float]
+    Capex_total_Furnace_wet_connected_USD:
+      sample_data: 743000.0
+      types_found: [float]
+    Capex_total_GHP_connected_USD:
+      sample_data: 1293315.686
+      types_found: [float]
+    Capex_total_GRID_connected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Capex_total_HP_Lake_connected_USD:
+      sample_data: 2301261.546
+      types_found: [float]
+    Capex_total_HP_Server_connected_USD:
+      sample_data: 2300034.45
+      types_found: [float]
+    Capex_total_HP_Sewage_connected_USD:
+      sample_data: 2300034.45
+      types_found: [float]
+    Capex_total_PVT_connected_USD:
+      sample_data: 2444846.939
+      types_found: [float]
+    Capex_total_PV_connected_USD:
+      sample_data: 351815.052
+      types_found: [float]
+    Capex_total_PeakBoiler_NG_connected_USD:
+      sample_data: 95543.119
+      types_found: [float]
+    Capex_total_SC_ET_connected_USD:
+      sample_data: 3834891.764
+      types_found: [float]
+    Capex_total_SC_FP_connected_USD:
+      sample_data: 6250129.607000002
+      types_found: [float]
+    Capex_total_SeasonalStorage_WS_connected_USD:
+      sample_data: 2739331.684
+      types_found: [float]
+    Capex_total_SubstationsHeating_connected_USD:
+      sample_data: 87805.32199999999
+      types_found: [float]
+    GHG_DB_connected_tonCO2yr:
+      sample_data: 0.028
+      types_found: [float]
+    GHG_GRID_exports_connected_tonCO2yr:
+      sample_data: -0.547
+      types_found: [float]
+    GHG_GRID_imports_connected_tonCO2yr:
+      sample_data: 460.405
+      types_found: [float]
+    GHG_NG_connected_tonCO2yr:
+      sample_data: 1073.456
+      types_found: [float]
+    GHG_WB_connected_tonCO2yr:
+      sample_data: 0.0
+      types_found: [float]
+    Opex_fixed_BackupBoiler_NG_connected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Opex_fixed_BaseBoiler_NG_connected_USD:
+      sample_data: 21581.422
+      types_found: [float]
+    Opex_fixed_CHP_NG_connected_USD:
+      sample_data: 67729.4
+      types_found: [float]
+    Opex_fixed_DHN_connected_USD:
+      sample_data: 58727.21599999999
+      types_found: [float]
+    Opex_fixed_Furnace_dry_connected_USD:
+      sample_data: 37150.0
+      types_found: [float]
+    Opex_fixed_Furnace_wet_connected_USD:
+      sample_data: 37150.0
+      types_found: [float]
+    Opex_fixed_GHP_connected_USD:
+      sample_data: 1565.8370000000002
+      types_found: [float]
+    Opex_fixed_GRID_connected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Opex_fixed_HP_Lake_connected_USD:
+      sample_data: 115013.993
+      types_found: [float]
+    Opex_fixed_HP_Server_connected_USD:
+      sample_data: 115001.723
+      types_found: [float]
+    Opex_fixed_HP_Sewage_connected_USD:
+      sample_data: 115001.723
+      types_found: [float]
+    Opex_fixed_PVT_connected_USD:
+      sample_data: 1035.257
+      types_found: [float]
+    Opex_fixed_PV_connected_USD:
+      sample_data: 3518.151
+      types_found: [float]
+    Opex_fixed_PeakBoiler_NG_connected_USD:
+      sample_data: 4777.156
+      types_found: [float]
+    Opex_fixed_SC_ET_connected_USD:
+      sample_data: 72953.235
+      types_found: [float]
+    Opex_fixed_SC_FP_connected_USD:
+      sample_data: 195647.312
+      types_found: [float]
+    Opex_fixed_SeasonalStorage_WS_connected_USD:
+      sample_data: 119394.695
+      types_found: [float]
+    Opex_fixed_SubstationsHeating_connected_USD:
+      sample_data: 4390.266
+      types_found: [float]
+    Opex_var_DB_connected_USD:
+      sample_data: 213.74400000000003
+      types_found: [float]
+    Opex_var_GRID_exports_connected_USD:
+      sample_data: -1179.652
+      types_found: [float]
+    Opex_var_GRID_imports_connected_USD:
+      sample_data: 993029.533
+      types_found: [float]
+    Opex_var_NG_connected_USD:
+      sample_data: 400191.933
+      types_found: [float]
+    Opex_var_WB_connected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    PEN_DB_connected_MJoilyr:
+      sample_data: 429.133
+      types_found: [float]
+    PEN_GRID_exports_connected_MJoilyr:
+      sample_data: -546.93
+      types_found: [float]
+    PEN_GRID_imports_connected_MJoilyr:
+      sample_data: 460404.601
+      types_found: [float]
+    PEN_NG_connected_MJoilyr:
+      sample_data: 17966263.708
+      types_found: [float]
+    PEN_WB_connected_MJoilyr:
+      sample_data: 0.0
+      types_found: [float]
+    'Unnamed: 0':
+      sample_data: !!python/long '2'
+      types_found: [long]
+    generation:
+      sample_data: !!python/long '1'
+      types_found: [long]
+    individual:
+      sample_data: !!python/long '2'
+      types_found: [long]
+    individual_name:
+      sample_data: Sys 1-2
+      types_found: [string]
+  used_by: []
+get_optimization_generation_disconnected_performance:
+  created_by: [optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_2/gen_2_disconnected_performance.csv
+  file_type: csv
+  schema:
+    Capex_a_cooling_disconnected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Capex_a_heating_disconnected_USD:
+      sample_data: 40276.715
+      types_found: [float]
+    Capex_total_cooling_disconnected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Capex_total_heating_disconnected_USD:
+      sample_data: 546309.921
+      types_found: [float]
+    GHG_cooling_disconnected_tonCO2:
+      sample_data: 0.0
+      types_found: [float]
+    GHG_heating_disconnected_tonCO2:
+      sample_data: 51.856
+      types_found: [float]
+    Opex_fixed_cooling_disconnected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Opex_fixed_heating_disconnected_USD:
+      sample_data: 18068.548
+      types_found: [float]
+    Opex_var_cooling_disconnected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Opex_var_heating_disconnected_USD:
+      sample_data: 34719.614
+      types_found: [float]
+    PEN_cooling_disconnected_MJoil:
+      sample_data: 0.0
+      types_found: [float]
+    PEN_heating_disconnected_MJoil:
+      sample_data: 732184.657
+      types_found: [float]
+    'Unnamed: 0':
+      sample_data: !!python/long '1'
+      types_found: [long]
+    generation:
+      sample_data: !!python/long '2'
+      types_found: [long]
+    individual:
+      sample_data: !!python/long '1'
+      types_found: [long]
+    individual_name:
+      sample_data: Sys 2-1
+      types_found: [string]
+  used_by: []
+get_optimization_generation_total_performance:
+  created_by: [optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_2/gen_2_total_performance.csv
+  file_type: csv
+  schema:
+    Capex_a_sys_USD:
+      sample_data: 2956564.1210000007
+      types_found: [float]
+    Capex_a_sys_connected_USD:
+      sample_data: 2916287.4060000004
+      types_found: [float]
+    Capex_a_sys_disconnected_USD:
+      sample_data: 40276.715
+      types_found: [float]
+    Capex_total_sys_USD:
+      sample_data: 37939467.308
+      types_found: [float]
+    Capex_total_sys_connected_USD:
+      sample_data: 37393157.387
+      types_found: [float]
+    Capex_total_sys_disconnected_USD:
+      sample_data: 546309.921
+      types_found: [float]
+    GHG_sys_connected_tonCO2:
+      sample_data: 898.086
+      types_found: [float]
+    GHG_sys_disconnected_tonCO2:
+      sample_data: 51.856
+      types_found: [float]
+    GHG_sys_tonCO2:
+      sample_data: 949.943
+      types_found: [float]
+    Opex_a_sys_USD:
+      sample_data: 2503918.819
+      types_found: [float]
+    Opex_a_sys_connected_USD:
+      sample_data: 2451130.6580000003
+      types_found: [float]
+    Opex_a_sys_disconnected_USD:
+      sample_data: 52788.16099999999
+      types_found: [float]
+    PEN_sys_MJoil:
+      sample_data: 7766635.2760000015
+      types_found: [float]
+    PEN_sys_connected_MJoil:
+      sample_data: 7034450.618
+      types_found: [float]
+    PEN_sys_disconnected_MJoil:
+      sample_data: 732184.657
+      types_found: [float]
+    TAC_sys_USD:
+      sample_data: 5460482.94
+      types_found: [float]
+    TAC_sys_connected_USD:
+      sample_data: 5367418.063
+      types_found: [float]
+    TAC_sys_disconnected_USD:
+      sample_data: 93064.877
+      types_found: [float]
+    'Unnamed: 0':
+      sample_data: !!python/long '1'
+      types_found: [long]
+    generation:
+      sample_data: !!python/long '2'
+      types_found: [long]
+    individual:
+      sample_data: !!python/long '1'
+      types_found: [long]
+    individual_name:
+      sample_data: Sys 2-1
+      types_found: [string]
+  used_by: []
+get_optimization_generation_total_performance_halloffame:
+  created_by: [optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_1/gen_1_total_performance_halloffame.csv
+  file_type: csv
+  schema:
+    Capex_a_sys_USD:
+      sample_data: 2323391.831
+      types_found: [float]
+    Capex_a_sys_connected_USD:
+      sample_data: 2243228.046
+      types_found: [float]
+    Capex_a_sys_disconnected_USD:
+      sample_data: 80163.785
+      types_found: [float]
+    Capex_total_sys_USD:
+      sample_data: 29851093.005
+      types_found: [float]
+    Capex_total_sys_connected_USD:
+      sample_data: 28772014.923
+      types_found: [float]
+    Capex_total_sys_disconnected_USD:
+      sample_data: 1079078.082
+      types_found: [float]
+    GHG_sys_connected_tonCO2:
+      sample_data: 1533.341
+      types_found: [float]
+    GHG_sys_disconnected_tonCO2:
+      sample_data: 129.993
+      types_found: [float]
+    GHG_sys_tonCO2:
+      sample_data: 1663.3339999999996
+      types_found: [float]
+    Opex_a_sys_USD:
+      sample_data: 2473676.228
+      types_found: [float]
+    Opex_a_sys_connected_USD:
+      sample_data: 2362892.941
+      types_found: [float]
+    Opex_a_sys_disconnected_USD:
+      sample_data: 110783.287
+      types_found: [float]
+    PEN_sys_MJoil:
+      sample_data: 20382200.772
+      types_found: [float]
+    PEN_sys_connected_MJoil:
+      sample_data: 18426550.512
+      types_found: [float]
+    PEN_sys_disconnected_MJoil:
+      sample_data: 1955650.26
+      types_found: [float]
+    TAC_sys_USD:
+      sample_data: 4797068.0589999985
+      types_found: [float]
+    TAC_sys_connected_USD:
+      sample_data: 4606120.9860000005
+      types_found: [float]
+    TAC_sys_disconnected_USD:
+      sample_data: 190947.072
+      types_found: [float]
+    'Unnamed: 0':
+      sample_data: !!python/long '4'
+      types_found: [long]
+    generation:
+      sample_data: !!python/long '1'
+      types_found: [long]
+    individual:
+      sample_data: !!python/long '2'
+      types_found: [long]
+    individual_name:
+      sample_data: Sys 1-2
+      types_found: [string]
+  used_by: []
+get_optimization_generation_total_performance_pareto:
+  created_by: [optimization]
+  file_path: outputs/data/optimization/slave/gen_2/gen_2_total_performance_pareto.csv
+  file_type: csv
+  schema:
+    Capex_a_sys_USD:
+      sample_data: 2956564.1210000007
+      types_found: [float]
+    Capex_a_sys_connected_USD:
+      sample_data: 2916287.4060000004
+      types_found: [float]
+    Capex_a_sys_disconnected_USD:
+      sample_data: 40276.715
+      types_found: [float]
+    Capex_total_sys_USD:
+      sample_data: 37939467.308
+      types_found: [float]
+    Capex_total_sys_connected_USD:
+      sample_data: 37393157.387
+      types_found: [float]
+    Capex_total_sys_disconnected_USD:
+      sample_data: 546309.921
+      types_found: [float]
+    GHG_sys_connected_tonCO2:
+      sample_data: 898.086
+      types_found: [float]
+    GHG_sys_disconnected_tonCO2:
+      sample_data: 51.856
+      types_found: [float]
+    GHG_sys_tonCO2:
+      sample_data: 949.943
+      types_found: [float]
+    Opex_a_sys_USD:
+      sample_data: 2503918.819
+      types_found: [float]
+    Opex_a_sys_connected_USD:
+      sample_data: 2451130.6580000003
+      types_found: [float]
+    Opex_a_sys_disconnected_USD:
+      sample_data: 52788.16099999999
+      types_found: [float]
+    PEN_sys_MJoil:
+      sample_data: 7766635.2760000015
+      types_found: [float]
+    PEN_sys_connected_MJoil:
+      sample_data: 7034450.618
+      types_found: [float]
+    PEN_sys_disconnected_MJoil:
+      sample_data: 732184.657
+      types_found: [float]
+    TAC_sys_USD:
+      sample_data: 5460482.94
+      types_found: [float]
+    TAC_sys_connected_USD:
+      sample_data: 5367418.063
+      types_found: [float]
+    TAC_sys_disconnected_USD:
+      sample_data: 93064.877
+      types_found: [float]
+    'Unnamed: 0':
+      sample_data: !!python/long '2'
+      types_found: [long]
+    generation:
+      sample_data: !!python/long '2'
+      types_found: [long]
+    individual:
+      sample_data: !!python/long '1'
+      types_found: [long]
+    individual_name:
+      sample_data: Sys 2-1
+      types_found: [string]
+  used_by: [multi_criteria_analysis]
+get_optimization_individuals_in_generation:
+  created_by: [optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_2/generation_2_individuals.csv
+  file_type: csv
+  schema:
+    B01_DH:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    B02_DH:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    B03_DH:
+      sample_data: !!python/long '1'
+      types_found: [long]
+    B04_DH:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    B05_DH:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    B06_DH:
+      sample_data: !!python/long '1'
+      types_found: [long]
+    B07_DH:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    B08_DH:
+      sample_data: !!python/long '1'
+      types_found: [long]
+    B09_DH:
+      sample_data: !!python/long '1'
+      types_found: [long]
+    DB_Cogen:
+      sample_data: 0.71
+      types_found: [float]
+    DS_HP:
+      sample_data: 0.95
+      types_found: [float]
+    GS_HP:
+      sample_data: 0.43
+      types_found: [float]
+    NG_BaseBoiler:
+      sample_data: 0.77
+      types_found: [float]
+    NG_Cogen:
+      sample_data: 0.8
+      types_found: [float]
+    NG_PeakBoiler:
+      sample_data: 0.72
+      types_found: [float]
+    PV:
+      sample_data: 0.47
+      types_found: [float]
+    PVT:
+      sample_data: 0.07
+      types_found: [float]
+    SC_ET:
+      sample_data: 0.0
+      types_found: [float]
+    SC_FP:
+      sample_data: 0.18
+      types_found: [float]
+    SS_HP:
+      sample_data: 0.73
+      types_found: [float]
+    'Unnamed: 0':
+      sample_data: !!python/long '1'
+      types_found: [long]
+    WB_Cogen:
+      sample_data: 0.76
+      types_found: [float]
+    WS_HP:
+      sample_data: 0.15
+      types_found: [float]
+    generation:
+      sample_data: !!python/long '2'
+      types_found: [long]
+    individual:
+      sample_data: !!python/long '1'
+      types_found: [long]
+  used_by: []
+get_optimization_network_results_summary:
+  created_by: [optimization]
+  file_path: outputs/data/optimization/network/DH_Network_summary_result_0x1be.csv
+  file_type: csv
+  schema:
+    DATE:
+      sample_data: '2005-12-31 23:00:00'
+      types_found: [date]
+    Q_DHNf_W:
+      sample_data: 135419.017
+      types_found: [float]
+    Q_DH_losses_W:
+      sample_data: 43548.017
+      types_found: [float]
+    Qcdata_netw_total_kWh:
+      sample_data: 213.451
+      types_found: [float]
+    T_DHNf_re_K:
+      sample_data: 311.008
+      types_found: [float]
+    T_DHNf_sup_K:
+      sample_data: 344.89099999999996
+      types_found: [float]
+    mcpdata_netw_total_kWperC:
+      sample_data: 26.680999999999997
+      types_found: [float]
+    mdot_DH_netw_total_kgpers:
+      sample_data: 0.955
+      types_found: [float]
+  used_by: [optimization, optimization, optimization, optimization, optimization,
+    optimization, optimization, optimization]
+get_optimization_slave_building_connectivity:
+  created_by: [optimization, optimization, optimization, optimization, optimization,
+    optimization, optimization, optimization, optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_2/ind_1_building_connectivity.csv
+  file_type: csv
+  schema:
+    DC_connectivity:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    DH_connectivity:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    Name:
+      sample_data: B09
+      types_found: [string]
+  used_by: []
+get_optimization_slave_connected_performance:
+  created_by: [optimization, optimization, optimization, optimization, optimization,
+    optimization, optimization, optimization, optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_1/ind_2_buildings_connected_performance.csv
+  file_type: csv
+  schema:
+    Capex_a_BackupBoiler_NG_connected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Capex_a_BaseBoiler_NG_connected_USD:
+      sample_data: 34634.982
+      types_found: [float]
+    Capex_a_CHP_NG_connected_USD:
+      sample_data: 177961.829
+      types_found: [float]
+    Capex_a_DHN_connected_USD:
+      sample_data: 47939.992999999995
+      types_found: [float]
+    Capex_a_Furnace_dry_connected_USD:
+      sample_data: 59620.242
+      types_found: [float]
+    Capex_a_Furnace_wet_connected_USD:
+      sample_data: 59620.242
+      types_found: [float]
+    Capex_a_GHP_connected_USD:
+      sample_data: 74831.147
+      types_found: [float]
+    Capex_a_GRID_connected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Capex_a_HP_Lake_connected_USD:
+      sample_data: 180020.139
+      types_found: [float]
+    Capex_a_HP_Server_connected_USD:
+      sample_data: 179924.147
+      types_found: [float]
+    Capex_a_HP_Sewage_connected_USD:
+      sample_data: 179924.147
+      types_found: [float]
+    Capex_a_PVT_connected_USD:
+      sample_data: 191544.276
+      types_found: [float]
+    Capex_a_PV_connected_USD:
+      sample_data: 28230.55
+      types_found: [float]
+    Capex_a_PeakBoiler_NG_connected_USD:
+      sample_data: 7666.6269999999995
+      types_found: [float]
+    Capex_a_SC_ET_connected_USD:
+      sample_data: 303085.06899999996
+      types_found: [float]
+    Capex_a_SC_FP_connected_USD:
+      sample_data: 496890.00200000004
+      types_found: [float]
+    Capex_a_SeasonalStorage_WS_connected_USD:
+      sample_data: 214288.928
+      types_found: [float]
+    Capex_a_SubstationsHeating_connected_USD:
+      sample_data: 7045.726
+      types_found: [float]
+    Capex_total_BackupBoiler_NG_connected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Capex_total_BaseBoiler_NG_connected_USD:
+      sample_data: 431628.43700000003
+      types_found: [float]
+    Capex_total_CHP_NG_connected_USD:
+      sample_data: 2257646.663
+      types_found: [float]
+    Capex_total_DHN_connected_USD:
+      sample_data: 597730.201
+      types_found: [float]
+    Capex_total_Furnace_dry_connected_USD:
+      sample_data: 743000.0
+      types_found: [float]
+    Capex_total_Furnace_wet_connected_USD:
+      sample_data: 743000.0
+      types_found: [float]
+    Capex_total_GHP_connected_USD:
+      sample_data: 1293315.686
+      types_found: [float]
+    Capex_total_GRID_connected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Capex_total_HP_Lake_connected_USD:
+      sample_data: 2301261.546
+      types_found: [float]
+    Capex_total_HP_Server_connected_USD:
+      sample_data: 2300034.45
+      types_found: [float]
+    Capex_total_HP_Sewage_connected_USD:
+      sample_data: 2300034.45
+      types_found: [float]
+    Capex_total_PVT_connected_USD:
+      sample_data: 2444846.9390000002
+      types_found: [float]
+    Capex_total_PV_connected_USD:
+      sample_data: 351815.052
+      types_found: [float]
+    Capex_total_PeakBoiler_NG_connected_USD:
+      sample_data: 95543.119
+      types_found: [float]
+    Capex_total_SC_ET_connected_USD:
+      sample_data: 3834891.764
+      types_found: [float]
+    Capex_total_SC_FP_connected_USD:
+      sample_data: 6250129.607000001
+      types_found: [float]
+    Capex_total_SeasonalStorage_WS_connected_USD:
+      sample_data: 2739331.684
+      types_found: [float]
+    Capex_total_SubstationsHeating_connected_USD:
+      sample_data: 87805.32199999999
+      types_found: [float]
+    GHG_DB_connected_tonCO2yr:
+      sample_data: 0.027999999999999997
+      types_found: [float]
+    GHG_GRID_exports_connected_tonCO2yr:
+      sample_data: -0.547
+      types_found: [float]
+    GHG_GRID_imports_connected_tonCO2yr:
+      sample_data: 460.405
+      types_found: [float]
+    GHG_NG_connected_tonCO2yr:
+      sample_data: 1073.4560000000001
+      types_found: [float]
+    GHG_WB_connected_tonCO2yr:
+      sample_data: 0.0
+      types_found: [float]
+    Opex_fixed_BackupBoiler_NG_connected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Opex_fixed_BaseBoiler_NG_connected_USD:
+      sample_data: 21581.422000000002
+      types_found: [float]
+    Opex_fixed_CHP_NG_connected_USD:
+      sample_data: 67729.4
+      types_found: [float]
+    Opex_fixed_DHN_connected_USD:
+      sample_data: 58727.21599999999
+      types_found: [float]
+    Opex_fixed_Furnace_dry_connected_USD:
+      sample_data: 37150.0
+      types_found: [float]
+    Opex_fixed_Furnace_wet_connected_USD:
+      sample_data: 37150.0
+      types_found: [float]
+    Opex_fixed_GHP_connected_USD:
+      sample_data: 1565.8370000000002
+      types_found: [float]
+    Opex_fixed_GRID_connected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Opex_fixed_HP_Lake_connected_USD:
+      sample_data: 115013.993
+      types_found: [float]
+    Opex_fixed_HP_Server_connected_USD:
+      sample_data: 115001.72300000001
+      types_found: [float]
+    Opex_fixed_HP_Sewage_connected_USD:
+      sample_data: 115001.72300000001
+      types_found: [float]
+    Opex_fixed_PVT_connected_USD:
+      sample_data: 1035.257
+      types_found: [float]
+    Opex_fixed_PV_connected_USD:
+      sample_data: 3518.151
+      types_found: [float]
+    Opex_fixed_PeakBoiler_NG_connected_USD:
+      sample_data: 4777.156
+      types_found: [float]
+    Opex_fixed_SC_ET_connected_USD:
+      sample_data: 72953.235
+      types_found: [float]
+    Opex_fixed_SC_FP_connected_USD:
+      sample_data: 195647.312
+      types_found: [float]
+    Opex_fixed_SeasonalStorage_WS_connected_USD:
+      sample_data: 119394.695
+      types_found: [float]
+    Opex_fixed_SubstationsHeating_connected_USD:
+      sample_data: 4390.266
+      types_found: [float]
+    Opex_var_DB_connected_USD:
+      sample_data: 213.74400000000003
+      types_found: [float]
+    Opex_var_GRID_exports_connected_USD:
+      sample_data: -1179.652
+      types_found: [float]
+    Opex_var_GRID_imports_connected_USD:
+      sample_data: 993029.5329999999
+      types_found: [float]
+    Opex_var_NG_connected_USD:
+      sample_data: 400191.93299999996
+      types_found: [float]
+    Opex_var_WB_connected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    PEN_DB_connected_MJoilyr:
+      sample_data: 429.13300000000004
+      types_found: [float]
+    PEN_GRID_exports_connected_MJoilyr:
+      sample_data: -546.93
+      types_found: [float]
+    PEN_GRID_imports_connected_MJoilyr:
+      sample_data: 460404.601
+      types_found: [float]
+    PEN_NG_connected_MJoilyr:
+      sample_data: 17966263.708
+      types_found: [float]
+    PEN_WB_connected_MJoilyr:
+      sample_data: 0.0
+      types_found: [float]
+  used_by: []
+get_optimization_slave_cooling_activation_pattern:
+  created_by: [optimization, optimization, optimization, optimization, optimization,
+    optimization, optimization, optimization, optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_1/ind_2_Cooling_Activation_Pattern.csv
+  file_type: csv
+  schema:
+    DATE:
+      sample_data: '2005-12-31 23:00:00'
+      types_found: [date]
+  used_by: []
+get_optimization_slave_disconnected_performance:
+  created_by: [optimization, optimization, optimization, optimization, optimization,
+    optimization, optimization, optimization, optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_2/ind_0_buildings_disconnected_performance.csv
+  file_type: csv
+  schema:
+    Capex_a_cooling_disconnected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Capex_a_heating_disconnected_USD:
+      sample_data: 84207.61300000001
+      types_found: [float]
+    Capex_total_cooling_disconnected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Capex_total_heating_disconnected_USD:
+      sample_data: 1123517.345
+      types_found: [float]
+    GHG_cooling_disconnected_tonCO2:
+      sample_data: 0.0
+      types_found: [float]
+    GHG_heating_disconnected_tonCO2:
+      sample_data: 194.65
+      types_found: [float]
+    Opex_fixed_cooling_disconnected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Opex_fixed_heating_disconnected_USD:
+      sample_data: 40725.691
+      types_found: [float]
+    Opex_var_cooling_disconnected_USD:
+      sample_data: 0.0
+      types_found: [float]
+    Opex_var_heating_disconnected_USD:
+      sample_data: 103095.933
+      types_found: [float]
+    PEN_cooling_disconnected_MJoil:
+      sample_data: 0.0
+      types_found: [float]
+    PEN_heating_disconnected_MJoil:
+      sample_data: 2988525.0310000004
+      types_found: [float]
+  used_by: []
+get_optimization_slave_electricity_activation_pattern:
+  created_by: [optimization, optimization, optimization, optimization, optimization,
+    optimization, optimization, optimization, optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_1/ind_1_Electricity_Activation_Pattern.csv
+  file_type: csv
+  schema:
+    DATE:
+      sample_data: '2005-12-31 23:00:00'
+      types_found: [date]
+    E_CHP_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_CHP_gen_export_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_Furnace_dry_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_Furnace_dry_gen_export_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_Furnace_wet_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_Furnace_wet_gen_export_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_GRID_directload_W:
+      sample_data: 601120.3570000001
+      types_found: [float]
+    E_PVT_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_PVT_gen_export_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_PV_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_PV_gen_export_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_Trigen_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_Trigen_gen_export_W:
+      sample_data: 0.0
+      types_found: [float]
+  used_by: []
+get_optimization_slave_electricity_requirements_data:
+  created_by: [optimization, optimization, optimization, optimization, optimization,
+    optimization, optimization, optimization, optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_1/ind_1_Electricity_Requirements_Pattern.csv
+  file_type: csv
+  schema:
+    DATE:
+      sample_data: '2005-12-31 23:00:00'
+      types_found: [date]
+    E_BackupBoiler_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_BackupVCC_AS_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_BaseBoiler_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_BaseVCC_AS_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_BaseVCC_WS_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_DCN_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_DHN_req_W:
+      sample_data: 21.72
+      types_found: [float]
+    E_GHP_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_HP_Lake_req_W:
+      sample_data: 19817.367
+      types_found: [float]
+    E_HP_PVT_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_HP_SC_ET_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_HP_SC_FP_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_HP_Server_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_HP_Sew_req_W:
+      sample_data: 47346.331
+      types_found: [float]
+    E_PeakBoiler_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_PeakVCC_AS_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_PeakVCC_WS_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_Storage_charging_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_Storage_discharging_req_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_cs_cre_cdata_req_connected_W:
+      sample_data: 95248.0
+      types_found: [float]
+    E_cs_cre_cdata_req_disconnected_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_electricalnetwork_sys_req_W:
+      sample_data: 601120.3570000001
+      types_found: [float]
+    E_hs_ww_req_connected_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_hs_ww_req_disconnected_W:
+      sample_data: 23007.938
+      types_found: [float]
+    Eal_req_W:
+      sample_data: 102750.0
+      types_found: [float]
+    Eaux_req_W:
+      sample_data: 73704.0
+      types_found: [float]
+    Edata_req_W:
+      sample_data: 237370.0
+      types_found: [float]
+    Epro_req_W:
+      sample_data: 1855.0
+      types_found: [float]
+  used_by: []
+get_optimization_slave_heating_activation_pattern:
+  created_by: [optimization, optimization, optimization, optimization, optimization,
+    optimization, optimization, optimization, optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_2/ind_0_Heating_Activation_Pattern.csv
+  file_type: csv
+  schema:
+    DATE:
+      sample_data: '2005-12-31 23:00:00'
+      types_found: [date]
+    E_CHP_gen_W:
+      sample_data: 116165.871
+      types_found: [float]
+    E_Furnace_dry_gen_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_Furnace_wet_gen_W:
+      sample_data: 0.0
+      types_found: [float]
+    E_PVT_gen_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_BackupBoiler_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_BaseBoiler_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_CHP_gen_directload_W:
+      sample_data: 127930.20599999999
+      types_found: [float]
+    Q_Furnace_dry_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_Furnace_wet_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_GHP_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_HP_Lake_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_HP_Server_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_HP_Server_storage_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_HP_Sew_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_PVT_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_PVT_gen_storage_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_PeakBoiler_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_SC_ET_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_SC_ET_gen_storage_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_SC_FP_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_SC_FP_gen_storage_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_Storage_gen_directload_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_districtheating_sys_req_W:
+      sample_data: 127930.20599999999
+      types_found: [float]
+  used_by: []
+get_optimization_slave_total_performance:
+  created_by: [optimization, optimization, optimization, optimization, optimization,
+    optimization, optimization, optimization, optimization, optimization]
+  file_path: outputs/data/optimization/slave/gen_0/ind_2_total_performance.csv
+  file_type: csv
+  schema:
+    Capex_a_sys_USD:
+      sample_data: 3377085.172
+      types_found: [float]
+    Capex_a_sys_connected_USD:
+      sample_data: 3350777.7939999998
+      types_found: [float]
+    Capex_a_sys_disconnected_USD:
+      sample_data: 26307.377999999997
+      types_found: [float]
+    Capex_total_sys_USD:
+      sample_data: 43311842.726
+      types_found: [float]
+    Capex_total_sys_connected_USD:
+      sample_data: 42950724.305
+      types_found: [float]
+    Capex_total_sys_disconnected_USD:
+      sample_data: 361118.42100000003
+      types_found: [float]
+    GHG_sys_connected_tonCO2:
+      sample_data: 932.6089999999999
+      types_found: [float]
+    GHG_sys_disconnected_tonCO2:
+      sample_data: 33.012
+      types_found: [float]
+    GHG_sys_tonCO2:
+      sample_data: 965.6210000000001
+      types_found: [float]
+    Opex_a_sys_USD:
+      sample_data: 2612465.273
+      types_found: [float]
+    Opex_a_sys_connected_USD:
+      sample_data: 2575913.886
+      types_found: [float]
+    Opex_a_sys_disconnected_USD:
+      sample_data: 36551.386
+      types_found: [float]
+    PEN_sys_MJoil:
+      sample_data: 8100757.728999999
+      types_found: [float]
+    PEN_sys_connected_MJoil:
+      sample_data: 7663457.079
+      types_found: [float]
+    PEN_sys_disconnected_MJoil:
+      sample_data: 437300.65
+      types_found: [float]
+    TAC_sys_USD:
+      sample_data: 5989550.445
+      types_found: [float]
+    TAC_sys_connected_USD:
+      sample_data: 5926691.68
+      types_found: [float]
+    TAC_sys_disconnected_USD:
+      sample_data: 62858.764
+      types_found: [float]
+  used_by: []
+get_optimization_substations_results_file:
+  created_by: [decentralized, optimization, thermal_network]
+  file_path: outputs/data/optimization/substations/110011011DH_B001_result.csv
+  file_type: csv
+  schema:
+    A_hex_dhw_design_m2:
+      sample_data: 2.016
+      types_found: [float]
+    A_hex_heating_design_m2:
+      sample_data: 22.897
+      types_found: [float]
+    Q_dhw_W:
+      sample_data: 0.0
+      types_found: [float]
+    Q_heating_W:
+      sample_data: 0.0
+      types_found: [float]
+    T_return_DH_result_K:
+      sample_data: 273.0
+      types_found: [float]
+    T_supply_DH_result_K:
+      sample_data: 338.0
+      types_found: [float]
+    mdot_DH_result_kgpers:
+      sample_data: 0.0
+      types_found: [float]
+  used_by: [optimization]
+get_optimization_substations_total_file:
+  created_by: [optimization, thermal_network]
+  file_path: outputs/data/optimization/substations/Total_DH_111111111.csv
   file_type: csv
   schema:
     Af_m2:
-      sample_data: 41088.084
+      sample_data: 1967.668
+      types_found: [float]
+    Aocc_m2:
+      sample_data: 2248.763
       types_found: [float]
     Aroof_m2:
-      sample_data: 4076.199
+      sample_data: 624.66
       types_found: [float]
     COAL_hs0_kW:
       sample_data: 0.0
@@ -4526,10 +5109,10 @@ get_total_demand:
       sample_data: 0.0
       types_found: [float]
     E_cs0_kW:
-      sample_data: 1577.5620000000001
+      sample_data: 21.636999999999997
       types_found: [float]
     E_cs_MWhyr:
-      sample_data: 4216.749
+      sample_data: 3.737
       types_found: [float]
     E_hs0_kW:
       sample_data: 0.0
@@ -4538,10 +5121,10 @@ get_total_demand:
       sample_data: 0.0
       types_found: [float]
     E_sys0_kW:
-      sample_data: 913.715
+      sample_data: 48.471000000000004
       types_found: [float]
     E_sys_MWhyr:
-      sample_data: 4664.590999999999
+      sample_data: 129.517
       types_found: [float]
     E_ww0_kW:
       sample_data: 0.0
@@ -4549,23 +5132,35 @@ get_total_demand:
     E_ww_MWhyr:
       sample_data: 0.0
       types_found: [float]
+    Ea0_kW:
+      sample_data: 14.464
+      types_found: [float]
+    Ea_MWhyr:
+      sample_data: 38.4
+      types_found: [float]
     Eal0_kW:
-      sample_data: 913.148
+      sample_data: 48.11600000000001
       types_found: [float]
     Eal_MWhyr:
-      sample_data: 4657.619000000001
+      sample_data: 128.80200000000002
       types_found: [float]
     Eaux0_kW:
-      sample_data: 3.907
+      sample_data: 0.355
       types_found: [float]
     Eaux_MWhyr:
-      sample_data: 6.972
+      sample_data: 0.715
       types_found: [float]
     Edata0_kW:
       sample_data: 0.0
       types_found: [float]
     Edata_MWhyr:
       sample_data: 0.0
+      types_found: [float]
+    El0_kW:
+      sample_data: 33.652
+      types_found: [float]
+    El_MWhyr:
+      sample_data: 90.40299999999999
       types_found: [float]
     Epro0_kW:
       sample_data: 0.0
@@ -4574,31 +5169,88 @@ get_total_demand:
       sample_data: 0.0
       types_found: [float]
     GFA_m2:
-      sample_data: 48914.385
+      sample_data: 4997.251
       types_found: [float]
     GRID0_kW:
-      sample_data: 2487.5820000000003
+      sample_data: 69.851
       types_found: [float]
     GRID_MWhyr:
-      sample_data: 8881.34
+      sample_data: 133.253
       types_found: [float]
-    Aocc_m2:
-      sample_data: 48914.385
+    GRID_a0_kW:
+      sample_data: 14.464
+      types_found: [float]
+    GRID_a_MWhyr:
+      sample_data: 38.4
+      types_found: [float]
+    GRID_aux0_kW:
+      sample_data: 0.355
+      types_found: [float]
+    GRID_aux_MWhyr:
+      sample_data: 0.715
+      types_found: [float]
+    GRID_cdata0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_cdata_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_cre0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_cre_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_cs0_kW:
+      sample_data: 21.636999999999997
+      types_found: [float]
+    GRID_cs_MWhyr:
+      sample_data: 3.737
+      types_found: [float]
+    GRID_data0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_data_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_hs0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_hs_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_l0_kW:
+      sample_data: 33.652
+      types_found: [float]
+    GRID_l_MWhyr:
+      sample_data: 90.40299999999999
+      types_found: [float]
+    GRID_pro0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_pro_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_ww0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_ww_MWhyr:
+      sample_data: 0.0
       types_found: [float]
     NG_hs0_kW:
-      sample_data: 0.0
+      sample_data: 298.438
       types_found: [float]
     NG_hs_MWhyr:
-      sample_data: 0.0
+      sample_data: 186.141
       types_found: [float]
     NG_ww0_kW:
-      sample_data: 0.0
+      sample_data: 10.177
       types_found: [float]
     NG_ww_MWhyr:
-      sample_data: 0.0
+      sample_data: 18.988
       types_found: [float]
     Name:
-      sample_data: B010
+      sample_data: B09
       types_found: [string]
     OIL_hs0_kW:
       sample_data: 0.0
@@ -4619,16 +5271,16 @@ get_total_demand:
       sample_data: 0.0
       types_found: [float]
     QC_sys0_kW:
-      sample_data: 5651.345
+      sample_data: 71.498
       types_found: [float]
     QC_sys_MWhyr:
-      sample_data: 19034.678
+      sample_data: 18.061
       types_found: [float]
     QH_sys0_kW:
-      sample_data: 0.0
+      sample_data: 241.64
       types_found: [float]
     QH_sys_MWhyr:
-      sample_data: 0.0
+      sample_data: 164.10299999999998
       types_found: [float]
     Qcdata0_kW:
       sample_data: 0.0
@@ -4640,6 +5292,12 @@ get_total_demand:
       sample_data: 0.0
       types_found: [float]
     Qcdata_sys_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    Qcpro_sys0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcpro_sys_MWhyr:
       sample_data: 0.0
       types_found: [float]
     Qcre0_kW:
@@ -4658,49 +5316,49 @@ get_total_demand:
       sample_data: 0.0
       types_found: [float]
     Qcs_MWhyr:
-      sample_data: -18681.528000000002
+      sample_data: -17.433
       types_found: [float]
     Qcs_dis_ls0_kW:
       sample_data: 0.0
       types_found: [float]
     Qcs_dis_ls_MWhyr:
-      sample_data: -4.622
+      sample_data: -0.043
       types_found: [float]
     Qcs_em_ls0_kW:
       sample_data: 0.0
       types_found: [float]
     Qcs_em_ls_MWhyr:
-      sample_data: -348.528
+      sample_data: -0.585
       types_found: [float]
     Qcs_lat_ahu0_kW:
       sample_data: 0.0
       types_found: [float]
     Qcs_lat_ahu_MWhyr:
-      sample_data: -9048.286
+      sample_data: -9.738999999999999
       types_found: [float]
     Qcs_lat_aru0_kW:
       sample_data: 0.0
       types_found: [float]
     Qcs_lat_aru_MWhyr:
-      sample_data: -1059.479
+      sample_data: -1.021
       types_found: [float]
     Qcs_lat_sys0_kW:
-      sample_data: 3797.1540000000005
+      sample_data: 51.928000000000004
       types_found: [float]
     Qcs_lat_sys_MWhyr:
-      sample_data: 10107.766
+      sample_data: 10.76
       types_found: [float]
     Qcs_sen_ahu0_kW:
       sample_data: 0.0
       types_found: [float]
     Qcs_sen_ahu_MWhyr:
-      sample_data: -2766.322
+      sample_data: -6.063
       types_found: [float]
     Qcs_sen_aru0_kW:
       sample_data: 0.0
       types_found: [float]
     Qcs_sen_aru_MWhyr:
-      sample_data: -5807.441
+      sample_data: -0.61
       types_found: [float]
     Qcs_sen_scu0_kW:
       sample_data: 0.0
@@ -4712,36 +5370,30 @@ get_total_demand:
       sample_data: 0.0
       types_found: [float]
     Qcs_sen_sys_MWhyr:
-      sample_data: -8573.763
+      sample_data: -6.672999999999999
       types_found: [float]
     Qcs_sys0_kW:
-      sample_data: 5651.345
+      sample_data: 71.498
       types_found: [float]
     Qcs_sys_MWhyr:
-      sample_data: 19034.678
+      sample_data: 18.061
       types_found: [float]
     Qcs_sys_ahu0_kW:
       sample_data: 0.0
       types_found: [float]
     Qcs_sys_ahu_MWhyr:
-      sample_data: -11928.566
+      sample_data: -16.319000000000003
       types_found: [float]
     Qcs_sys_aru0_kW:
       sample_data: 0.0
       types_found: [float]
     Qcs_sys_aru_MWhyr:
-      sample_data: -7106.111999999999
+      sample_data: -1.743
       types_found: [float]
     Qcs_sys_scu0_kW:
       sample_data: 0.0
       types_found: [float]
     Qcs_sys_scu_MWhyr:
-      sample_data: 0.0
-      types_found: [float]
-    Qcpro_sys0_kW:
-      sample_data: 0.0
-      types_found: [float]
-    Qcpro_sys_MWhyr:
       sample_data: 0.0
       types_found: [float]
     Qhpro_sys0_kW:
@@ -4751,35 +5403,31 @@ get_total_demand:
       sample_data: 0.0
       types_found: [float]
     Qhs0_kW:
-      sample_data: 0.0
+      sample_data: 227.85
       types_found: [float]
     Qhs_MWhyr:
-      sample_data: 0.0
+      sample_data: 138.17700000000002
       types_found: [float]
     Qhs_dis_ls0_kW:
-      sample_data: 0.0
+      sample_data: 0.887
       types_found: [float]
     Qhs_dis_ls_MWhyr:
-      sample_data: 0.0
+      sample_data: 0.498
       types_found: [float]
     Qhs_em_ls0_kW:
-      sample_data: 0.0
+      sample_data: 104.223
       types_found: [float]
     Qhs_em_ls_MWhyr:
-      sample_data: 0.0
+      sample_data: 10.238
       types_found: [float]
     Qhs_lat_ahu0_kW:
-      sample_data: 0.0
-      types_found: [float]
+      types_found: [null]
     Qhs_lat_ahu_MWhyr:
-      sample_data: 0.0
-      types_found: [float]
+      types_found: [null]
     Qhs_lat_aru0_kW:
-      sample_data: 0.0
-      types_found: [float]
+      types_found: [null]
     Qhs_lat_aru_MWhyr:
-      sample_data: 0.0
-      types_found: [float]
+      types_found: [null]
     Qhs_lat_sys0_kW:
       sample_data: 0.0
       types_found: [float]
@@ -4799,22 +5447,22 @@ get_total_demand:
       sample_data: 0.0
       types_found: [float]
     Qhs_sen_shu0_kW:
-      sample_data: 0.0
+      sample_data: 227.85
       types_found: [float]
     Qhs_sen_shu_MWhyr:
-      sample_data: 0.0
+      sample_data: 138.17700000000002
       types_found: [float]
     Qhs_sen_sys0_kW:
-      sample_data: 0.0
+      sample_data: 227.85
       types_found: [float]
     Qhs_sen_sys_MWhyr:
-      sample_data: 0.0
+      sample_data: 138.17700000000002
       types_found: [float]
     Qhs_sys0_kW:
-      sample_data: 0.0
+      sample_data: 238.75
       types_found: [float]
     Qhs_sys_MWhyr:
-      sample_data: 0.0
+      sample_data: 148.91299999999998
       types_found: [float]
     Qhs_sys_ahu0_kW:
       sample_data: 0.0
@@ -4829,22 +5477,898 @@ get_total_demand:
       sample_data: 0.0
       types_found: [float]
     Qhs_sys_shu0_kW:
-      sample_data: 0.0
+      sample_data: 238.75
       types_found: [float]
     Qhs_sys_shu_MWhyr:
-      sample_data: 0.0
+      sample_data: 148.91299999999998
       types_found: [float]
     Qww0_kW:
-      sample_data: 0.0
+      sample_data: 6.312
       types_found: [float]
     Qww_MWhyr:
-      sample_data: 0.0
+      sample_data: 11.815999999999999
       types_found: [float]
     Qww_sys0_kW:
-      sample_data: 0.0
+      sample_data: 8.142000000000001
       types_found: [float]
     Qww_sys_MWhyr:
+      sample_data: 15.19
+      types_found: [float]
+    SOLAR_hs0_kW:
       sample_data: 0.0
+      types_found: [float]
+    SOLAR_hs_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    SOLAR_ww0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    SOLAR_ww_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    'Unnamed: 0':
+      sample_data: !!python/long '8'
+      types_found: [long]
+    WOOD_hs0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    WOOD_hs_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    WOOD_ww0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    WOOD_ww_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    people0:
+      sample_data: 257.0
+      types_found: [float]
+  used_by: []
+get_optimization_thermal_network_data_file:
+  created_by: []
+  file_path: outputs/data/optimization/network/DH_Network_summary_result_0x19b.csv
+  file_type: csv
+  schema:
+    DATE:
+      sample_data: '2005-12-31 23:00:00'
+      types_found: [date]
+    Q_DHNf_W:
+      sample_data: 129923.009
+      types_found: [float]
+    Q_DH_losses_W:
+      sample_data: 38052.009
+      types_found: [float]
+    Qcdata_netw_total_kWh:
+      sample_data: 0.0
+      types_found: [float]
+    T_DHNf_re_K:
+      sample_data: 311.513
+      types_found: [float]
+    T_DHNf_sup_K:
+      sample_data: 344.02099999999996
+      types_found: [float]
+    mcpdata_netw_total_kWperC:
+      sample_data: 0.0
+      types_found: [float]
+    mdot_DH_netw_total_kgpers:
+      sample_data: 0.955
+      types_found: [float]
+  used_by: [optimization, optimization, optimization, optimization, optimization,
+    optimization, optimization, optimization]
+get_radiation_building:
+  created_by: [radiation]
+  file_path: outputs/data/solar-radiation/B001_radiation.csv
+  file_type: csv
+  schema:
+    Date:
+      sample_data: '2005-12-31 23:00:00'
+      types_found: [date]
+    roofs_top_kW:
+      sample_data: 0.0
+      types_found: [float]
+    roofs_top_m2:
+      sample_data: 624.66
+      types_found: [float]
+    walls_east_kW:
+      sample_data: 0.0
+      types_found: [float]
+    walls_east_m2:
+      sample_data: 468.62
+      types_found: [float]
+    walls_north_kW:
+      sample_data: 0.0
+      types_found: [float]
+    walls_north_m2:
+      sample_data: 468.62
+      types_found: [float]
+    walls_south_kW:
+      sample_data: 0.0
+      types_found: [float]
+    walls_south_m2:
+      sample_data: 468.62
+      types_found: [float]
+    walls_west_kW:
+      sample_data: 0.0
+      types_found: [float]
+    walls_west_m2:
+      sample_data: 468.62
+      types_found: [float]
+    windows_east_kW:
+      sample_data: 0.0
+      types_found: [float]
+    windows_east_m2:
+      sample_data: 156.21
+      types_found: [float]
+    windows_north_kW:
+      sample_data: 0.0
+      types_found: [float]
+    windows_north_m2:
+      sample_data: 156.21
+      types_found: [float]
+    windows_south_kW:
+      sample_data: 0.0
+      types_found: [float]
+    windows_south_m2:
+      sample_data: 156.21
+      types_found: [float]
+    windows_west_kW:
+      sample_data: 0.0
+      types_found: [float]
+    windows_west_m2:
+      sample_data: 156.21
+      types_found: [float]
+  used_by: [photovoltaic_thermal, solar_collector, photovoltaic, demand]
+get_radiation_building_sensors:
+  created_by: [radiation]
+  file_path: outputs/data/solar-radiation/B001_insolation_Whm2.json
+  file_type: json
+  schema:
+    srf0:
+      sample_data: 0.0
+      types_found: [float]
+  used_by: [photovoltaic_thermal, solar_collector, photovoltaic, demand]
+get_radiation_materials:
+  created_by: [radiation]
+  file_path: outputs/data/solar-radiation/buidling_materials.csv
+  file_type: csv
+  schema:
+    G_win:
+      sample_data: 0.75
+      types_found: [float]
+    Name:
+      sample_data: B09
+      types_found: [string]
+    r_roof:
+      sample_data: 0.5
+      types_found: [float]
+    r_wall:
+      sample_data: 0.15
+      types_found: [float]
+    type_roof:
+      sample_data: T4
+      types_found: [string]
+    type_wall:
+      sample_data: T5
+      types_found: [string]
+    type_win:
+      sample_data: T2
+      types_found: [string]
+  used_by: []
+get_radiation_metadata:
+  created_by: [radiation]
+  file_path: outputs/data/solar-radiation/B001_geometry.csv
+  file_type: csv
+  schema:
+    AREA_m2:
+      sample_data: 27.417685998042234
+      types_found: [float]
+    BUILDING:
+      sample_data: B01
+      types_found: [string]
+    SURFACE:
+      sample_data: srf260
+      types_found: [string]
+    TYPE:
+      sample_data: roofs
+      types_found: [string]
+    Xcoor:
+      sample_data: 463133.4420092157
+      types_found: [float]
+    Xdir:
+      sample_data: 0.0
+      types_found: [float]
+    Ycoor:
+      sample_data: 5225373.9933082415
+      types_found: [float]
+    Ydir:
+      sample_data: 0.0
+      types_found: [float]
+    Zcoor:
+      sample_data: 447.20458277424143
+      types_found: [float]
+    Zdir:
+      sample_data: 1.0
+      types_found: [float]
+    intersection:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    orientation:
+      sample_data: top
+      types_found: [string]
+  used_by: [photovoltaic_thermal, solar_collector, photovoltaic, demand]
+get_schedule_model_file:
+  created_by: [schedule_maker]
+  file_path: outputs/data/occupancy/B001.csv
+  file_type: csv
+  schema:
+    DATE:
+      sample_data: '2005-12-31 23:00:00'
+      types_found: [date]
+    Ea_W:
+      sample_data: 1349.2579999999998
+      types_found: [float]
+    Ed_W:
+      sample_data: 0.0
+      types_found: [float]
+    El_W:
+      sample_data: 17216.532
+      types_found: [float]
+    Epro_W:
+      sample_data: 0.0
+      types_found: [float]
+    Qcpro_W:
+      sample_data: 0.0
+      types_found: [float]
+    Qcre_W:
+      sample_data: 0.0
+      types_found: [float]
+    Qhpro_W:
+      sample_data: 0.0
+      types_found: [float]
+    Qs_W:
+      sample_data: 0.0
+      types_found: [float]
+    Tcs_set_C:
+      sample_data: 'OFF'
+      types_found: [string]
+    Ths_set_C:
+      sample_data: '12.000'
+      types_found: [string]
+    Ve_lps:
+      sample_data: 0.0
+      types_found: [float]
+    Vw_lph:
+      sample_data: 0.0
+      types_found: [float]
+    Vww_lph:
+      sample_data: 0.0
+      types_found: [float]
+    X_gh:
+      sample_data: 0.0
+      types_found: [float]
+    people_pax:
+      sample_data: 0.0
+      types_found: [float]
+  used_by: [demand]
+get_sewage_heat_potential:
+  created_by: [sewage_potential]
+  file_path: outputs/data/potentials/Sewage_heat_potential.csv
+  file_type: csv
+  schema:
+    Qsw_kW:
+      sample_data: 2004.381
+      types_found: [float]
+    T_in_HP_C:
+      sample_data: 7.0
+      types_found: [float]
+    T_in_sw_C:
+      sample_data: 41.347
+      types_found: [float]
+    T_out_HP_C:
+      sample_data: 13.198
+      types_found: [float]
+    T_out_sw_C:
+      sample_data: 34.53
+      types_found: [float]
+    Ts_C:
+      sample_data: 37.939
+      types_found: [float]
+    mww_zone_kWperC:
+      sample_data: 294.013
+      types_found: [float]
+  used_by: [optimization]
+get_street_network:
+  created_by: []
+  file_path: inputs/networks/streets.shp
+  file_type: shp
+  schema:
+    Id:
+      sample_data: !!python/long '0'
+      types_found: [long]
+    geometry:
+      sample_data: ((x1 y1, x2 y2, ...))
+      types_found: [LineString]
+  used_by: [optimization, network_layout]
+get_surroundings_geometry:
+  created_by: []
+  file_path: inputs/building-geometry/surroundings.shp
+  file_type: shp
+  schema:
+    Name:
+      sample_data: B16
+      types_found: [string]
+    floors_ag:
+      sample_data: !!python/long '7'
+      types_found: [long]
+    floors_bg:
+      sample_data: !!python/long '1'
+      types_found: [long]
+    geometry:
+      sample_data: ((x1 y1, x2 y2, ...))
+      types_found: [Polygon]
+    height_ag:
+      sample_data: 25.0
+      types_found: [float]
+    height_bg:
+      sample_data: 3.57142857143
+      types_found: [float]
+  used_by: [schedule_maker, radiation]
+get_terrain:
+  created_by: []
+  file_path: inputs/topography/terrain.tif
+  file_type: tif
+  schema:
+    raster_value:
+      sample_data: 1.0
+      types_found: [!!python/name:__builtin__.float '']
+  used_by: [schedule_maker, radiation]
+get_thermal_demand_csv_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__thermal_demand_per_building_W.csv
+  file_type: csv
+  schema:
+    B01:
+      sample_data: 0.0
+      types_found: [float]
+  used_by: []
+get_thermal_network_edge_list_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__metadata_edges.csv
+  file_type: csv
+  schema:
+    D_int_m:
+      sample_data: 0.1325
+      types_found: [float]
+    Pipe_DN:
+      sample_data: !!python/long '125'
+      types_found: [long]
+    Type_mat:
+      sample_data: T1
+      types_found: [string]
+    length_m:
+      sample_data: 1.4142135623730951
+      types_found: [float]
+  used_by: [optimization]
+get_thermal_network_layout_massflow_edges_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__massflow_edges_kgs.csv
+  file_type: csv
+  schema:
+    PIPE0:
+      sample_data: 5.425997e-07
+      types_found: [float]
+  used_by: []
+get_thermal_network_layout_massflow_nodes_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__massflow_nodes_kgs.csv
+  file_type: csv
+  schema:
+    NODE0:
+      sample_data: 0.0
+      types_found: [float]
+  used_by: []
+get_thermal_network_node_types_csv_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__metadata_nodes.csv
+  file_type: csv
+  schema:
+    Building:
+      sample_data: NONE
+      types_found: [string]
+    Type:
+      sample_data: PLANT
+      types_found: [string]
+  used_by: []
+get_thermal_network_plant_heat_requirement_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__plant_thermal_load_kW.csv
+  file_type: csv
+  schema:
+    NONE:
+      sample_data: 188.36340783456825
+      types_found: [float]
+  used_by: []
+get_thermal_network_pressure_losses_edges_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__pressure_losses_edges_kW.csv
+  file_type: csv
+  schema:
+    PIPE0:
+      sample_data: 0.0
+      types_found: [float]
+  used_by: []
+get_thermal_network_substation_ploss_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__pumping_load_due_to_substations_kW.csv
+  file_type: csv
+  schema:
+    B01:
+      sample_data: 0.0
+      types_found: [float]
+  used_by: []
+get_thermal_network_velocity_edges_file:
+  created_by: [thermal_network]
+  file_path: outputs/data/thermal-network/DH__velocity_edges_mpers.csv
+  file_type: csv
+  schema:
+    PIPE0:
+      sample_data: 6.035042e-08
+      types_found: [float]
+  used_by: []
+get_total_demand:
+  created_by: [demand]
+  file_path: outputs/data/demand/Total_demand.csv
+  file_type: csv
+  schema:
+    Af_m2:
+      sample_data: 1967.668
+      types_found: [float]
+    Aocc_m2:
+      sample_data: 2248.763
+      types_found: [float]
+    Aroof_m2:
+      sample_data: 624.66
+      types_found: [float]
+    COAL_hs0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    COAL_hs_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    COAL_ww0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    COAL_ww_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cdata0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cdata_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cre0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cre_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cs0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    DC_cs_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    DH_hs0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    DH_hs_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    DH_ww0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    DH_ww_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    E_cdata0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    E_cdata_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    E_cre0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    E_cre_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    E_cs0_kW:
+      sample_data: 21.636999999999997
+      types_found: [float]
+    E_cs_MWhyr:
+      sample_data: 3.737
+      types_found: [float]
+    E_hs0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    E_hs_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    E_sys0_kW:
+      sample_data: 48.471000000000004
+      types_found: [float]
+    E_sys_MWhyr:
+      sample_data: 129.517
+      types_found: [float]
+    E_ww0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    E_ww_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    Ea0_kW:
+      sample_data: 14.464
+      types_found: [float]
+    Ea_MWhyr:
+      sample_data: 38.4
+      types_found: [float]
+    Eal0_kW:
+      sample_data: 48.11600000000001
+      types_found: [float]
+    Eal_MWhyr:
+      sample_data: 128.80200000000002
+      types_found: [float]
+    Eaux0_kW:
+      sample_data: 0.355
+      types_found: [float]
+    Eaux_MWhyr:
+      sample_data: 0.715
+      types_found: [float]
+    Edata0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Edata_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    El0_kW:
+      sample_data: 33.652
+      types_found: [float]
+    El_MWhyr:
+      sample_data: 90.40299999999999
+      types_found: [float]
+    Epro0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Epro_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    GFA_m2:
+      sample_data: 4997.251
+      types_found: [float]
+    GRID0_kW:
+      sample_data: 69.851
+      types_found: [float]
+    GRID_MWhyr:
+      sample_data: 133.253
+      types_found: [float]
+    GRID_a0_kW:
+      sample_data: 14.464
+      types_found: [float]
+    GRID_a_MWhyr:
+      sample_data: 38.4
+      types_found: [float]
+    GRID_aux0_kW:
+      sample_data: 0.355
+      types_found: [float]
+    GRID_aux_MWhyr:
+      sample_data: 0.715
+      types_found: [float]
+    GRID_cdata0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_cdata_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_cre0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_cre_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_cs0_kW:
+      sample_data: 21.636999999999997
+      types_found: [float]
+    GRID_cs_MWhyr:
+      sample_data: 3.737
+      types_found: [float]
+    GRID_data0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_data_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_hs0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_hs_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_l0_kW:
+      sample_data: 33.652
+      types_found: [float]
+    GRID_l_MWhyr:
+      sample_data: 90.40299999999999
+      types_found: [float]
+    GRID_pro0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_pro_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_ww0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    GRID_ww_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    NG_hs0_kW:
+      sample_data: 298.438
+      types_found: [float]
+    NG_hs_MWhyr:
+      sample_data: 186.141
+      types_found: [float]
+    NG_ww0_kW:
+      sample_data: 10.177
+      types_found: [float]
+    NG_ww_MWhyr:
+      sample_data: 18.988
+      types_found: [float]
+    Name:
+      sample_data: B09
+      types_found: [string]
+    OIL_hs0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    OIL_hs_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    OIL_ww0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    OIL_ww_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    PV0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    PV_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    QC_sys0_kW:
+      sample_data: 71.498
+      types_found: [float, null]
+    QC_sys_MWhyr:
+      sample_data: 18.061
+      types_found: [float]
+    QH_sys0_kW:
+      sample_data: 241.64
+      types_found: [float]
+    QH_sys_MWhyr:
+      sample_data: 164.10299999999998
+      types_found: [float]
+    Qcdata0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcdata_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    Qcdata_sys0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcdata_sys_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    Qcpro_sys0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcpro_sys_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    Qcre0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcre_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    Qcre_sys0_kW:
+      sample_data: 0.0
+      types_found: [float, null]
+    Qcre_sys_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_MWhyr:
+      sample_data: -17.433
+      types_found: [float]
+    Qcs_dis_ls0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_dis_ls_MWhyr:
+      sample_data: -0.043
+      types_found: [float]
+    Qcs_em_ls0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_em_ls_MWhyr:
+      sample_data: -0.585
+      types_found: [float]
+    Qcs_lat_ahu0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_lat_ahu_MWhyr:
+      sample_data: -9.738999999999999
+      types_found: [float]
+    Qcs_lat_aru0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_lat_aru_MWhyr:
+      sample_data: -1.021
+      types_found: [float]
+    Qcs_lat_sys0_kW:
+      sample_data: 51.928000000000004
+      types_found: [float]
+    Qcs_lat_sys_MWhyr:
+      sample_data: 10.76
+      types_found: [float]
+    Qcs_sen_ahu0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sen_ahu_MWhyr:
+      sample_data: -6.063
+      types_found: [float]
+    Qcs_sen_aru0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sen_aru_MWhyr:
+      sample_data: -0.61
+      types_found: [float]
+    Qcs_sen_scu0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sen_scu_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sen_sys0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sen_sys_MWhyr:
+      sample_data: -6.672999999999999
+      types_found: [float]
+    Qcs_sys0_kW:
+      sample_data: 71.498
+      types_found: [float]
+    Qcs_sys_MWhyr:
+      sample_data: 18.061
+      types_found: [float]
+    Qcs_sys_ahu0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sys_ahu_MWhyr:
+      sample_data: -16.319000000000003
+      types_found: [float]
+    Qcs_sys_aru0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sys_aru_MWhyr:
+      sample_data: -1.743
+      types_found: [float]
+    Qcs_sys_scu0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qcs_sys_scu_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    Qhpro_sys0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qhpro_sys_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs0_kW:
+      sample_data: 227.85
+      types_found: [float]
+    Qhs_MWhyr:
+      sample_data: 138.17700000000002
+      types_found: [float]
+    Qhs_dis_ls0_kW:
+      sample_data: 0.887
+      types_found: [float]
+    Qhs_dis_ls_MWhyr:
+      sample_data: 0.498
+      types_found: [float]
+    Qhs_em_ls0_kW:
+      sample_data: 104.223
+      types_found: [float]
+    Qhs_em_ls_MWhyr:
+      sample_data: 10.238
+      types_found: [float]
+    Qhs_lat_ahu0_kW:
+      types_found: [null]
+    Qhs_lat_ahu_MWhyr:
+      types_found: [null]
+    Qhs_lat_aru0_kW:
+      types_found: [null]
+    Qhs_lat_aru_MWhyr:
+      types_found: [null]
+    Qhs_lat_sys0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_lat_sys_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sen_ahu0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sen_ahu_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sen_aru0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sen_aru_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sen_shu0_kW:
+      sample_data: 227.85
+      types_found: [float]
+    Qhs_sen_shu_MWhyr:
+      sample_data: 138.17700000000002
+      types_found: [float]
+    Qhs_sen_sys0_kW:
+      sample_data: 227.85
+      types_found: [float]
+    Qhs_sen_sys_MWhyr:
+      sample_data: 138.17700000000002
+      types_found: [float]
+    Qhs_sys0_kW:
+      sample_data: 238.75
+      types_found: [float]
+    Qhs_sys_MWhyr:
+      sample_data: 148.91299999999998
+      types_found: [float]
+    Qhs_sys_ahu0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sys_ahu_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sys_aru0_kW:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sys_aru_MWhyr:
+      sample_data: 0.0
+      types_found: [float]
+    Qhs_sys_shu0_kW:
+      sample_data: 238.75
+      types_found: [float]
+    Qhs_sys_shu_MWhyr:
+      sample_data: 148.91299999999998
+      types_found: [float]
+    Qww0_kW:
+      sample_data: 6.312
+      types_found: [float]
+    Qww_MWhyr:
+      sample_data: 11.815999999999999
+      types_found: [float]
+    Qww_sys0_kW:
+      sample_data: 8.142000000000001
+      types_found: [float]
+    Qww_sys_MWhyr:
+      sample_data: 15.19
       types_found: [float]
     SOLAR_hs0_kW:
       sample_data: 0.0
@@ -4871,23 +6395,35 @@ get_total_demand:
       sample_data: 0.0
       types_found: [float]
     people0:
-      sample_data: 5665.0
+      sample_data: 257.0
       types_found: [float]
-  used_by: [sewage-potential, emissions, operation-costs, network-layout]
-get_weather_file:
-  created_by: [weather-helper]
-  description: "weather/weather.epw Returns the path to a weather file to use for simulations"
-  file_path: "{general:scenario}/inpusts/weather/weather.epw"
+  used_by: [optimization, network_layout, sewage_potential, decentralized, operation_costs,
+    thermal_network, emissions]
+get_water_body_potential:
+  created_by: [water_body_potential]
+  file_path: outputs/data/potentials/Water_body_potential.csv
+  file_type: csv
+  schema:
+    QLake_kW:
+      sample_data: 326009.175
+      types_found: [float]
+    Ts_C:
+      sample_data: 5.004
+      types_found: [float]
+  used_by: [optimization]
+get_weather:
+  created_by: []
+  file_path: ../../../../github/cityenergyanalyst/cea/databases/weather/Zug-inducity_1990_2010_TMY.epw
   file_type: epw
   schema:
     Albedo (index = 32):
       sample_data: 0.2
       types_found: [float]
     aerosol_opt_thousandths (index = 29):
-      sample_data: 0.24100000000000002
+      sample_data: 0.077
       types_found: [float]
     atmos_Pa (index = 9):
-      sample_data: !!python/long '100889'
+      sample_data: !!python/long '96531'
       types_found: [long]
     ceiling_hgt_m (index = 25):
       sample_data: !!python/long '99999'
@@ -4902,7 +6438,7 @@ get_weather_file:
       sample_data: !!python/long '88'
       types_found: [long]
     dewpoint_C (index = 7):
-      sample_data: 22.6
+      sample_data: -2.1
       types_found: [float]
     difhorillum_lux (index = 18):
       sample_data: !!python/long '0'
@@ -4917,7 +6453,7 @@ get_weather_file:
       sample_data: !!python/long '0'
       types_found: [long]
     drybulb_C (index = 6):
-      sample_data: 24.2
+      sample_data: -1.1
       types_found: [float]
     extdirrad_Whm2 (index = 11):
       sample_data: !!python/long '0'
@@ -4932,7 +6468,7 @@ get_weather_file:
       sample_data: !!python/long '0'
       types_found: [long]
     horirsky_Whm2 (index = 12):
-      sample_data: !!python/long '402'
+      sample_data: !!python/long '269'
       types_found: [long]
     hour (index = 3):
       sample_data: !!python/long '24'
@@ -4950,10 +6486,10 @@ get_weather_file:
       sample_data: !!python/long '12'
       types_found: [long]
     opaqskycvr_tenths (index = 23):
-      sample_data: !!python/long '6'
+      sample_data: !!python/long '7'
       types_found: [long]
     precip_wtr_mm (index = 28):
-      sample_data: !!python/long '45'
+      sample_data: !!python/long '8'
       types_found: [long]
     presweathcodes (index = 27):
       sample_data: !!python/long '999999999'
@@ -4962,19 +6498,19 @@ get_weather_file:
       sample_data: !!python/long '9'
       types_found: [long]
     relhum_percent (index = 8):
-      sample_data: !!python/long '91'
+      sample_data: !!python/long '93'
       types_found: [long]
     snowdepth_cm (index = 30):
       sample_data: !!python/long '0'
       types_found: [long]
     totskycvr_tenths (index = 22):
-      sample_data: !!python/long '6'
+      sample_data: !!python/long '8'
       types_found: [long]
     visibility_km (index = 24):
       sample_data: !!python/long '9999'
       types_found: [long]
     winddir_deg (index = 20):
-      sample_data: !!python/long '133'
+      sample_data: !!python/long '223'
       types_found: [long]
     windspd_ms (index = 21):
       sample_data: 0.1
@@ -4985,47 +6521,143 @@ get_weather_file:
     zenlum_lux (index = 19):
       sample_data: !!python/long '9999'
       types_found: [long]
-  used_by: [radiation, photovoltaic, photovoltaic-thermal, solar-collector,
-    demand, thermal-network]
+  used_by: [weather_helper]
+get_weather_file:
+  created_by: [weather_helper]
+  file_path: inputs/weather/weather.epw
+  file_type: epw
+  schema:
+    Albedo (index = 32):
+      sample_data: 0.2
+      types_found: [float]
+    aerosol_opt_thousandths (index = 29):
+      sample_data: 0.077
+      types_found: [float]
+    atmos_Pa (index = 9):
+      sample_data: !!python/long '96531'
+      types_found: [long]
+    ceiling_hgt_m (index = 25):
+      sample_data: !!python/long '99999'
+      types_found: [long]
+    datasource (index = 5):
+      sample_data: '*?*?*?*?*?*?*?*?*?*?*?*?*?*?*?*?*?*?*?*?*?*?'
+      types_found: [string]
+    day (index = 2):
+      sample_data: !!python/long '31'
+      types_found: [long]
+    days_last_snow (index = 31):
+      sample_data: !!python/long '88'
+      types_found: [long]
+    dewpoint_C (index = 7):
+      sample_data: -2.1
+      types_found: [float]
+    difhorillum_lux (index = 18):
+      sample_data: !!python/long '0'
+      types_found: [long]
+    difhorrad_Whm2 (index = 15):
+      sample_data: !!python/long '0'
+      types_found: [long]
+    dirnorillum_lux (index = 17):
+      sample_data: !!python/long '0'
+      types_found: [long]
+    dirnorrad_Whm2 (index = 14):
+      sample_data: !!python/long '0'
+      types_found: [long]
+    drybulb_C (index = 6):
+      sample_data: -1.1
+      types_found: [float]
+    extdirrad_Whm2 (index = 11):
+      sample_data: !!python/long '0'
+      types_found: [long]
+    exthorrad_Whm2 (index = 10):
+      sample_data: !!python/long '0'
+      types_found: [long]
+    glohorillum_lux (index = 16):
+      sample_data: !!python/long '0'
+      types_found: [long]
+    glohorrad_Whm2 (index = 13):
+      sample_data: !!python/long '0'
+      types_found: [long]
+    horirsky_Whm2 (index = 12):
+      sample_data: !!python/long '269'
+      types_found: [long]
+    hour (index = 3):
+      sample_data: !!python/long '24'
+      types_found: [long]
+    liq_precip_depth_mm (index = 33):
+      sample_data: 0.0
+      types_found: [float]
+    liq_precip_rate_Hour (index = 34):
+      sample_data: 99.0
+      types_found: [float]
+    minute (index = 4):
+      sample_data: !!python/long '60'
+      types_found: [long]
+    month (index = 1):
+      sample_data: !!python/long '12'
+      types_found: [long]
+    opaqskycvr_tenths (index = 23):
+      sample_data: !!python/long '7'
+      types_found: [long]
+    precip_wtr_mm (index = 28):
+      sample_data: !!python/long '8'
+      types_found: [long]
+    presweathcodes (index = 27):
+      sample_data: !!python/long '999999999'
+      types_found: [long]
+    presweathobs (index = 26):
+      sample_data: !!python/long '9'
+      types_found: [long]
+    relhum_percent (index = 8):
+      sample_data: !!python/long '93'
+      types_found: [long]
+    snowdepth_cm (index = 30):
+      sample_data: !!python/long '0'
+      types_found: [long]
+    totskycvr_tenths (index = 22):
+      sample_data: !!python/long '8'
+      types_found: [long]
+    visibility_km (index = 24):
+      sample_data: !!python/long '9999'
+      types_found: [long]
+    winddir_deg (index = 20):
+      sample_data: !!python/long '223'
+      types_found: [long]
+    windspd_ms (index = 21):
+      sample_data: 0.1
+      types_found: [float]
+    year (index = 0):
+      sample_data: !!python/long '2005'
+      types_found: [long]
+    zenlum_lux (index = 19):
+      sample_data: !!python/long '9999'
+      types_found: [long]
+  used_by: [schedule_maker, photovoltaic_thermal, decentralized, solar_collector,
+    radiation, thermal_network, optimization, shallow_geothermal_potential, demand,
+    photovoltaic]
 get_zone_geometry:
   created_by: []
-  description: scenario/inputs/building-geometry/zone.shp
   file_path: inputs/building-geometry/zone.shp
   file_type: shp
   schema:
     Name:
-      sample_data: B010
+      sample_data: B09
       types_found: [string]
     floors_ag:
-      sample_data: !!python/long '12'
+      sample_data: !!python/long '7'
       types_found: [long]
     floors_bg:
-      sample_data: !!python/long '0'
+      sample_data: !!python/long '1'
       types_found: [long]
     geometry:
       sample_data: ((x1 y1, x2 y2, ...))
       types_found: [Polygon]
     height_ag:
-      sample_data: !!python/long '42'
-      types_found: [long]
+      sample_data: 25.0
+      types_found: [float]
     height_bg:
-      sample_data: !!python/long '0'
-      types_found: [long]
-  used_by: [photovoltaic, photovoltaic-thermal, emissions, network-layout, radiation,
-    demand, solar-collector]
-get_geothermal_potential:
-    created_by: [shallow-geothermal-potential]
-    description: scenario/outputs/data/potentials/geothermal/geothermal.csv
-    file_path: C:\Users\darthoma\Documents\CityEnergyAnalyst\projects\reference-case-open\baseline\outputs/data/potentials\Shallow_geothermal_potential.csv
-    file_type: csv
-    schema:
-        Area_avail_m2:
-            sample_data: 5621.908
-            types_found: [float]
-        QGHP_kW:
-            sample_data: 450.0
-            types_found: [float]
-        Ts_C:
-            sample_data: 10.156
-            types_found: [float]
-    used_by: [optimization]
+      sample_data: 3.57142857143
+      types_found: [float]
+  used_by: [schedule_maker, photovoltaic_thermal, decentralized, network_layout, radiation,
+    demand, solar_collector, thermal_network, optimization, shallow_geothermal_potential,
+    emissions, sewage_potential, data_helper, photovoltaic]

--- a/cea/scripts.yml
+++ b/cea/scripts.yml
@@ -105,6 +105,7 @@ Demand forecasting:
       - [get_zone_geometry]
       - [get_radiation_metadata, building_name]
       - [get_radiation_building, building_name]
+      - [get_schedule_model_file, building_name]
 
 Energy potentials:
   - name: shallow-geothermal-potential

--- a/notebooks/update_schemas_yml.ipynb
+++ b/notebooks/update_schemas_yml.ipynb
@@ -1,0 +1,140 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# update schemas.yml with output from trace-inputlocator script"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [],
+   "source": "import yaml\nimport os\nimport cea.inputlocator"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [],
+   "source": "# some constants\nTRACE_OUTPUT_YML = r\"C:\\Users\\darthoma\\Documents\\CityEnergyAnalyst\\projects\\reference-case-open\\baseline\\outputs\\trace_inputlocator.output.yml\"\nSCENARIO = r\"C:\\Users\\darthoma\\Documents\\CityEnergyAnalyst\\projects\\reference-case-open\\baseline\"\nSCHEMAS_YML = r\"C:\\Users\\darthoma\\Documents\\GitHub\\CityEnergyAnalyst\\cea\\schemas.yml\""
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### clean up trace output"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [],
+   "source": "with open(TRACE_OUTPUT_YML, 'r') as trace_output_fp:\n    trace_output = yaml.load(trace_output_fp)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": "\n"
+    }
+   ],
+   "source": "# this tests whether we have any non-scenario file_paths - it seems we don't. this is good!\nprint '\\n'.join(k for k in trace_output.keys() if not os.path.commonprefix([SCENARIO, trace_output[key][\"file_path\"]]) == SCENARIO)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [],
+   "source": "# convert all file paths to relative and replace backslashes with forward slashes\nfor key in trace_output:\n    file_path = trace_output[key][\"file_path\"]\n    file_path = os.path.normpath(file_path)\n    file_path = os.path.relpath(file_path, SCENARIO)\n    file_path = file_path.replace(\"\\\\\", \"/\")\n    file_path = file_path.replace(\"B01\", \"B001\")\n    trace_output[key][\"file_path\"] = file_path"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [],
+   "source": "# remove \"description\" filed (not used in schemas.yml)\nfor key in trace_output:\n    if \"description\" in trace_output[key]:\n        del trace_output[key][\"description\"]"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "###  make sure all methods in schemas.yml are present in InputLocator"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [],
+   "source": "with open(SCHEMAS_YML, 'r') as schemas_fp:\n    schemas = yaml.load(schemas_fp)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [],
+   "source": "locator = cea.inputlocator.InputLocator(SCENARIO)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [],
+   "source": "# the output here should be empty!\nfor key in schemas:\n    if not hasattr(locator, key):\n        print \"locator not found:\", key"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### i'm curious: what methods are not in the trace-inputlocator output?"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [],
+   "source": "# expect an empty list...\nfor key in schemas:\n    if not key in trace_output:\n        print \"missing key in trace_output:\", key"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### assuming we're not missing any methods, replace the schemas.yml file "
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {},
+   "outputs": [],
+   "source": "with open(SCHEMAS_YML, 'w') as schemas_fp:\n    yaml.dump(trace_output, schemas_fp)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": ""
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR solves #2506 (Add get_database_envelope_systems to schemas.yml (update schemas.yml?)) and adds a jupyter notebook to make this easier in the future.

To test, create a new project with a new scenario.
DO NOT run data-helper.
INSTEAD: run demand. you should be greeted with a list of missing input files and hints how to get them.