### PR TITLE
update schemas.yml file to conform to changes in PR 2532

### DIFF
--- a/cea/schemas.yml
+++ b/cea/schemas.yml
@@ -2078,7 +2078,7 @@ get_database_supply_systems:
       unit:
         sample_data: W
         types_found: [string]
-    DETAILED_ELEC_PRICES:
+    DETAILED_ELEC_COSTS:
       Opex_var_buy_USD2015perkWh:
         sample_data: 0.04936071505496888
         types_found: [float]


### PR DESCRIPTION
This PR fixes a small omission in PR #2532: The worksheet name in the `schemas.yml` file for `get_database_supply_systems` is now "DETAILED_ELEC_COSTS".