### PR TITLE
Fixed typo in a variable name

### DIFF
--- a/cea/default.config
+++ b/cea/default.config
@@ -518,10 +518,10 @@ network-model.type = ChoiceParameter
 network-model.choices = simplified, detailed
 network-model.help = Choose either simplified (seconds) or detailed model (several hours)
 
-min-head-susbstation = 20
-min-head-susbstation.type = RealParameter
-min-head-susbstation.help = Minimum head loss in kPa expected at each thermal transfer substation
-min-head-susbstation.category = Parameters of simplified model
+min-head-substation = 20
+min-head-substation.type = RealParameter
+min-head-substation.help = Minimum head loss in kPa expected at each thermal transfer substation
+min-head-substation.category = Parameters of simplified model
 
 hw-friction-coefficient = 100
 hw-friction-coefficient.type = IntegerParameter

--- a/cea/technologies/thermal_network/simplified_thermal_network.py
+++ b/cea/technologies/thermal_network/simplified_thermal_network.py
@@ -169,7 +169,7 @@ def calc_thermal_loss_per_pipe(T_in_K, m_kgpers, T_ground_K, k_kWperK):
 def thermal_network_simplified(locator, config, network_name):
     # local variables
     network_type = config.thermal_network.network_type
-    min_head_substation_kPa = config.thermal_network.min_head_susbstation
+    min_head_substation_kPa = config.thermal_network.min_head_substation
     thermal_transfer_unit_design_head_m = min_head_substation_kPa * 1000 / M_WATER_TO_PA
     coefficient_friction_hazen_williams = config.thermal_network.hw_friction_coefficient
     velocity_ms = config.thermal_network.peak_load_velocity


### PR DESCRIPTION
Was: "min-head-susbstation"; Should be: "min-head-substation"