### PR TITLE
Release 2.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,750 +1,755 @@
-2020-02-19 - 2.29.0 - #2571 fix skytemp
-2020-02-18 - 2.29.0 - #2574 Use consistent input locator method in building_properties.py
-2020-02-18 - 2.29.0 - #2563 2227 negative values in ct
-2020-02-17 - 2.29.0 - #2565 Issue databases
-2020-02-17 - 2.29.0 - #2557 I2553 restructure database
-2020-02-13 - 2.29.0 - #2562 2551 many files optimization
-2020-02-13 - 2.29.0 - #2559 Update how-are-schedules-defined.rst
-2020-02-11 - 2.29.0 - #2556 `Annual Cost` and `Annual Emissions` plots x-axis are sorted by cost
-2020-02-10 - 2.29.0 - #2554 2536 technology editor
-2020-02-10 - 2.29.0 - #2550 I2534 opt technologies, merging but sending a new PR with more tests in case functionality is broken (not likely) according to extensive testing.
-2020-02-06 - 2.29.0 - #2546 Glossary.csv - synchronized with newest schemas.yml
-2020-02-03 - 2.29.0 - #2544 update schemas.yml file to conform to changes in PR 2532
-2020-02-03 - 2.29.0 - #2545 Fixed typo in a variable name @martin-mosteiro good catch
-2020-01-23 - 2.29.0 - #2542 Release 2.29
-2020-01-23 - 2.28.1 - #2526 Fix COOLROOM bug in thermal networks
-2020-01-23 - 2.28.1 - #2530 updated schemas.yml with trace-inputlocator output
-2020-01-23 - 2.28.1 - #2532 fixed workflow and also bug in supply_systems.xls
-2020-01-21 - 2.28.1 - #2528 Fix incorrect locator method @martin-mosteiro great catch!
-2020-01-20 - 2.28.1 - #2522 2493 decentralized optimization. Tested with the centralized optimization too. @daren-thomas grande!
-2020-01-20 - 2.28.1 - #2523 Typos and nomenclature in thermal networks
-2020-01-17 - 2.28.1 - #2521 Open plot in new window @reyery working great!
-2020-01-14 - 2.28.1 - #2520 Release 2.28
-2020-01-14 - 2.27.0 - #2516 fixing small bugs i2512 and i2509
-2020-01-14 - 2.27.0 - #2513 fix nominal cap
-2020-01-10 - 2.27.0 - #2517 2511 solar plots
-2020-01-10 - 2.27.0 - #2499 @daren-thomas well as soon as this fixes the problem of #2502
-2020-01-09 - 2.27.0 - #2503 Fix for scenario creation
-2020-01-09 - 2.27.0 - #2412 Simplify environment.ubuntu.yml
-2020-01-09 - 2.27.0 - #2492 Fixing plots nyc
-2020-01-08 - 2.27.0 - #2497 Rtd build errors
-2020-01-07 - 2.27.0 - #2498 Missing input files should create an error, not a success in the jobs list
-2019-12-10 - 2.27.0 - #2495 Release 2.27.0
-2019-12-06 - 2.26.0a0 - #2481 Show plot input files
-2019-12-06 - 2.26.0a0 - #2462 Test epanet - simple thermal model Merging!! wihuu
-2019-12-04 - 2.26.0 - #2467 1777 optimize decentralized script for speed
-2019-12-03 - 2.26.0 - #2479 Data validation for inputs in front end
-2019-12-03 - 2.26.0 - #2478 2477 wrong column name in piping catalog
-2019-11-29 - 2.26.0 - #2475 Window to wall ratio and envelope properties
-2019-11-26 - 2.26.0 - #2470 Schedule reader to api
-2019-11-18 - 2.26.0 - #2466 Release 2.26
-2019-11-15 - 2.25.2 - #2455 2349 suspend simulations
-2019-11-14 - 2.25.1 - #2448 Ventilation to avoid unrealistically high temperatures during heating season
-2019-11-12 - 2.25.1 - #2452 Update epwreader.py
-2019-11-11 - 2.25.1 - #2439 Databases major refactoring
-2019-11-07 - 2.25.1 - #2444 Update input api
-2019-11-06 - 2.25.1 - #2420 I1633 gains and losses proportional to conditioned area
-2019-11-05 - 2.25.1 - #2441 Release 2.25, I also updated the CEA website to reflect this
-2019-11-04 - 2.24 - #2434 Delete converter_old_schedules_to_csv.py
-2019-11-04 - 2.24 - #2437 Update input api
-2019-11-04 - 2.24 - #2354 2082 add remaining network plots to dashboard
-2019-11-04 - 2.24 - #2431 Update scripts.yml
-2019-11-04 - 2.24 - #2433 Update geometry_generator.py
-2019-10-31 - 2.24 - #2417 BUGFIX: Handle folder locator methods in TraceInputLocator
-2019-10-31 - 2.24 - #2416 Radiation now account for adjacent buildings
-2019-10-30 - 2.24 - #2414 Terminate running cea worker processes when closing the GUI @daren-thomas works like a charm, good stuff!
-2019-10-30 - 2.24 - #2421 BUGFIX: UnboundLocalError: local variable 'number_of_occupants' referenced before assignment
-2019-10-30 - 2.24 - #2415 Allow importing scripts.py from the Grasshopper interface
-2019-10-29 - 2.24 - #2419 fix to schedule maker
-2019-10-29 - 2.24 - #2411 2392 build the docs
-2019-10-29 - 2.24 - #2418 2324 resume workflow feature
-2019-10-24 - 2.24 - #2407 Update LCA_infrastructure.xlsx
-2019-10-23 - 2.24 - #2398 Update URL for CityEnergyAnalyst-GUI
-2019-10-23 - 2.24 - #2400 2399 demand keyerror rhum max pc
-2019-10-21 - 2.24 - #2396 Release 2.24
-2019-10-21 - 2.23 - #2391 Show plot parameters when adding and changing plots
-2019-10-18 - 2.23 - #2383 Fix to load curves plot and to glossary
-2019-10-17 - 2.23 - #2382 New Schedules Maker / Model
-2019-10-17 - 2.23 - #2384 fix void-deck issues @lguilhermers thanks!, we will implement cell validation in another issue #2141
-2019-10-17 - 2.23 - #2390 I816 stop bayesian calibration support @martin-mosteiro alright we take it out
-2019-10-15 - 2.23 - #2386 fix coordinate system
-2019-10-15 - 2.23 - #2372 2360 create installer for electron interface
-2019-10-14 - 2.23 - #2380 2344 multiprocessing and stdout
-2019-10-11 - 2.23 - #2374 2356 Update environment.ubuntu.yml
-2019-10-11 - 2.23 - #2378 I2204b temperature setpoints finish
-2019-10-10 - 2.23 - #2363 I2204 temperature setpoints
-2019-10-09 - 2.23 - #2318 Optimization cooling, Alright guys, we are merging and creating more issues should we find more problems.
-2019-10-08 - 2.23 - #2365 Ventilation code cleanup
-2019-10-08 - 2.23 - #2369 Glossary api for electron
-2019-10-07 - 2.23 - #2362 Raise an error for false weather files
-2019-10-07 - 2.23 - #2368 Release 2.23
-2019-10-02 - 2.22 - #2338 Moving flexibility (concept project) to legacy
-2019-10-02 - 2.22 - #2353 Project api for electron application
-2019-10-02 - 2.22 - #2337 fix to network layout script (EL is not implemented yet) @daren-thomas thanks for checking this out
-2019-09-24 - 2.21 - #2335 Bugfix: Edit selection in input editor does not work if some old values is equal to the new value
-2019-09-24 - 2.21 - #2334 Show Es and Ns variable for architecture in dashboard
-2019-09-24 - 2.21 - #2320 BUG: fixed default value for workflow parameter
-2019-09-23 - 2.21 - #2303 CEA Occupancy-Schedule Updates
-2019-09-20 - 2.21 - #2286 Fix to #1271
-2019-09-18 - 2.21 - #2319 Bugfix: Dashboard set scenario function not working
-2019-09-18 - 2.21 - #2289 2255 thermal network optimization refactoring
-2019-09-17 - 2.21 - #2313 set seed for sensitivity analysis test
-2019-09-17 - 2.21 - #2299 2192 single plot view
-2019-09-17 - 2.21 - #2198 macOS installation guide
-2019-09-17 - 2.21 - #2305 2279 show baseline network in input editor
-2019-09-16 - 2.21 - #2306 2019.09.16 run radiation daysim from pycharm
-2019-09-16 - 2.21 - #2304 Renamed Zurich 2015 and 2016 files
-2019-09-13 - 2.21 - #2297 FEATURE: 1926 cea worker / non-blocking tools
-2019-09-12 - 2.21 - #2275 2063 process cooling
-2019-09-12 - 2.21 - #2301 hotfix for parameters changed in lca_operation
-2019-09-12 - 2.21 - #2292 steps for creating a release updated
-2019-09-10 - 2.21 - #2251 Change naming of weather files
-2019-09-10 - 2.21 - #2284 2277 update new release documentation
-2019-09-06 - 2.21 - #2294 Bugfix: BooleanParameter can now decode bool values
-2019-09-05 - 2.21 - #2266 Delete cooling_case_workflow.py
-2019-09-05 - 2.21 - #2288 FEATURE: New React Dashboard
-2019-09-05 - 2.21 - #2290 changing workflows structure
-2019-09-04 - 2.21 - #2287 I753 remove global vars last steps
-2019-09-03 - 2.21 - #2280 2279 generate network from building supply properties
-2019-09-03 - 2.21 - #2281 2256 update conditions to run disconnected_buildings_heating_main @shanshanhsieh elegant fix
-2019-08-30 - 2.21 - #2282 I2249 opt cooling
-2019-08-26 - 2.21 - #2278 Updated version number, changelog and credits for 2.21
-2019-08-26 - 2.20.3 - #2253 Feature: Supply system map plot @daren-thomas merging as we need it to plan for the 30 sec video for Arno
-2019-08-23 - 2.20.3 - #2258 2117 weather as input file
-2019-08-23 - 2.20.3 - #2257 FEATURE: lazy loading of cea.api module
-2019-08-23 - 2.20.3 - #2252 Fix: Add alert when user changes occupancy @reyery thanks for this!
-2019-08-22 - 2.20.3 - #2250 753 global variables removal 2.21
-2019-08-22 - 2.20.3 - #2248 Add legend toggle drop down to plots
-2019-08-21 - 2.20.3 - #2265 FEATURE: allow user-specified region databases for the data-helper
-2019-08-13 - 2.20.1 - #2241 updating version, changelog and credits for v2.20
-2019-08-13 - 2.19 - #2239 Bugfix: Map not initializing if district data does not exist
-2019-08-13 - 2.19 - #2238 Feature: Grid Layout for Dashboard
-2019-08-08 - 2.19 - #2216 Bugfix: Add script input validation for dashboard
-2019-08-08 - 2.19 - #2225 I2224 optimization heating
-2019-08-08 - 2.19 - #2230 fix occupancy
-2019-08-05 - 2.19 - #2228 Bugfix: Calculate and save projected coordinate system
-2019-08-05 - 2.19 - #2226 I2146 decentralized cooling @shanshanhsieh great! thanks!
-2019-08-02 - 2.19 - #2222 I2120 fixing optimization cooling
-2019-07-31 - 2.19 - #2160 2150 Feature: cea rename-building
-2019-07-29 - 2.19 - #2217 Release 2.19
-2019-07-29 - 2.18.1 - #2215 Minor Fix: Add tooltips to plot buttons
-2019-07-25 - 2.18.1 - #2209 Add "change plot" button to row layout
-2019-07-24 - 2.18.1 - #2191 I2182 read occupancy schedules
-2019-07-24 - 2.18.1 - #2203 Closes #2202
-2019-07-24 - 2.18.1 - #2199 Heating case workflow
-2019-07-23 - 2.18.1 - #2193 2143 document and proof default config
-2019-07-23 - 2.18.1 - #2196 I2195 fix vectorized setpoint
-2019-07-23 - 2.18.1 - #2161 don't create the inputs folder when opening a project + scenario
-2019-07-23 - 2.18.1 - #2194 Fixed typos in error message
-2019-07-22 - 2.18.1 - #2159 added more uses to reference-case-cooling
-2019-07-22 - 2.18.1 - #2166 I2120 re(making)factor optimization
-2019-07-19 - 2.18.1 - #2178 Fix: Dashboard popup tables
-2019-07-19 - 2.18.1 - #2181 adding comfort to dashboard
-2019-07-18 - 2.18.1 - #2162 FEATURE: New Map Dashboard layout
-2019-07-17 - 2.18.1 - #2164 2095 FIXED "ArcGIS interface installation does not work anymore"
-2019-07-17 - 2.18.1 - #2090 1870 dashboard settings not working for capex vs opex
-2019-07-13 - 2.18.1 - #2158 Thanks @Jack-Hawthorne!
-2019-07-12 - 2.18 - #2157 Release 2.18
-2019-07-09 - 2.17.1 - #2137 Bugfix for input editor
-2019-07-08 - 2.17.1 - #2145 remove faulty input requests
-2019-07-05 - 2.17.1 - #2085 1971 check input files
-2019-07-03 - 2.17.1 - #2134 Bugfix: Allow decimal values for number inputs
-2019-07-03 - 2.17.1 - #2129 Fix to known issues
-2019-07-03 - 2.17.1 - #2133 FEATURE: New 500 status error page
-2019-07-03 - 2.17.1 - #2128 Minor bugfix for glossary frontend
-2019-07-02 - 2.17.1 - #2071 I2015 constant supply temperature at plants
-2019-07-02 - 2.17.1 - #2125 FEATURE: Add Glossary Search to Dashboard
-2019-07-01 - 2.17 - #2124 Release 2.17
-2019-07-01 - 2.17a1 - #2121 Bugfix: Maintain original coordinate system when saving new input files
-2019-07-01 - 2.17a1 - #2093 1978 create an uninstaller for the cea sure! @daren-thomas
-2019-07-01 - 2.17a0 - #2119 creating warning
-2019-07-01 - 2.17a0 - #2118 Bugfix: Update scenario image if zone file is modified
-2019-07-01 - 2.17a0 - #2116 FEATURE: Improvements to Dashboard input editor @reyery great job. It works also with files without the reference tab
-2019-06-28 - 2.17a0 - #2109 2096 error on creating energy use intensity plot @daren-thomas thanks for this!
-2019-06-28 - 2.17a0 - #2106 I1834 description variables
-2019-06-28 - 2.17a0 - #2108 Bugfix: REFERENCE column is not added when user changes parameters in zone and district helper
-2019-06-28 - 2.17a0 - #2110 I1927 multicriteria for dh cases
-2019-06-28 - 2.17a0 - #2103 Add collapsible fields for tools @reyery it works like a charm. Merging this...
-2019-06-27 - 2.17a0 - #2101 Update how-to-run-CEA-optimization.rst
-2019-06-27 - 2.17a0 - #2099 Fixed documentation build errors
-2019-06-25 - 2.17a0 - #2086 2008 demand tool not working when non existing building selected
-2019-06-25 - 2.17a0 - #2087 2026 dashboard tools parameters ignored
-2019-06-25 - 2.17a0 - #2084 add message for script completion to dashboard
-2019-06-24 - 2.16 - #2083 1984 add thermal networks plots to the dashboard
-2019-06-21 - 2.16 - #2017 1956 glossary to dashboard
-2019-06-19 - 2.16 - #2067 Updated documentation to include trace-inputlocator
-2019-06-19 - 2.16 - #2080 Bugfix: Fix terrain boundary caused by rounding error
-2019-06-18 - 2.16 - #2076 Bugfix: Ignore REFERENCE when checking columns in data_helper
-2019-06-18 - 2.16 - #2077 Bugfix: Remove 'Open project' default value if path does not exists.
-2019-06-14 - 2.16 - #2075 Release 2.16
-2019-06-13 - 2.15 - #2059 Remove brackets from `sheet_name` instances
-2019-06-12 - 2.15 - #2010 Import input files during scenario creation
-2019-06-12 - 2.15 - #2055 1961 project overview improvements
-2019-06-12 - 2.15 - #2052 Thermal network simulation config file
-2019-06-12 - 2.15 - #2034 I1932 process schedules for lab
-2019-06-11 - 2.15 - #2022 1949 3d visualization
-2019-06-04 - 2.15 - #2050 Improve description of variable `network-type`
-2019-06-04 - 2.15 - #2047 Release 2.15
-2019-06-04 - 2.14 - #2035 fixes building energy balance plots
-2019-06-04 - 2.14 - #2042 fixes #1988
-2019-06-03 - 2.14 - #2029 1761 fix grasshopper installer script
-2019-05-30 - 2.14 - #2028 Steiner tree and buildings with no demand
-2019-05-30 - 2.14 - #2019 1983 add solar technologies plots to the dashboard
-2019-05-30 - 2.14 - #1994 Missing cool room and server room loads
-2019-05-27 - 2.14 - #1998 I1958 cooling case workflow not working
-2019-05-27 - 2.14 - #2009 Closes #1985 add life cycle plots to the dashboard
-2019-05-24 - 2.14 - #2003 Closes #1982
-2019-05-23 - 2.14 - #2000 I1950 remove arcgis radiation
-2019-05-23 - 2.14 - #1997 1987 fix qt conf for installer
-2019-05-23 - 2.14 - #1903 Make each function that has occupants have a minimum of one occupant
-2019-05-22 - 2.14 - #1993 1955 the installer shows low res icons on the desktop
-2019-05-22 - 2.14 - #1992 closes #1960
-2019-05-22 - 2.14 - #1963 1868 dashboard file directory opener is not working
-2019-05-22 - 2.14 - #1975 2019.05.17 some documentation fixes
-2019-05-21 - 2.14 - #1973 Fix for cea install-grasshopper
-2019-05-17 - 2.14 - #1972 Release 2.14
-2019-05-15 - 2.13.5a1 - #1962 753 remove globalvars
-2019-05-15 - 2.13.5a1 - #1959 1942 fix default dashboard plot @reyery good job on this...we are one step further in functionality
-2019-05-15 - 2.13.5a1 - #1965 Retain dtypes of dataframe columns @reyery thaks, this works...
-2019-05-13 - 2.13.5a1 - #1947 1914 radiation daysim windows installer
-2019-05-10 - 2.13 - #1951 1921 dashboard landing page
-2019-05-09 - 2.13 - #1948 Update installation-on-euler.rst Sure I can pass this...however we will need to automate this from the dashboard eventually
-2019-05-08 - 2.13 - #1944 Add data_source to input table in dashboard @reyery working, I changed the name to "REFERENCE" instead of "data_source" so we do not have problems of truncation
-2019-05-07 - 2.13 - #1943 Update installer to retrieve CEA environment from a known location
-2019-05-06 - 2.13 - #1936 Updating credits and version number for 2.13
-2019-05-06 - 2.12.0a3 - #1941 Update inputs.yml
-2019-05-06 - 2.12.0a3 - #1940 1938 relocate side panel links @reyery thanks, it works as expected
-2019-05-06 - 2.12.0a3 - #1939 Split coordinates to lat lon input
-2019-05-06 - 2.12.0a3 - #1931 1917 create zone shapfile from map
-2019-05-06 - 2.12.0a3 - #1905 Add floor cooling to CEA systems
-2019-05-03 - 2.12.0a3 - #1929 adding automatic occupancy of site. This closes #1924, closes #1920
-2019-05-03 - 2.12.0a3 - #1928 Various small fixes
-2019-04-30 - 2.12.0a3 - #1919 1813 Zone Helper
-2019-04-30 - 2.12.0a3 - #1922 fix
-2019-04-30 - 2.12.0a3 - #1837 I1600 electric and thermal network planning @shanshanhsieh @BhargavaKrishnaSreepathi thanks for the hard work on this. the script works
-2019-04-30 - 2.12.0a3 - #1910 I1907 docu new project @Jack-Hawthorne we will pass this since I  was asked for this update for a while
-2019-04-26 - 2.12.0a3 - #1908 1828 make one for all installer for windows alrighty merging for now and expecting a solution to the daysim problem as a first step
-2019-04-24 - 2.12.0a1 - #1899 Make solar plots run if only one technology is selected
-2019-04-24 - 2.12.0a1 - #1900 Shift case studies below sea level to an elevation of 1 meter @martin-mosteiro  great, this works quite well. good fix!
-2019-04-24 - 2.12.0a1 - #1906 Add weather file for Dutch case study
-2019-04-18 - 2.12.0a1 - #1895 I1826 document optimization in cea @shanshanhsieh great, it looks good
-2019-04-18 - 2.12.0a1 - #1880 1869 dashboard plot settings are not working
-2019-04-18 - 2.12.0a1 - #1887 Fix typo in `datacenter_loads` @martin-mosteiro, you are the man, thanks for this quick fix
-2019-04-18 - 2.12.0a1 - #1877 1069 db metadata
-2019-04-16 - 2.12.0a1 - #1885 Restrict length of year to 8760 hours
-2019-04-16 - 2.12.0a1 - #1856 1684 test supply system and optimization
-2019-04-12 - 2.12.0a1 - #1879 added the schedule information to tutorials
-2019-04-12 - 2.12.0a1 - #1872 1827 config file is getting reset to default values after running scripts
-2019-04-12 - 2.12.0a1 - #1861 I1859 remove gv from occupancy
-2019-04-12 - 2.12.0a1 - #1878 I1871 region parameter
-2019-04-11 - 2.12.0a1 - #1874 i1841 Incomplete function call in energy_mix_based_on_technologies_script.py
-2019-04-11 - 2.12.0a1 - #1876 1875 fix broken link on dev tutorials
-2019-04-11 - 2.12.0a1 - #1846 Remove conda environment creation from jenkins
-2019-04-11 - 2.12.0a0 - #1867 Plot cache for dashboard
-2019-04-05 - 2.12.0a0 - #1860 753 remove low hanging fruit global variables
-2019-04-04 - 2.12.0a0 - #1854 1005 fix installation guide for ubuntu
-2019-04-04 - 2.11 - #1850 Automated generation of streets and district file from Open Street Maps for CEA
-2019-04-02 - 2.11 - #1845 I1836 network layout
-2019-03-28 - 2.11 - #1824 Updated version number and credits for closing milestone M2.11
-2019-03-27 - 2.9.2a - #1843 1825 lca calculations fix
-2019-03-27 - 2.9.2a - #1839 1811 fix module doc strings
-2019-03-27 - 2.9.2a - #1842 advanced tutorials link fixed
-2019-03-14 - 2.9.2a - #1820 Adding concept algorithms, building models developed by TUM into CEA @daren-thomas we need this PR to continue., the test pass locally in 2 computers but Jenkins throws the same error of six.
-2019-03-14 - 2.9.2a - #1810 Fixing cea optimization plots @daren-thomas we need to merge this to continue with other work. The jenkins still does not work... Tests pass locally..
-2019-03-13 - 2.9.2a - #1818 Rename hidden py4design functions in geometry_generator
-2019-03-07 - 2.9.2 - #1821 1819 update install doc daysim
-2019-03-04 - 2.9.2 - #1809 1808 autodoc build for inputs/outputs graphviz
-2019-03-04 - 2.9.2 - #1807 Calculating demand from varying setpoint temperatures
-2019-02-25 - 2.9.2 - #1804 1798 re add arcgis
-2019-02-25 - 2.9.2 - #1790 1769 reference case open improvement
-2019-02-22 - 2.9.2 - #1793 Correct archetypal values of Es for PARKING and COOLROOM
-2019-02-21 - 2.9.2 - #1787 1069 document input output variables
-2019-02-15 - 2.9.2 - #1795 1784 connectivity network + CEA Open Source + Goodbye ArcGIS
-2019-02-12 - 2.9.2 - #1789 1780 thermal network matrix rename
-2019-02-12 - 2.9.2 - #1599 Network optimization
-2019-02-06 - 2.9.2 - #1788 1729 autodoc error radiation daysim
-2019-02-01 - 2.9.2 - #1785 Fixing calc cop ccgt
-2019-02-01 - 2.9.2 - #1783 Fixed typo in yearly demand writer that caused issues with operation_costs script
-2019-01-31 - 2.9.2 - #1778 I 1767 fix longwave radiation bug
-2019-01-30 - 2.9.2 - #1775 Add missing file outputs from representative week method
-2019-01-30 - 2.9.2 - #1773 Release 2.9.2
-2019-01-29 - 2.9.1 - #1737 I1735 fix full demand reporting
-2019-01-29 - 2.9.1 - #1772 updated the install instructions to include size and time
-2019-01-24 - 2.9.1 - #1765 a more robust way of getting a Default.gdb workspace for arcgis
-2019-01-24 - 2.9.1 - #1759 Show default values for tool parameters in cea and cea-config
-2019-01-23 - 2.9.1 - #1756 Fix issue with `mcpcdata_sys_kWperC`
-2019-01-23 - 2.9.1 - #1746 adding credits to the best of my knowledge
-2019-01-23 - 2.9.0 - #1752 Make sure the Jenkins tests run again @daren-thomas great job!, it passes all the tests locally too!
-2019-01-21 - 2.9.0 - #1690 i1679: Varying electrical price integration
-2019-01-21 - 2.9.0 - #1661 967 dashboard plots
-2019-01-21 - 2.9.0 - #1748 1734 importerror dll load failed fiona ogrext
-2019-01-16 - 2.9.0 - #1747 Fix conda environment.yml
-2019-01-09 - 2.9.0 - #1740 add new files to output annual aggregation per building
-2019-01-09 - 2.9.0 - #1743 updated ArcGIS install instructions
-2019-01-07 - 2.9.0 - #1742 I1605 variable naming convention @BhargavaKrishnaSreepathi great! thanks for this!
-2019-01-07 - 2.9.0 - #1728 1727 autodoc errors for optimization
-2018-12-18 - 2.9.0 - #1721 1717 model existing thermal networks @shanshanhsieh great! thanks for this1
-2018-12-18 - 2.9.0 - #1732 1731 autodoc errors for cea tests test dbf
-2018-12-18 - 2.9.0 - #1733 1730 Autodoc errors for thermal_network/network_layout
-2018-12-13 - 2.9.0 - #1724 Autodoc import error fixed for analysis/clustering
-2018-12-13 - 2.9.0 - #1711 updating credits and readme @daren-thomas I have to merge now since, NRF our funding agency needs a link to CEA - credits / manuals etc. urgently.
-2018-12-13 - 2.9.0 - #1713 1651 1652 1691 1604 dbf files fix
-2018-12-04 - 2.9.0 - #1682 1656 hardcoded regions
-2018-11-30 - 2.9.0 - #1702 I1700 net floor area @martin-mosteiro great work. It woudl be also good to change the presentation of what are the inputs of CEA? so we add the new input NS
-2018-11-30 - 2.9.0 - #1716 #753 get rid of gv
-2018-11-30 - 2.9.0 - #1715 taking gv out of neural network
-2018-11-30 - 2.9.0 - #1692 1239 known issues table ref I am merging. a new PR solves the problems of the documentation. thanks @Jack-Hawthorne for this
-2018-11-30 - 2.9.0 - #1638 Create warning for RC-model breakdown
-2018-11-30 - 2.9.0 - #1707 1706 Stochastic occupancy update @martin-mosteiro great, well caught!
-2018-11-30 - 2.9.0 - #1699 Update reference-case-WTP.zip @gabriel-happle great , thanks for this
-2018-11-26 - 2.9.0 - #1697 1665 how to create pull request
-2018-11-23 - 2.9.0 - #1696 1666 how to document cea update
-2018-11-14 - 2.9.0 - #1680 Release 2.9.0
-2018-11-14 - 2.9.0 - #1671 I530 floor height
-2018-11-12 - 2.9.0 - #1673 adding flag to solve issue
-2018-11-09 - 2.9.0 - #1678 I1668 buggy control flow in calc hex heating
-2018-11-09 - 2.9.0 - #1677 creating legacy folder
-2018-11-09 - 2.9.0 - #1676 I1557 none error
-2018-11-09 - 2.9.0 - #1674 Fixing substation.calc_HEX_cooling loop with bhargava
-2018-11-09 - 2.9.0 - #1675 753 remove gv log calls
-2018-11-08 - 2.9.0 - #1669 adding the 'roles' work
-2018-11-08 - 2.9.0 - #1672 fix error message radiation daysim
-2018-11-07 - 2.9.0 - #1622 I1541 refactor and rejig optimization
-2018-11-06 - 2.9.0 - #1667 RTD - fixes some issues with the documentation
-2018-11-05 - 2.9.0 - #1663 delete test_sensible_loads.py
-2018-10-30 - 2.9.0 - #1655 I1619 calibration
-2018-10-10 - 2.9.0 - #1627 1224 improve runtime for solar collectors
-2018-10-08 - 2.9.0 - #1629 1625 figure out why the radiation daysim tool hangs on sabines scenario
-2018-10-04 - 2.9.0 - #1615 This is a first stab to updating the documentation
-2018-10-02 - 2.9.0 - #1618 967 dashboard - changes so far It runs so I am merging. I guess we can talk about the changes on the presentation of the 18th.
-2018-09-20 - 2.7.22 - #1624 Fixing the pyliburo / radiation geometry problems
-2018-09-18 - 2.7.22 - #1608 this solves issue #1351
-2018-09-08 - 2.7.22 - #1614 Typos and cleanup
-2018-09-04 - 2.7.22 - #1603 @daren-thomas great thanks!
-2018-08-08 - 2.7.22 - #1601 added ActiveX control bug to Known Issues
-2018-08-08 - 2.7.22 - #1602 checked and changed zone geometry dbf to reflect variable names
-2018-08-03 - 2.7.22 - #1592 I1588 bugfix aru model
-2018-08-03 - 2.7.22 - #1587 LCA database Reference documentation update
-2018-07-19 - 2.7.22 - #1586 Correct number of inputs to calc_Qcdataf @martin-mosteiro good catch!
-2018-07-16 - 2.7.22 - #1583 Solving issue #1445
-2018-07-13 - 2.7.22 - #1558 remove dependency on csv module for grasshopper
-2018-07-13 - 2.7.22 - #1579 adding paris
-2018-07-13 - 2.7.22 - #1543 I1542 qcre takes 3 arguments
-2018-07-06 - 2.7.21 - #1572 fix for selecting a different project
-2018-07-05 - 2.7.20 - #1571 I1569 lca comparison plots
-2018-07-05 - 2.7.20 - #1566 1564 issue of new technology
-2018-07-04 - 2.7.19 - #1561 Fixes for 4day
-2018-07-04 - 2.7.19 - #1549 I1545 further enhancements
-2018-07-03 - 2.7.17 - #1554 I1553 fix path in individual evaluation
-2018-06-29 - 2.7.12 - #1548 fix
-2018-06-29 - 2.7.11 - #1547 I1269 interface for individual evaluation
-2018-06-29 - 2.7.10 - #1546 1519 new optimization plotting
-2018-06-28 - 2.7.9 - #1539 I1494 update network plots
-2018-06-22 - 2.7.9 - #1530 Fix to decentralized cooling, where the same name has been referenced for different technologies
-2018-06-21 - 2.7.9 - #1528 fixes i1527
-2018-06-21 - 2.7.9 - #1526 fixing heatmaps
-2018-06-20 - 2.7.9 - #1525 I1501 tap water volume good catch martin. Bear in mind that the result is tap cold water but not the entire water use.
-2018-06-20 - 2.7.9 - #1524 BUGFIX for solar:annual-radiation-threshold
-2018-06-20 - 2.7.9 - #1523 update to cea-workflow.bat
-2018-06-20 - 2.7.9 - #1521 I1164 solar collector temperatures
-2018-06-20 - 2.7.9 - #1517 Setting random seed for optimization
-2018-06-20 - 2.7.9 - #1520 I1501 fix occupancy and electricity
-2018-06-19 - 2.7.9 - #1514 I773 operating cost of solar collectors is not calculated
-2018-06-19 - 2.7.8 - #1518 1515 jenkins has a problem
-2018-06-19 - 2.7.8 - #1516 check to make sure reference-case really got deleted before cea test
-2018-06-19 - 2.7.8 - #1489 Linking lca database to optimization calculations
-2018-06-18 - 2.7.8 - #1504 1394 restrict config to script inputs working beautifully @daren-thomas
-2018-06-18 - 2.7.8 - #1505 cea-workflow
-2018-06-18 - 2.7.8 - #1503 I1409 negative production from solar collectors
-2018-06-18 - 2.7.8 - #1463 1238 glossary terms and databases
-2018-06-18 - 2.7.8 - #1506 Speed up optimization (low hanging fruit)
-2018-06-18 - 2.7.8 - #1508 fixes to run from intermittent generations
-2018-06-13 - 2.7.8 - #1499 Readthedocs
-2018-06-13 - 2.7.8 - #1460 fix to new project
-2018-06-13 - 2.7.8 - #1496 I1476 retrofit potential tool keyerror qhsf mwhyr @martin-mosteiro great thanks for this!
-2018-06-13 - 2.7.8 - #1371 I1279 update pressure loss calculation in thermal network matrix
-2018-06-12 - 2.7.8 - #1490 1335 import arcgisscripting ImportError: DLL load failed: %1 is not a valid Win32 application.
-2018-06-12 - 2.7.8 - #1453 1451/1368 fix databases copy working well and passing the tests in the Arcgis interface
-2018-06-12 - 2.7.8 - #1485 Various additions to thermal network matrix @roglen it passess the unittests and the plots look good
-2018-06-12 - 2.7.8 - #1459 fix to config and radiation
-2018-06-12 - 2.7.8 - #1484 fix to operation_costs script location
-2018-06-11 - 2.7.8 - #1474 update documentation with new names for solar collectors
-2018-06-11 - 2.7.8 - #1468 Fixes to stack plots
-2018-06-11 - 2.7.8 - #1462 Updated LCA infrastructure database for Singapore
-2018-06-08 - 2.7.8 - #1456 Limit number of processes of multiprocessing @roglen it works quite good thanks!
-2018-06-08 - 2.7.8 - #1454 I1364 change final to sys
-2018-06-07 - 2.7.8 - #1431 967 interface and dashboard for the cea. VERY VERY cool stuff. I am loving the editing capabilities. Some of the plots do not work but i guess we can create an issue for that after the next PR passes
-2018-06-07 - 2.7.8 - #1427 1238 glossary terms and databases
-2018-06-06 - 2.7.8 - #1448 1261 - add note to installation guide
-2018-06-05 - 2.7.8 - #1447 Urgent fix for a h5py error that just showed up (failing jenkins tests)
-2018-06-05 - 2.7.8 - #1443 fix to ensure a folder is created before it is called
-2018-06-05 - 2.7.8 - #1429 I1244 modify solar technology plots and interface. tested and the plots work
-2018-06-05 - 2.7.8 - #1438 minor fixes to issues raised in optimization and toolbox
-2018-06-05 - 2.7.8 - #1439 update ceajenkins.py to use ngrok.io instead of localtunnel.me
-2018-06-05 - 2.7.8 - #1411 I1410 benchmark values
-2018-06-05 - 2.7.8 - #1414 fixes #1386 - ArcGIS interface: Plotting tool only works if at least one scenario for comparison is selected
-2018-06-04 - 2.7.8 - #1434 1063 issues into rst
-2018-06-04 - 2.7.8 - #1424 I928b recovering SuS calibration
-2018-06-04 - 2.7.8 - #1432 IMPORTANT SOLAR RADIATION FIX!
-2018-06-01 - 2.7.8 - #1397 1263 api build debug
-2018-06-01 - 2.7.8 - #1428 1298 api demand building properties
-2018-05-31 - 2.7.8 - #1380 I1281 implement reduced time step option for thermal network matrix
-2018-05-31 - 2.7.8 - #1358 Cost analysis plots @BhargavaKrishnaSreepathi great job! I created a small issue about a plot. but the rest looks good.
-2018-05-30 - 2.7.8 - #1420 this should fix the failing jenkins tests
-2018-05-29 - 2.7.8 - #1405 1404 api demand occupancy model
-2018-05-28 - 2.7.8 - #1403 907-minor additions
-2018-05-25 - 2.7.8 - #1400 fixes #1399
-2018-05-25 - 2.7.6 - #1398 1390 arcgis interface should update the config file
-2018-05-24 - 2.7.5 - #1396 fixes #1323
-2018-05-24 - 2.7.5 - #1395 adding region to data-helper tool
-2018-05-24 - 2.7.5 - #1393 1389 weather file cannot be changed from arcgis interface
-2018-05-23 - 2.7.4 - #1383 fixed comfort plot: pass down locator and config, fix type
-2018-05-23 - 2.7.4 - #1381 I1289 improve solar technology tools
-2018-05-23 - 2.7.3 - #1379 1321 arcgis interface plotting of scenario comparison not interactive @daren-thomas it works perfectly fine. I tested it with the open case and the new singaporean case.
-2018-05-23 - 2.7.3 - #1378 I1377 cpg problem
-2018-05-23 - 2.7.3 - #1356 Fix mobility issue again
-2018-05-23 - 2.7.3 - #1372 fix so we do not double account emissions
-2018-05-22 - 2.7.1 - #1370 i1369 fix solar technology potential plot when there the total potential is zero
-2018-05-21 - 2.7.1 - #1366 fixing issue @martin-mosteiro all the issues regarding the demand plots were merged into master. thanks to @gabriel-happle for quick testing.
-2018-05-21 - 2.7.1 - #1362 I1361 fix zero hot water demand
-2018-05-21 - 2.7.1 - #1360 I1352 end use plots
-2018-05-21 - 2.7.1 - #1348 Solves call from ArcGis
-2018-05-18 - 2.7 - #1347 fixes #1346 - Plot tool doesn't work on ArcScene
-2018-05-18 - 2.7 - #1299 I1288 substation calling only cooling for design
-2018-05-17 - 2.7 - #1345 Demand script output csv columns
-2018-05-17 - 2.7 - #1338 I1331 pv panels fail to run
-2018-05-17 - 2.7 - #1334 I1305 bug in master
-2018-05-17 - 2.7 - #1273 1116 Automated setup of looped networks
-2018-05-17 - 2.7 - #1304 Fixes issue in mobility.py
-2018-05-17 - 2.7 - #1324 1222 ploting interface for arcgis should show list of buildings
-2018-05-15 - 2.7 - #1306 fixing guide
-2018-05-15 - 2.7 - #1268 Minimum mass flow
-2018-05-14 - 2.7 - #1284 I 1055 more legible plots
-2018-05-14 - 2.7 - #1287 i1192-i1286-clean-total-demands-fixed-comfort-plot all plots run correctly
-2018-05-09 - 2.7 - #1283 import all functions from math library
-2018-05-08 - 2.7 - #1276 done
-2018-05-08 - 2.7 - #1274 Quick fix to environment. It helps to get plotly correctly installed.
-2018-05-07 - 2.7 - #1266 I 1255 refactoring solar plots
-2018-04-27 - 2.7 - #1250 I1248 update thermal network plots
-2018-04-27 - 2.7 - #1236 907 update the role of the cea core developers
-2018-04-27 - 2.7 - #1251 Integrating cooling technologies into CEA
-2018-04-27 - 2.7 - #1265 I1223 issue cooling calc
-2018-04-25 - 2.7 - #1260 Removing unnecessary lines in the Zurich-2015.epw
-2018-04-20 - 2.7 - #1257 1252-cea-installation
-2018-04-19 - 2.7 - #1172 I1138 plots cea arcgis
-2018-04-19 - 2.7 - #1249 1225 - Fix arcgis interface folder path pop-up
-2018-04-18 - 2.7 - #1235 Minor changes to Windows install
-2018-04-18 - 2.7 - #1241 I1233 larger pipe diameters
-2018-04-18 - 2.7 - #1237 Updated installation doc
-2018-04-17 - 2.7 - #1228 I1169 integrating thermal network matrix with the new demand outputs
-2018-04-16 - 2.7 - #1226 fix mcp_kWperK list type
-2018-04-13 - 2.7 - #1216 I 209 clean and documented comfort plot
-2018-04-13 - 2.7 - #1168 I1152 linking thermal pressure losses to dhn
-2018-04-13 - 2.7 - #1206 I 209 psychroplotting for cea
-2018-04-13 - 2.7 - #1207 I1193 electricity bug
-2018-04-13 - 2.7 - #1208 Fix to unit problem in thermal network matrix
-2018-04-11 - 2.7 - #1189 removing faulty control from legacy
-2018-04-11 - 2.7 - #1190 I1184 fixing outputs of solar scripts
-2018-04-10 - 2.7 - #1203 I1202 fix
-2018-04-09 - 2.7 - #1174 I1173 atot calculation
-2018-04-09 - 2.7 - #1178 Fix _get_region_specific_db_file
-2018-04-05 - 2.7 - #1165 I1024 absorption chiller
-2018-04-05 - 2.7 - #1181 adding T4 back to domestic hot water emission system
-2018-03-29 - 2.7 - #1171 update test data
-2018-03-28 - 2.7 - #1167 Two versions of CEA logo and one MUSES
-2018-03-28 - 2.7 - #1133 I1073 stochastic
-2018-03-28 - 2.7 - #1159 Cea global constants file creation
-2018-03-26 - 2.7 - #1160 I1076 revert to last working
-2018-03-23 - 2.7 - #1158 Readthedocs
-2018-03-23 - 2.7 - #1157 1156 fix jenkins bug in master
-2018-03-22 - 2.7 - #1151 refactoring and re-adding final heating and cooling demand calc
-2018-03-22 - 2.7 - #1149 Thermal network plots alternate
-2018-03-21 - 2.7 - #1084 Optimization tool box for ArcGIS
-2018-03-21 - 2.7 - #1140 I1090 multiprocessing for thermal network
-2018-03-16 - 2.7 - #1126 I1058 heat load balance PR apart from optimization folder structure changes @BhargavaKrishnaSreepathi great stuff!
-2018-03-16 - 2.7 - #1135 I1132 refix energy balance graph
-2018-03-16 - 2.7 - #1122 I1100 longitude problem
-2018-03-12 - 2.7 - #1120 I1070 update building energy balance dashboard
-2018-03-12 - 2.7 - #1118 I1099 change temperature outputs in sc total and pvt total
-2018-03-12 - 2.7 - #1096 Cea open case study updated
-2018-03-09 - 2.7 - #1119 Update README.rst
-2018-03-08 - 2.7 - #1098 fixes bug with jenkins tests on master (updates radiation data for zurich reference cases)
-2018-03-05 - 2.7 - #1097 fixes #1094 @daren-thomas great fix!
-2018-03-05 - 2.7 - #1095 fixing path so Singapore case study works
-2018-03-05 - 2.7 - #1062 I1018 simple indoor humidity
-2018-03-02 - 2.7 - #1077 I1031 implement looped networks
-2018-03-02 - 2.7 - #1083 Add a test for sensitivity analysis to the Jenkins tests
-2018-03-02 - 2.7 - #1082 I665 export ubg to cea files
-2018-03-02 - 2.7 - #1089 implements #957 (Add a "restore defaults" button to the config editor
-2018-02-27 - 2.7 - #1056 I985 activation curve
-2018-02-26 - 2.7 - #1068 Release 2 7
-2018-02-19 - 2.6 - #1051 fix according to calc_temperature_ground
-2018-02-15 - 2.6 - #1057 I1052 scenario comparison
-2018-02-14 - 2.6 - #1050 I1049 life cycle
-2018-02-13 - 2.6 - #1045 Add Zurich 2015 & 2016 weather files
-2018-02-08 - 2.6 - #991 966 try plotly dash
-2018-02-08 - 2.6 - #1036 I998 update shp for zug
-2018-02-08 - 2.6 - #1038 I 974 review thermal network
-2018-02-07 - 2.6 - #1030 1013 cea launch tool
-2018-02-07 - 2.6 - #1037 994 dashboard building does not work for reference case zug
-2018-02-07 - 2.6 - #995 I982 update network shp files
-2018-02-05 - 2.6 - #1019 I1015 tutorials movement
-2018-02-05 - 2.6 - #1028 Use appropriate InputLocator to list building names
-2018-02-02 - 2.6 - #1026 I1014 fix shapefiles create new project
-2018-02-02 - 2.6 - #1016 I1012 inconsistent saving of files opt
-2018-02-01 - 2.6 - #1009 I1007 radiation prerequisite
-2018-02-01 - 2.6 - #1002 I1001 economic plots
-2018-01-31 - 2.6 - #1011 I977 solar pot graph
-2018-01-31 - 2.6 - #996 fixing errors in electricity load
-2018-01-30 - 2.6 - #1004 i997_thermal_network_matrix_does_not_run_for_DH
-2018-01-30 - 2.6 - #1006 this should fix #999
-2018-01-30 - 2.6 - #993 I987 cea workflow
-2018-01-26 - 2.6 - #990 colors added as a class
-2018-01-25 - 2.6 - #981 I 975 detailed heat balance
-2018-01-25 - 2.6 - #984 I968 opt graphs
-2018-01-24 - 2.6 - #980 Incorporating changes to optimization_main file to handle intermediate generations
-2018-01-23 - 2.6 - #972 I971 new project tool
-2018-01-22 - 2.6 - #976 Renaming tools for ArcGIS
-2018-01-18 - 2.6 - #961 created `locator.get_zone_building_names()` and updated most usages
-2018-01-17 - 2.6 - #965 I905 dashboard
-2018-01-15 - 2.6 - #959 951 chisqprob is deprecated
-2018-01-12 - 2.6 - #947 fixes #353
-2018-01-10 - 2.6 - #956 quick fix to epwreader
-2018-01-10 - 2.6 - #954 904 config file editor
-2018-01-10 - 2.6 - #939 937 config calibration
-2018-01-09 - 2.6 - #953 steps to avoid Nan's and 0K temperature values
-2018-01-09 - 2.6 - #949 i forgot to comment out the creation of test.pyt on `cea install-toolbox`
-2017-12-20 - 2.6 - #946 945 modify dynamic supply systems interface
-2017-12-18 - 2.6 - #938 heating and cooling season is now extracted from a location specific …
-2017-12-14 - 2.6 - #929 Modifying parts of optimization to comply with new config file format
-2017-12-11 - 2.6 - #924 Create the release v2.6
-2017-12-08 - 2.6rc1 - #932 20171214 bugfixes for master
-2017-12-07 - 2.5a4 - #933 930 sensitivity broken
-2017-12-04 - 2.5a4 - #916 902 update documentation to reflect cli changes
-2017-12-04 - 2.5rc2 - #913 #909 h5py cea
-2017-12-01 - 2.5rc1 - #899 I797 daysim for demand2
-2017-12-01 - 2.5a2 - #914 excel/shapefiles, references in config file
-2017-11-28 - 2.5a1 - #912 adjust office occupant density in SG
-2017-11-27 - 2.5a1 - #910 relaxing restrictions on some packages
-2017-11-23 - 2.5a0 - #898 Add multiple network cal procedure
-2017-11-23 - 2.5a0 - #896 timeseries fix to be compliant with new config file
-2017-11-23 - 2.5a0 - #903 Great stuff, thanks for this
-2017-11-23 - 2.5a0 - #901 I works fine :-)
-2017-11-20 - 2.5a0 - #893 i833 - ArcGIS interfaces
-2017-11-14 - 2.4a4 - #889 Removing unnecessary saving of files
-2017-11-14 - 2.4a4 - #892 Calculate radiation total from insolation files
-2017-11-14 - 2.4a4 - #890 I837 ecocampus demand check
-2017-11-13 - 2.4a4 - #835 I833 switch databases
-2017-11-10 - 2.4a4 - #884 conversion into hexadecimal notation
-2017-11-10 - 2.4a4 - #887 changing the mutation strategy
-2017-11-10 - 2.4a4 - #886 fixes #885
-2017-11-08 - 2.4a4 - #883 @BhargavaKrishnaSreepathi working good
-2017-11-08 - 2.4a4 - #882 changes to incorporate geothermal potential calculations
-2017-11-06 - 2.4a4 - #879 Automated file generation which further can be used for plots
-2017-11-06 - 2.4a4 - #881 Fixes to optimization to run with new config file
-2017-10-27 - 2.4a4 - #878 including centralized supply systems in building HP electricity calculation
-2017-10-19 - 2.4a4 - #873 I351x calibrator nn based
-2017-10-19 - 2.4a4 - #870 I839 simulate cooling network for ecocampus
-2017-10-19 - 2.4a4 - #871 updating reference case open fixing control system of B06
-2017-10-19 - 2.4a4 - #869 Small fix to radiation script
-2017-10-16 - 2.4a4 - #859 I838 network ecocampus
-2017-10-12 - 2.4a4 - #798 I724 daylight saving
-2017-10-11 - 2.4a4 - #857 Fix thermal network to match demand columns
-2017-10-10 - 2.4a4 - #855 695 document the jenkins setup
-2017-10-09 - 2.4a4 - #853 695 document the jenkins setup - think it is now working!
-2017-10-09 - 2.4a4 - #852 695 document the jenkins setup - does this change trigger the `run cea test on merge to master` jenkins item?
-2017-10-09 - 2.4a4 - #851 695 document the jenkins setup - does the merge-to-master trigger work now?
-2017-10-09 - 2.4a4 - #831 695 document the jenkins setup - this should trigger the job "run cea test on merge to master"
-2017-10-09 - 2.4a4 - #843 Fix solar technology scripts
-2017-10-09 - 2.4a4 - #842 I840 dx minisplit
-2017-10-05 - 2.4a4 - #783 437 remove multiprocessing from gv
-2017-10-04 - 2.4a4 - #834 I832 minisplit
-2017-10-02 - 2.4a4 - #781 I712 sensitivity analysis tool
-2017-10-02 - 2.4a4 - #760 I351 calibrator cea
-2017-09-27 - 2.4a4 - #788 711 launch tool energy potential analysis
-2017-09-27 - 2.4a4 - #791 684 launch tool urban solar radiation
-2017-09-27 - 2.4a4 - #784 I268 technology cost database
-2017-09-27 - 2.4a4 - #793 723 grasshopper modules for cea
-2017-09-27 - 2.4a4 - #725 i636 connect solar collector and pvt with new radiation results. test pass so merging it
-2017-09-27 - 2.4a4 - #826 825 test failing in master
-2017-09-26 - 2.4a4 - #796 Readthedocs - fix build errors in rtd
-2017-09-25 - 2.4a4 - #795 adding guide
-2017-08-28 - 2.4a4 - #778 Refactoring labels in saved files to include units
-2017-08-22 - 2.4a4 - #779 updates to the documentation - sphinx now builds without warnings
-2017-08-16 - 2.4a4 - #777 731 port cea to arcgis 10 5 for computerroom hil e65
-2017-08-11 - 2.4a2 - #780 2017 08 09 easier installation guide
-2017-07-31 - 2.4a2 - #767 I766 Remove unnecessary error message
-2017-07-31 - 2.3 - #765 761 port cea to 64 bit python
-2017-07-27 - 2.3 - #763 I672 xls2dbf
-2017-07-26 - 2.3 - #716 Adding solution for case when V=0
-2017-07-20 - 2.3a1 - #700 I694 archetype application
-2017-07-20 - 2.3a1 - #741 I733 cooling conditioned buildings
-2017-07-19 - 2.3a1 - #740 I649 decentralized buildings preprocessing
-2017-07-14 - 2.3a1 - #686 642 arcgis remember last options
-2017-07-14 - 2.3a1 - #732 changes to dhw in database
-2017-07-14 - 2.3a1 - #678 I633 interface for solar potential @shanshanhsieh good job!!
-2017-07-14 - 2.3a1 - #685 radiation arcgis for ecocampus - giving up, we need this only for the ecocampus case.
-2017-07-12 - 2.3a1 - #728 I643 retrofit analysis
-2017-07-05 - 2.3a1 - #708 I663 lca tools subfolders
-2017-07-05 - 2.3a1 - #707 I383 process heat
-2017-07-05 - 2.3a1 - #690 I673 cea optimization workflow
-2017-06-30 - 2.3a1 - #680 566 code the program to call cea from gh
-2017-06-30 - 2.3a1 - #715 Revert "xls2dbf_new_branch"
-2017-06-30 - 2.3a1 - #714 @Khayatian thanks and congrats on your first contrib to CEA!
-2017-06-30 - 2.3a1 - #677 I662 ciao citygml
-2017-06-29 - 2.3a1 - #702 fixing special case radiation
-2017-06-27 - 2.3a1 - #696 cool stuff!, thanks for this, it is much clear
-2017-06-23 - 2.3a1 - #693 I372 data helper discrepancy
-2017-06-22 - 2.3a1 - #689 I688 fix broken build
-2017-06-20 - 2.3a1 - #675 I612 preprocessing multiuse buildings
-2017-06-15 - 2.3a1 - #674 645 switch between infiltration models, working like a charm
-2017-06-12 - 2.3a1 - #671 Cascading config files
-2017-06-12 - 2.3a1 - #656 I655 ctrl vent changes
-2017-05-25 - 2.3a1 - #659 minimalistic first stab at a documentation guide
-2017-05-24 - 2.3a1 - #653 I648 radaition working
-2017-05-19 - 2.3a1 - #627 I613 guide on how files are saved
-2017-05-18 - 2.3a1 - #624 607 document steps to create arelease
-2017-05-15 - 2.2 - #635 correct conversion of string to integer if dbf file is defined as double accidentally
-2017-05-15 - 2.2 - #616 I615 modifying import of dataframes
-2017-05-10 - 2.2 - #623 I526 archetypes singapore
-2017-05-10 - 2.2 - #629 updated installation-guide because new pandas version breaks geopandas
-2017-05-09 - 2.2 - #424 I336 add pv script to the core. @shanshanhsieh great refactoring, I also created a technology database in databases/CH/systems which helps to take out the constant variables of PV technologies, in this way we can try many other PV technologies. Please check it out. Could you also apply this for the sollar collector and PVT script? are there issues already created for this?
-2017-05-09 - 2.2 - #631 :-D so the line was just commented...
-2017-05-03 - 2.2 - #625 I622 data cleaning ipynb
-2017-04-26 - 2.2 - #621 Singapore weather 2015 ok
-2017-04-26 - 2.2 - #619 changes naming
-2017-04-25 - 2.2 - #567 I9 new radiation engine daysim by paul
-2017-04-21 - 2.2 - #611 removing NUS_weather file
-2017-04-19 - 2.2a4 - #572 Uncertainty analysis and individual evaluation
-2017-04-19 - 2.2a4 - #597 I596 occupancy density
-2017-04-18 - 2.2 - #602 I601 installation guide doc
-2017-04-18 - 2.2 - #595 I573 fix sax opt
-2017-04-18 - 2.2 - #553 Fix errors caused by tank size 0
-2017-04-18 - 2.2 - #600 fix environment for running fiona.ogrext - this should fix a lot of installation problems
-2017-04-11 - 2.2 - #594 proposal for fixing credits/licenses
-2017-04-05 - 2.1 - #588 I587 ventilation bugfix for cisbat
-2017-04-03 - 2.1 - #580 i558 Recirculation error fix - replaces PR #559
-2017-04-03 - 2.1 - #581 i560 RC model inconsistent inputes - replaces PR #561
-2017-04-03 - 2.1 - #579 Replacing #576
-2017-04-03 - 2.1 - #582 fixing the arcgis toolbox (import arcpy)
-2017-03-31 - 2.1a5 - #578 small fix to sensitivity
-2017-03-31 - 2.1a5 - #577 Adding more info on running on Euler
-2017-03-31 - 2.1a5 - #557 Adding ETH heating network
-2017-03-31 - 2.1a5 - #574 added clarification as per issue #571
-2017-03-31 - 2.1a5 - #545 changes to getting started documentation
-2017-03-28 - 2.1a5 - #564 Adding missing libraries to the documentation on Euler
-2017-03-27 - 2.1a5 - #565 Revert "I9 new radiation engine daysim by paul"
-2017-03-27 - 2.1a5 - #500 I9 new radiation engine daysim by paul
-2017-03-27 - 2.1a5 - #563 556 fix broken build on master
-2017-03-23 - 1.1a7 - #554 403 conda install cea
-2017-03-22 - 0.1 - #551 Correcting weather file path in the euler readme
-2017-03-22 - 0.1 - #549 I531 new database structure
-2017-03-22 - 0.1 - #548 I529 hideblenght bwidth
-2017-03-21 - 0.1 - #547 I529 hideblenght bwidth
-2017-03-21 - 0.1 - #523 add schedule of Library
-2017-03-21 - 0.1 - #546 Wrong filepath for the weather in the final example
-2017-03-15 - 0.1 - #534 Singapore weather file 2016
-2017-03-08 - 0.1 - #497 Bhargava and daren refactoring
-2017-03-06 - 0.1 - #491 Changing 'DEPO' occupancy to 'PARKING'
-2017-03-03 - 0.1 - #490 I472 sensitivity
-2017-03-03 - 0.1 - #496 I464 technology documentation
-2017-02-24 - 0.1 - #503 Added `LAB` and `MUSEUM` archetypes
-2017-02-24 - 0.1 - #493 Correcting citation
-2017-02-24 - 0.1 - #502 I486 small load bug
-2017-02-23 - 0.1 - #501 added grasshopper file
-2017-02-22 - 0.1 - #499 Fix import arcpy error in ScenarioPlotsTool
-2017-02-10 - 0.1 - #485 I464 analysis
-2017-02-09 - 0.1 - #477 386 create readthedocs style api documentation
-2017-01-27 - 0.1 - #469 I453 optimization refactor
-2017-01-24 - 0.1 - #448 441 create call graph
-2016-12-21 - 0.1 - #434 I416 expand sensitivity
-2016-12-14 - 0.1 - #433 235 move weather files to separate directory
-2016-12-14 - 0.1 - #435 222 check for radiation input in demand script
-2016-12-14 - 0.1 - #432 fixed error handling. error still get's thrown, but the files do not stay open.
-2016-12-08 - 0.1 - #431 split all the tools into separate files
-2016-12-08 - 0.1 - #429 Finished installer for ArcGIS integration
-2016-12-08 - 0.1 - #428 423 fix optimization use of inputlocator
-2016-11-30 - 0.1 - #426 147 refactor embodied.py
-2016-11-30 - 0.1 - #425 I387 ventilation systems
-2016-11-30 - 0.1 - #422 fixes #247 by updating unit tests to reflect changes that had already been made
-2016-11-29 - 0.1 - #419 I415 finish documentation for sensitivity analysis
-2016-11-29 - 0.1 - #413 1270 document optimization
-2016-11-28 - 0.1 - #421 fixes issue #362
-2016-11-15 - 0.1 - #402 Radiation script GUI with longitude and latitude fields
-2016-11-14 - 0.1 - #396 new open case study
-2016-11-10 - 0.1 - #391 I389 embodied energy
-2016-11-02 - 0.1 - #390 I351 the calibrator
-2016-10-17 - 0.1 - #367 I360 calc eaf should be calculated based on aef
-2016-10-17 - 0.1 - #364 I297 tabs temperature
-2016-10-17 - 0.1 - #363 fixes #350
-2016-10-14 - 0.1 - #365 Documentation and refactoring
-2016-10-13 - 0.1 - #361 Documentation and refactoring
-2016-10-12 - 0.1 - #357 Jenkins - adds continuous integration
-2016-10-05 - 0.1 - #348 create the solar radiation folder if it does not yet exist
-2016-09-22 - 0.1 - #340 building_info.py script
-2016-09-22 - 0.1 - #342 I341 demand calculation hq masterplan
-2016-09-07 - 0.1 - #335 I329 bugfix latent cooling load
-2016-09-05 - 0.1 - #325 I35 preserve order of columns when writing out to excel
-2016-08-31 - 0.1 - #328 Rename and column order
-2016-08-30 - 0.1 - #326 fixes #250
-2016-08-26 - 0.1 - #319 I-318 - timeseries interactive graphs
-2016-08-26 - 0.1 - #317 I301 embodied and operational energy
-2016-08-26 - 0.1 - #321 I288 moved requirement for numba to a separate compile script
-2016-08-26 - 0.1 - #316 I282 settingwithcopywarning in cea analysis embodied
-2016-08-26 - 0.1 - #314 I305 running emissions operation error
-2016-08-24 - 0.1 - #313 I286 reduce calculation time for demand graphs
-2016-08-24 - 0.1 - #302 fixes #293 (Full reports not working with tsd as dict)
-2016-08-23 - 0.1 - #311 Removed ExtendInputLocator
-2016-08-23 - 0.1 - #307 i287-problem-demand-graphs
-2016-08-23 - 0.1 - #299 separated electricity demands in output files
-2016-08-23 - 0.1 - #298 I055 floor heating model
-2016-08-22 - 0.1 - #294 start with demand calculation before the beginning of the heating season (dynamic warm up phase)
-2016-08-18 - 0.1 - #284 I257 test py script not working with multiprocessing
-2016-08-17 - 0.1 - #281 I279 investigate numba aot to spead up calc tm
-2016-08-15 - 0.1 - #278 I277 bugfix thermal load
-2016-08-15 - 0.1 - #266 Port to ArcGIS 10.4
-2016-08-08 - 0.1 - #265 I 262 tds creating high overhead
-2016-08-08 - 0.1 - #263 I 262 tds creating high overhead
-2016-07-22 - 0.1 - #260 final remarks in refactoring
-2016-07-22 - 0.1 - #259 I258 refactor functions
-2016-07-18 - 0.1 - #252 Thermal loads with dataframes (and parallelization)
-2016-06-08 - 0.1 - #239 I016 2 simplified new ventilation and thermal loads
-2016-06-07 - 0.1 - #226 I016 thermal loads new ventilation
-2016-06-07 - 0.1 - #229 Scenario plots @daren-thomas great work
-2016-06-07 - 0.1 - #230 I182 benchmark plots @martin-mosteiro great graphs buddy and super interface @daren-thomas
-2016-06-07 - 0.1 - #232 Igraphs totals
-2016-06-06 - 0.1 - #227 I064 1 update results on emission and control system
-2016-06-01 - 0.1 - #225 Changes to reference case folder structure
-2016-05-30 - 0.1 - #223 I221 class for calc loads input
-2016-05-27 - 0.1 - #219 I218 move technical
-2016-05-25 - 0.1 - #216 I215 buxfix ve schedule
-2016-05-25 - 0.1 - #212 I126 ventilation properties to archetypes db
-2016-05-25 - 0.1 - #211 I178 epw data file
-2016-05-24 - 0.1 - #213 I137 radiation script
-2016-05-24 - 0.1 - #199 I137 radiation script
-2016-05-20 - 0.1 - #197 I191 solar to radiation
-2016-05-20 - 0.1 - #195 I181 schedulemaker
-2016-05-18 - 0.1 - #194 I192 full reports
-2016-05-18 - 0.1 - #198 i49-Y-renaming
-2016-05-09 - 0.1 - #176 added `log` method to `GlobalVariables`
-2016-05-04 - 0.1 - #172 I171 refactor calcthermalloads
-2016-05-04 - 0.1 - #175 I173 move storagetank script to core
-2016-05-04 - 0.1 - #174 move storagetank_mixed.py into cea folder
-2016-05-04 - 0.1 - #170 implemented toolbox for heatmaps
-2016-05-04 - 0.1 - #168 I157 update toolbox for graphs
-2016-05-02 - 0.1 - #167 i163-fix-heatmaps (toolbox still needs to be implemented)
-2016-04-25 - 0.1 - #155 I06 archetypes shading fw - with some changes (@JIMENOFONSECA can you check these?)
-2016-04-25 - 0.1 - #153 I027 seperate dhw and sh supply
-2016-04-22 - 0.1 - #152 this should solve the MemoryError shanshan is having
-2016-04-21 - 0.1 - #151 I135 update toolbox new reference case
-2016-04-20 - 0.1 - #150 I114 update scripts
-2016-04-20 - 0.1 - #149 I114 update scripts
-2016-04-13 - 0.1 - #140 Fixed paths to new reference case location
-2016-04-11 - 0.1 - #133 folder 3
-2016-04-11 - 0.1 - #132 folders 2nd modification
-2016-04-11 - 0.1 - #131 folders
-2016-04-08 - 0.1 - #129 delete sensible files
-2016-04-01 - 0.1 - #116 Merge remote-tracking branch 'refs/remotes/origin/master' into i37_Extract_PropertiesTool_etc
-2016-04-01 - 0.1 - #115 I37 extract properties tool etc
-2016-03-31 - 0.1 - #106 Ii023 atot
-2016-03-30 - 0.1 - #103 I099 new properties - seems to be working for now...
+- 2020-02-21 - 2.30.0 - #2590 2586 add electric vehicles and embodied emissions as part of construction
+- 2020-02-21 - 2.30.0 - #2588 2586 plot fixes
+- 2020-02-21 - 2.30.0 - #2587 fixes to database
+- 2020-02-20 - 2.30.0 - #2581 Fix for radiation
+- 2020-02-20 - 2.30.0 - #2579 Separate archetypes into construction_standard and occupancy
+- 2020-02-19 - 2.30.0 - #2571 fix skytemp
+- 2020-02-18 - 2.29.0 - #2574 Use consistent input locator method in building_properties.py
+- 2020-02-18 - 2.29.0 - #2563 2227 negative values in ct
+- 2020-02-17 - 2.29.0 - #2565 Issue databases
+- 2020-02-17 - 2.29.0 - #2557 I2553 restructure database
+- 2020-02-13 - 2.29.0 - #2562 2551 many files optimization
+- 2020-02-13 - 2.29.0 - #2559 Update how-are-schedules-defined.rst
+- 2020-02-11 - 2.29.0 - #2556 `Annual Cost` and `Annual Emissions` plots x-axis are sorted by cost
+- 2020-02-10 - 2.29.0 - #2554 2536 technology editor
+- 2020-02-10 - 2.29.0 - #2550 I2534 opt technologies, merging but sending a new PR with more tests in case functionality is broken (not likely) according to extensive testing.
+- 2020-02-06 - 2.29.0 - #2546 Glossary.csv - synchronized with newest schemas.yml
+- 2020-02-03 - 2.29.0 - #2544 update schemas.yml file to conform to changes in PR 2532
+- 2020-02-03 - 2.29.0 - #2545 Fixed typo in a variable name @martin-mosteiro good catch
+- 2020-01-23 - 2.29.0 - #2542 Release 2.29
+- 2020-01-23 - 2.28.1 - #2526 Fix COOLROOM bug in thermal networks
+- 2020-01-23 - 2.28.1 - #2530 updated schemas.yml with trace-inputlocator output
+- 2020-01-23 - 2.28.1 - #2532 fixed workflow and also bug in supply_systems.xls
+- 2020-01-21 - 2.28.1 - #2528 Fix incorrect locator method @martin-mosteiro great catch!
+- 2020-01-20 - 2.28.1 - #2522 2493 decentralized optimization. Tested with the centralized optimization too. @daren-thomas grande!
+- 2020-01-20 - 2.28.1 - #2523 Typos and nomenclature in thermal networks
+- 2020-01-17 - 2.28.1 - #2521 Open plot in new window @reyery working great!
+- 2020-01-14 - 2.28.1 - #2520 Release 2.28
+- 2020-01-14 - 2.27.0 - #2516 fixing small bugs i2512 and i2509
+- 2020-01-14 - 2.27.0 - #2513 fix nominal cap
+- 2020-01-10 - 2.27.0 - #2517 2511 solar plots
+- 2020-01-10 - 2.27.0 - #2499 @daren-thomas well as soon as this fixes the problem of #2502
+- 2020-01-09 - 2.27.0 - #2503 Fix for scenario creation
+- 2020-01-09 - 2.27.0 - #2412 Simplify environment.ubuntu.yml
+- 2020-01-09 - 2.27.0 - #2492 Fixing plots nyc
+- 2020-01-08 - 2.27.0 - #2497 Rtd build errors
+- 2020-01-07 - 2.27.0 - #2498 Missing input files should create an error, not a success in the jobs list
+- 2019-12-10 - 2.27.0 - #2495 Release 2.27.0
+- 2019-12-06 - 2.26.0a0 - #2481 Show plot input files
+- 2019-12-06 - 2.26.0a0 - #2462 Test epanet - simple thermal model Merging!! wihuu
+- 2019-12-04 - 2.26.0 - #2467 1777 optimize decentralized script for speed
+- 2019-12-03 - 2.26.0 - #2479 Data validation for inputs in front end
+- 2019-12-03 - 2.26.0 - #2478 2477 wrong column name in piping catalog
+- 2019-11-29 - 2.26.0 - #2475 Window to wall ratio and envelope properties
+- 2019-11-26 - 2.26.0 - #2470 Schedule reader to api
+- 2019-11-18 - 2.26.0 - #2466 Release 2.26
+- 2019-11-15 - 2.25.2 - #2455 2349 suspend simulations
+- 2019-11-14 - 2.25.1 - #2448 Ventilation to avoid unrealistically high temperatures during heating season
+- 2019-11-12 - 2.25.1 - #2452 Update epwreader.py
+- 2019-11-11 - 2.25.1 - #2439 Databases major refactoring
+- 2019-11-07 - 2.25.1 - #2444 Update input api
+- 2019-11-06 - 2.25.1 - #2420 I1633 gains and losses proportional to conditioned area
+- 2019-11-05 - 2.25.1 - #2441 Release 2.25, I also updated the CEA website to reflect this
+- 2019-11-04 - 2.24 - #2434 Delete converter_old_schedules_to_csv.py
+- 2019-11-04 - 2.24 - #2437 Update input api
+- 2019-11-04 - 2.24 - #2354 2082 add remaining network plots to dashboard
+- 2019-11-04 - 2.24 - #2431 Update scripts.yml
+- 2019-11-04 - 2.24 - #2433 Update geometry_generator.py
+- 2019-10-31 - 2.24 - #2417 BUGFIX: Handle folder locator methods in TraceInputLocator
+- 2019-10-31 - 2.24 - #2416 Radiation now account for adjacent buildings
+- 2019-10-30 - 2.24 - #2414 Terminate running cea worker processes when closing the GUI @daren-thomas works like a charm, good stuff!
+- 2019-10-30 - 2.24 - #2421 BUGFIX: UnboundLocalError: local variable 'number_of_occupants' referenced before assignment
+- 2019-10-30 - 2.24 - #2415 Allow importing scripts.py from the Grasshopper interface
+- 2019-10-29 - 2.24 - #2419 fix to schedule maker
+- 2019-10-29 - 2.24 - #2411 2392 build the docs
+- 2019-10-29 - 2.24 - #2418 2324 resume workflow feature
+- 2019-10-24 - 2.24 - #2407 Update LCA_infrastructure.xlsx
+- 2019-10-23 - 2.24 - #2398 Update URL for CityEnergyAnalyst-GUI
+- 2019-10-23 - 2.24 - #2400 2399 demand keyerror rhum max pc
+- 2019-10-21 - 2.24 - #2396 Release 2.24
+- 2019-10-21 - 2.23 - #2391 Show plot parameters when adding and changing plots
+- 2019-10-18 - 2.23 - #2383 Fix to load curves plot and to glossary
+- 2019-10-17 - 2.23 - #2382 New Schedules Maker / Model
+- 2019-10-17 - 2.23 - #2384 fix void-deck issues @lguilhermers thanks!, we will implement cell validation in another issue #2141
+- 2019-10-17 - 2.23 - #2390 I816 stop bayesian calibration support @martin-mosteiro alright we take it out
+- 2019-10-15 - 2.23 - #2386 fix coordinate system
+- 2019-10-15 - 2.23 - #2372 2360 create installer for electron interface
+- 2019-10-14 - 2.23 - #2380 2344 multiprocessing and stdout
+- 2019-10-11 - 2.23 - #2374 2356 Update environment.ubuntu.yml
+- 2019-10-11 - 2.23 - #2378 I2204b temperature setpoints finish
+- 2019-10-10 - 2.23 - #2363 I2204 temperature setpoints
+- 2019-10-09 - 2.23 - #2318 Optimization cooling, Alright guys, we are merging and creating more issues should we find more problems.
+- 2019-10-08 - 2.23 - #2365 Ventilation code cleanup
+- 2019-10-08 - 2.23 - #2369 Glossary api for electron
+- 2019-10-07 - 2.23 - #2362 Raise an error for false weather files
+- 2019-10-07 - 2.23 - #2368 Release 2.23
+- 2019-10-02 - 2.22 - #2338 Moving flexibility (concept project) to legacy
+- 2019-10-02 - 2.22 - #2353 Project api for electron application
+- 2019-10-02 - 2.22 - #2337 fix to network layout script (EL is not implemented yet) @daren-thomas thanks for checking this out
+- 2019-09-24 - 2.21 - #2335 Bugfix: Edit selection in input editor does not work if some old values is equal to the new value
+- 2019-09-24 - 2.21 - #2334 Show Es and Ns variable for architecture in dashboard
+- 2019-09-24 - 2.21 - #2320 BUG: fixed default value for workflow parameter
+- 2019-09-23 - 2.21 - #2303 CEA Occupancy-Schedule Updates
+- 2019-09-20 - 2.21 - #2286 Fix to #1271
+- 2019-09-18 - 2.21 - #2319 Bugfix: Dashboard set scenario function not working
+- 2019-09-18 - 2.21 - #2289 2255 thermal network optimization refactoring
+- 2019-09-17 - 2.21 - #2313 set seed for sensitivity analysis test
+- 2019-09-17 - 2.21 - #2299 2192 single plot view
+- 2019-09-17 - 2.21 - #2198 macOS installation guide
+- 2019-09-17 - 2.21 - #2305 2279 show baseline network in input editor
+- 2019-09-16 - 2.21 - #2306 2019.09.16 run radiation daysim from pycharm
+- 2019-09-16 - 2.21 - #2304 Renamed Zurich 2015 and 2016 files
+- 2019-09-13 - 2.21 - #2297 FEATURE: 1926 cea worker / non-blocking tools
+- 2019-09-12 - 2.21 - #2275 2063 process cooling
+- 2019-09-12 - 2.21 - #2301 hotfix for parameters changed in lca_operation
+- 2019-09-12 - 2.21 - #2292 steps for creating a release updated
+- 2019-09-10 - 2.21 - #2251 Change naming of weather files
+- 2019-09-10 - 2.21 - #2284 2277 update new release documentation
+- 2019-09-06 - 2.21 - #2294 Bugfix: BooleanParameter can now decode bool values
+- 2019-09-05 - 2.21 - #2266 Delete cooling_case_workflow.py
+- 2019-09-05 - 2.21 - #2288 FEATURE: New React Dashboard
+- 2019-09-05 - 2.21 - #2290 changing workflows structure
+- 2019-09-04 - 2.21 - #2287 I753 remove global vars last steps
+- 2019-09-03 - 2.21 - #2280 2279 generate network from building supply properties
+- 2019-09-03 - 2.21 - #2281 2256 update conditions to run disconnected_buildings_heating_main @shanshanhsieh elegant fix
+- 2019-08-30 - 2.21 - #2282 I2249 opt cooling
+- 2019-08-26 - 2.21 - #2278 Updated version number, changelog and credits for 2.21
+- 2019-08-26 - 2.20.3 - #2253 Feature: Supply system map plot @daren-thomas merging as we need it to plan for the 30 sec video for Arno
+- 2019-08-23 - 2.20.3 - #2258 2117 weather as input file
+- 2019-08-23 - 2.20.3 - #2257 FEATURE: lazy loading of cea.api module
+- 2019-08-23 - 2.20.3 - #2252 Fix: Add alert when user changes occupancy @reyery thanks for this!
+- 2019-08-22 - 2.20.3 - #2250 753 global variables removal 2.21
+- 2019-08-22 - 2.20.3 - #2248 Add legend toggle drop down to plots
+- 2019-08-21 - 2.20.3 - #2265 FEATURE: allow user-specified region databases for the data-helper
+- 2019-08-13 - 2.20.1 - #2241 updating version, changelog and credits for v2.20
+- 2019-08-13 - 2.19 - #2239 Bugfix: Map not initializing if district data does not exist
+- 2019-08-13 - 2.19 - #2238 Feature: Grid Layout for Dashboard
+- 2019-08-08 - 2.19 - #2216 Bugfix: Add script input validation for dashboard
+- 2019-08-08 - 2.19 - #2225 I2224 optimization heating
+- 2019-08-08 - 2.19 - #2230 fix occupancy
+- 2019-08-05 - 2.19 - #2228 Bugfix: Calculate and save projected coordinate system
+- 2019-08-05 - 2.19 - #2226 I2146 decentralized cooling @shanshanhsieh great! thanks!
+- 2019-08-02 - 2.19 - #2222 I2120 fixing optimization cooling
+- 2019-07-31 - 2.19 - #2160 2150 Feature: cea rename-building
+- 2019-07-29 - 2.19 - #2217 Release 2.19
+- 2019-07-29 - 2.18.1 - #2215 Minor Fix: Add tooltips to plot buttons
+- 2019-07-25 - 2.18.1 - #2209 Add "change plot" button to row layout
+- 2019-07-24 - 2.18.1 - #2191 I2182 read occupancy schedules
+- 2019-07-24 - 2.18.1 - #2203 Closes #2202
+- 2019-07-24 - 2.18.1 - #2199 Heating case workflow
+- 2019-07-23 - 2.18.1 - #2193 2143 document and proof default config
+- 2019-07-23 - 2.18.1 - #2196 I2195 fix vectorized setpoint
+- 2019-07-23 - 2.18.1 - #2161 don't create the inputs folder when opening a project + scenario
+- 2019-07-23 - 2.18.1 - #2194 Fixed typos in error message
+- 2019-07-22 - 2.18.1 - #2159 added more uses to reference-case-cooling
+- 2019-07-22 - 2.18.1 - #2166 I2120 re(making)factor optimization
+- 2019-07-19 - 2.18.1 - #2178 Fix: Dashboard popup tables
+- 2019-07-19 - 2.18.1 - #2181 adding comfort to dashboard
+- 2019-07-18 - 2.18.1 - #2162 FEATURE: New Map Dashboard layout
+- 2019-07-17 - 2.18.1 - #2164 2095 FIXED "ArcGIS interface installation does not work anymore"
+- 2019-07-17 - 2.18.1 - #2090 1870 dashboard settings not working for capex vs opex
+- 2019-07-13 - 2.18.1 - #2158 Thanks @Jack-Hawthorne!
+- 2019-07-12 - 2.18 - #2157 Release 2.18
+- 2019-07-09 - 2.17.1 - #2137 Bugfix for input editor
+- 2019-07-08 - 2.17.1 - #2145 remove faulty input requests
+- 2019-07-05 - 2.17.1 - #2085 1971 check input files
+- 2019-07-03 - 2.17.1 - #2134 Bugfix: Allow decimal values for number inputs
+- 2019-07-03 - 2.17.1 - #2129 Fix to known issues
+- 2019-07-03 - 2.17.1 - #2133 FEATURE: New 500 status error page
+- 2019-07-03 - 2.17.1 - #2128 Minor bugfix for glossary frontend
+- 2019-07-02 - 2.17.1 - #2071 I2015 constant supply temperature at plants
+- 2019-07-02 - 2.17.1 - #2125 FEATURE: Add Glossary Search to Dashboard
+- 2019-07-01 - 2.17 - #2124 Release 2.17
+- 2019-07-01 - 2.17a1 - #2121 Bugfix: Maintain original coordinate system when saving new input files
+- 2019-07-01 - 2.17a1 - #2093 1978 create an uninstaller for the cea sure! @daren-thomas
+- 2019-07-01 - 2.17a0 - #2119 creating warning
+- 2019-07-01 - 2.17a0 - #2118 Bugfix: Update scenario image if zone file is modified
+- 2019-07-01 - 2.17a0 - #2116 FEATURE: Improvements to Dashboard input editor @reyery great job. It works also with files without the reference tab
+- 2019-06-28 - 2.17a0 - #2109 2096 error on creating energy use intensity plot @daren-thomas thanks for this!
+- 2019-06-28 - 2.17a0 - #2106 I1834 description variables
+- 2019-06-28 - 2.17a0 - #2108 Bugfix: REFERENCE column is not added when user changes parameters in zone and district helper
+- 2019-06-28 - 2.17a0 - #2110 I1927 multicriteria for dh cases
+- 2019-06-28 - 2.17a0 - #2103 Add collapsible fields for tools @reyery it works like a charm. Merging this...
+- 2019-06-27 - 2.17a0 - #2101 Update how-to-run-CEA-optimization.rst
+- 2019-06-27 - 2.17a0 - #2099 Fixed documentation build errors
+- 2019-06-25 - 2.17a0 - #2086 2008 demand tool not working when non existing building selected
+- 2019-06-25 - 2.17a0 - #2087 2026 dashboard tools parameters ignored
+- 2019-06-25 - 2.17a0 - #2084 add message for script completion to dashboard
+- 2019-06-24 - 2.16 - #2083 1984 add thermal networks plots to the dashboard
+- 2019-06-21 - 2.16 - #2017 1956 glossary to dashboard
+- 2019-06-19 - 2.16 - #2067 Updated documentation to include trace-inputlocator
+- 2019-06-19 - 2.16 - #2080 Bugfix: Fix terrain boundary caused by rounding error
+- 2019-06-18 - 2.16 - #2076 Bugfix: Ignore REFERENCE when checking columns in data_helper
+- 2019-06-18 - 2.16 - #2077 Bugfix: Remove 'Open project' default value if path does not exists.
+- 2019-06-14 - 2.16 - #2075 Release 2.16
+- 2019-06-13 - 2.15 - #2059 Remove brackets from `sheet_name` instances
+- 2019-06-12 - 2.15 - #2010 Import input files during scenario creation
+- 2019-06-12 - 2.15 - #2055 1961 project overview improvements
+- 2019-06-12 - 2.15 - #2052 Thermal network simulation config file
+- 2019-06-12 - 2.15 - #2034 I1932 process schedules for lab
+- 2019-06-11 - 2.15 - #2022 1949 3d visualization
+- 2019-06-04 - 2.15 - #2050 Improve description of variable `network-type`
+- 2019-06-04 - 2.15 - #2047 Release 2.15
+- 2019-06-04 - 2.14 - #2035 fixes building energy balance plots
+- 2019-06-04 - 2.14 - #2042 fixes #1988
+- 2019-06-03 - 2.14 - #2029 1761 fix grasshopper installer script
+- 2019-05-30 - 2.14 - #2028 Steiner tree and buildings with no demand
+- 2019-05-30 - 2.14 - #2019 1983 add solar technologies plots to the dashboard
+- 2019-05-30 - 2.14 - #1994 Missing cool room and server room loads
+- 2019-05-27 - 2.14 - #1998 I1958 cooling case workflow not working
+- 2019-05-27 - 2.14 - #2009 Closes #1985 add life cycle plots to the dashboard
+- 2019-05-24 - 2.14 - #2003 Closes #1982
+- 2019-05-23 - 2.14 - #2000 I1950 remove arcgis radiation
+- 2019-05-23 - 2.14 - #1997 1987 fix qt conf for installer
+- 2019-05-23 - 2.14 - #1903 Make each function that has occupants have a minimum of one occupant
+- 2019-05-22 - 2.14 - #1993 1955 the installer shows low res icons on the desktop
+- 2019-05-22 - 2.14 - #1992 closes #1960
+- 2019-05-22 - 2.14 - #1963 1868 dashboard file directory opener is not working
+- 2019-05-22 - 2.14 - #1975 2019.05.17 some documentation fixes
+- 2019-05-21 - 2.14 - #1973 Fix for cea install-grasshopper
+- 2019-05-17 - 2.14 - #1972 Release 2.14
+- 2019-05-15 - 2.13.5a1 - #1962 753 remove globalvars
+- 2019-05-15 - 2.13.5a1 - #1959 1942 fix default dashboard plot @reyery good job on this...we are one step further in functionality
+- 2019-05-15 - 2.13.5a1 - #1965 Retain dtypes of dataframe columns @reyery thaks, this works...
+- 2019-05-13 - 2.13.5a1 - #1947 1914 radiation daysim windows installer
+- 2019-05-10 - 2.13 - #1951 1921 dashboard landing page
+- 2019-05-09 - 2.13 - #1948 Update installation-on-euler.rst Sure I can pass this...however we will need to automate this from the dashboard eventually
+- 2019-05-08 - 2.13 - #1944 Add data_source to input table in dashboard @reyery working, I changed the name to "REFERENCE" instead of "data_source" so we do not have problems of truncation
+- 2019-05-07 - 2.13 - #1943 Update installer to retrieve CEA environment from a known location
+- 2019-05-06 - 2.13 - #1936 Updating credits and version number for 2.13
+- 2019-05-06 - 2.12.0a3 - #1941 Update inputs.yml
+- 2019-05-06 - 2.12.0a3 - #1940 1938 relocate side panel links @reyery thanks, it works as expected
+- 2019-05-06 - 2.12.0a3 - #1939 Split coordinates to lat lon input
+- 2019-05-06 - 2.12.0a3 - #1931 1917 create zone shapfile from map
+- 2019-05-06 - 2.12.0a3 - #1905 Add floor cooling to CEA systems
+- 2019-05-03 - 2.12.0a3 - #1929 adding automatic occupancy of site. This closes #1924, closes #1920
+- 2019-05-03 - 2.12.0a3 - #1928 Various small fixes
+- 2019-04-30 - 2.12.0a3 - #1919 1813 Zone Helper
+- 2019-04-30 - 2.12.0a3 - #1922 fix
+- 2019-04-30 - 2.12.0a3 - #1837 I1600 electric and thermal network planning @shanshanhsieh @BhargavaKrishnaSreepathi thanks for the hard work on this. the script works
+- 2019-04-30 - 2.12.0a3 - #1910 I1907 docu new project @Jack-Hawthorne we will pass this since I  was asked for this update for a while
+- 2019-04-26 - 2.12.0a3 - #1908 1828 make one for all installer for windows alrighty merging for now and expecting a solution to the daysim problem as a first step
+- 2019-04-24 - 2.12.0a1 - #1899 Make solar plots run if only one technology is selected
+- 2019-04-24 - 2.12.0a1 - #1900 Shift case studies below sea level to an elevation of 1 meter @martin-mosteiro  great, this works quite well. good fix!
+- 2019-04-24 - 2.12.0a1 - #1906 Add weather file for Dutch case study
+- 2019-04-18 - 2.12.0a1 - #1895 I1826 document optimization in cea @shanshanhsieh great, it looks good
+- 2019-04-18 - 2.12.0a1 - #1880 1869 dashboard plot settings are not working
+- 2019-04-18 - 2.12.0a1 - #1887 Fix typo in `datacenter_loads` @martin-mosteiro, you are the man, thanks for this quick fix
+- 2019-04-18 - 2.12.0a1 - #1877 1069 db metadata
+- 2019-04-16 - 2.12.0a1 - #1885 Restrict length of year to 8760 hours
+- 2019-04-16 - 2.12.0a1 - #1856 1684 test supply system and optimization
+- 2019-04-12 - 2.12.0a1 - #1879 added the schedule information to tutorials
+- 2019-04-12 - 2.12.0a1 - #1872 1827 config file is getting reset to default values after running scripts
+- 2019-04-12 - 2.12.0a1 - #1861 I1859 remove gv from occupancy
+- 2019-04-12 - 2.12.0a1 - #1878 I1871 region parameter
+- 2019-04-11 - 2.12.0a1 - #1874 i1841 Incomplete function call in energy_mix_based_on_technologies_script.py
+- 2019-04-11 - 2.12.0a1 - #1876 1875 fix broken link on dev tutorials
+- 2019-04-11 - 2.12.0a1 - #1846 Remove conda environment creation from jenkins
+- 2019-04-11 - 2.12.0a0 - #1867 Plot cache for dashboard
+- 2019-04-05 - 2.12.0a0 - #1860 753 remove low hanging fruit global variables
+- 2019-04-04 - 2.12.0a0 - #1854 1005 fix installation guide for ubuntu
+- 2019-04-04 - 2.11 - #1850 Automated generation of streets and district file from Open Street Maps for CEA
+- 2019-04-02 - 2.11 - #1845 I1836 network layout
+- 2019-03-28 - 2.11 - #1824 Updated version number and credits for closing milestone M2.11
+- 2019-03-27 - 2.9.2a - #1843 1825 lca calculations fix
+- 2019-03-27 - 2.9.2a - #1839 1811 fix module doc strings
+- 2019-03-27 - 2.9.2a - #1842 advanced tutorials link fixed
+- 2019-03-14 - 2.9.2a - #1820 Adding concept algorithms, building models developed by TUM into CEA @daren-thomas we need this PR to continue., the test pass locally in 2 computers but Jenkins throws the same error of six.
+- 2019-03-14 - 2.9.2a - #1810 Fixing cea optimization plots @daren-thomas we need to merge this to continue with other work. The jenkins still does not work... Tests pass locally..
+- 2019-03-13 - 2.9.2a - #1818 Rename hidden py4design functions in geometry_generator
+- 2019-03-07 - 2.9.2 - #1821 1819 update install doc daysim
+- 2019-03-04 - 2.9.2 - #1809 1808 autodoc build for inputs/outputs graphviz
+- 2019-03-04 - 2.9.2 - #1807 Calculating demand from varying setpoint temperatures
+- 2019-02-25 - 2.9.2 - #1804 1798 re add arcgis
+- 2019-02-25 - 2.9.2 - #1790 1769 reference case open improvement
+- 2019-02-22 - 2.9.2 - #1793 Correct archetypal values of Es for PARKING and COOLROOM
+- 2019-02-21 - 2.9.2 - #1787 1069 document input output variables
+- 2019-02-15 - 2.9.2 - #1795 1784 connectivity network + CEA Open Source + Goodbye ArcGIS
+- 2019-02-12 - 2.9.2 - #1789 1780 thermal network matrix rename
+- 2019-02-12 - 2.9.2 - #1599 Network optimization
+- 2019-02-06 - 2.9.2 - #1788 1729 autodoc error radiation daysim
+- 2019-02-01 - 2.9.2 - #1785 Fixing calc cop ccgt
+- 2019-02-01 - 2.9.2 - #1783 Fixed typo in yearly demand writer that caused issues with operation_costs script
+- 2019-01-31 - 2.9.2 - #1778 I 1767 fix longwave radiation bug
+- 2019-01-30 - 2.9.2 - #1775 Add missing file outputs from representative week method
+- 2019-01-30 - 2.9.2 - #1773 Release 2.9.2
+- 2019-01-29 - 2.9.1 - #1737 I1735 fix full demand reporting
+- 2019-01-29 - 2.9.1 - #1772 updated the install instructions to include size and time
+- 2019-01-24 - 2.9.1 - #1765 a more robust way of getting a Default.gdb workspace for arcgis
+- 2019-01-24 - 2.9.1 - #1759 Show default values for tool parameters in cea and cea-config
+- 2019-01-23 - 2.9.1 - #1756 Fix issue with `mcpcdata_sys_kWperC`
+- 2019-01-23 - 2.9.1 - #1746 adding credits to the best of my knowledge
+- 2019-01-23 - 2.9.0 - #1752 Make sure the Jenkins tests run again @daren-thomas great job!, it passes all the tests locally too!
+- 2019-01-21 - 2.9.0 - #1690 i1679: Varying electrical price integration
+- 2019-01-21 - 2.9.0 - #1661 967 dashboard plots
+- 2019-01-21 - 2.9.0 - #1748 1734 importerror dll load failed fiona ogrext
+- 2019-01-16 - 2.9.0 - #1747 Fix conda environment.yml
+- 2019-01-09 - 2.9.0 - #1740 add new files to output annual aggregation per building
+- 2019-01-09 - 2.9.0 - #1743 updated ArcGIS install instructions
+- 2019-01-07 - 2.9.0 - #1742 I1605 variable naming convention @BhargavaKrishnaSreepathi great! thanks for this!
+- 2019-01-07 - 2.9.0 - #1728 1727 autodoc errors for optimization
+- 2018-12-18 - 2.9.0 - #1721 1717 model existing thermal networks @shanshanhsieh great! thanks for this1
+- 2018-12-18 - 2.9.0 - #1732 1731 autodoc errors for cea tests test dbf
+- 2018-12-18 - 2.9.0 - #1733 1730 Autodoc errors for thermal_network/network_layout
+- 2018-12-13 - 2.9.0 - #1724 Autodoc import error fixed for analysis/clustering
+- 2018-12-13 - 2.9.0 - #1711 updating credits and readme @daren-thomas I have to merge now since, NRF our funding agency needs a link to CEA - credits / manuals etc. urgently.
+- 2018-12-13 - 2.9.0 - #1713 1651 1652 1691 1604 dbf files fix
+- 2018-12-04 - 2.9.0 - #1682 1656 hardcoded regions
+- 2018-11-30 - 2.9.0 - #1702 I1700 net floor area @martin-mosteiro great work. It woudl be also good to change the presentation of what are the inputs of CEA? so we add the new input NS
+- 2018-11-30 - 2.9.0 - #1716 #753 get rid of gv
+- 2018-11-30 - 2.9.0 - #1715 taking gv out of neural network
+- 2018-11-30 - 2.9.0 - #1692 1239 known issues table ref I am merging. a new PR solves the problems of the documentation. thanks @Jack-Hawthorne for this
+- 2018-11-30 - 2.9.0 - #1638 Create warning for RC-model breakdown
+- 2018-11-30 - 2.9.0 - #1707 1706 Stochastic occupancy update @martin-mosteiro great, well caught!
+- 2018-11-30 - 2.9.0 - #1699 Update reference-case-WTP.zip @gabriel-happle great , thanks for this
+- 2018-11-26 - 2.9.0 - #1697 1665 how to create pull request
+- 2018-11-23 - 2.9.0 - #1696 1666 how to document cea update
+- 2018-11-14 - 2.9.0 - #1680 Release 2.9.0
+- 2018-11-14 - 2.9.0 - #1671 I530 floor height
+- 2018-11-12 - 2.9.0 - #1673 adding flag to solve issue
+- 2018-11-09 - 2.9.0 - #1678 I1668 buggy control flow in calc hex heating
+- 2018-11-09 - 2.9.0 - #1677 creating legacy folder
+- 2018-11-09 - 2.9.0 - #1676 I1557 none error
+- 2018-11-09 - 2.9.0 - #1674 Fixing substation.calc_HEX_cooling loop with bhargava
+- 2018-11-09 - 2.9.0 - #1675 753 remove gv log calls
+- 2018-11-08 - 2.9.0 - #1669 adding the 'roles' work
+- 2018-11-08 - 2.9.0 - #1672 fix error message radiation daysim
+- 2018-11-07 - 2.9.0 - #1622 I1541 refactor and rejig optimization
+- 2018-11-06 - 2.9.0 - #1667 RTD - fixes some issues with the documentation
+- 2018-11-05 - 2.9.0 - #1663 delete test_sensible_loads.py
+- 2018-10-30 - 2.9.0 - #1655 I1619 calibration
+- 2018-10-10 - 2.9.0 - #1627 1224 improve runtime for solar collectors
+- 2018-10-08 - 2.9.0 - #1629 1625 figure out why the radiation daysim tool hangs on sabines scenario
+- 2018-10-04 - 2.9.0 - #1615 This is a first stab to updating the documentation
+- 2018-10-02 - 2.9.0 - #1618 967 dashboard - changes so far It runs so I am merging. I guess we can talk about the changes on the presentation of the 18th.
+- 2018-09-20 - 2.7.22 - #1624 Fixing the pyliburo / radiation geometry problems
+- 2018-09-18 - 2.7.22 - #1608 this solves issue #1351
+- 2018-09-08 - 2.7.22 - #1614 Typos and cleanup
+- 2018-09-04 - 2.7.22 - #1603 @daren-thomas great thanks!
+- 2018-08-08 - 2.7.22 - #1601 added ActiveX control bug to Known Issues
+- 2018-08-08 - 2.7.22 - #1602 checked and changed zone geometry dbf to reflect variable names
+- 2018-08-03 - 2.7.22 - #1592 I1588 bugfix aru model
+- 2018-08-03 - 2.7.22 - #1587 LCA database Reference documentation update
+- 2018-07-19 - 2.7.22 - #1586 Correct number of inputs to calc_Qcdataf @martin-mosteiro good catch!
+- 2018-07-16 - 2.7.22 - #1583 Solving issue #1445
+- 2018-07-13 - 2.7.22 - #1558 remove dependency on csv module for grasshopper
+- 2018-07-13 - 2.7.22 - #1579 adding paris
+- 2018-07-13 - 2.7.22 - #1543 I1542 qcre takes 3 arguments
+- 2018-07-06 - 2.7.21 - #1572 fix for selecting a different project
+- 2018-07-05 - 2.7.20 - #1571 I1569 lca comparison plots
+- 2018-07-05 - 2.7.20 - #1566 1564 issue of new technology
+- 2018-07-04 - 2.7.19 - #1561 Fixes for 4day
+- 2018-07-04 - 2.7.19 - #1549 I1545 further enhancements
+- 2018-07-03 - 2.7.17 - #1554 I1553 fix path in individual evaluation
+- 2018-06-29 - 2.7.12 - #1548 fix
+- 2018-06-29 - 2.7.11 - #1547 I1269 interface for individual evaluation
+- 2018-06-29 - 2.7.10 - #1546 1519 new optimization plotting
+- 2018-06-28 - 2.7.9 - #1539 I1494 update network plots
+- 2018-06-22 - 2.7.9 - #1530 Fix to decentralized cooling, where the same name has been referenced for different technologies
+- 2018-06-21 - 2.7.9 - #1528 fixes i1527
+- 2018-06-21 - 2.7.9 - #1526 fixing heatmaps
+- 2018-06-20 - 2.7.9 - #1525 I1501 tap water volume good catch martin. Bear in mind that the result is tap cold water but not the entire water use.
+- 2018-06-20 - 2.7.9 - #1524 BUGFIX for solar:annual-radiation-threshold
+- 2018-06-20 - 2.7.9 - #1523 update to cea-workflow.bat
+- 2018-06-20 - 2.7.9 - #1521 I1164 solar collector temperatures
+- 2018-06-20 - 2.7.9 - #1517 Setting random seed for optimization
+- 2018-06-20 - 2.7.9 - #1520 I1501 fix occupancy and electricity
+- 2018-06-19 - 2.7.9 - #1514 I773 operating cost of solar collectors is not calculated
+- 2018-06-19 - 2.7.8 - #1518 1515 jenkins has a problem
+- 2018-06-19 - 2.7.8 - #1516 check to make sure reference-case really got deleted before cea test
+- 2018-06-19 - 2.7.8 - #1489 Linking lca database to optimization calculations
+- 2018-06-18 - 2.7.8 - #1504 1394 restrict config to script inputs working beautifully @daren-thomas
+- 2018-06-18 - 2.7.8 - #1505 cea-workflow
+- 2018-06-18 - 2.7.8 - #1503 I1409 negative production from solar collectors
+- 2018-06-18 - 2.7.8 - #1463 1238 glossary terms and databases
+- 2018-06-18 - 2.7.8 - #1506 Speed up optimization (low hanging fruit)
+- 2018-06-18 - 2.7.8 - #1508 fixes to run from intermittent generations
+- 2018-06-13 - 2.7.8 - #1499 Readthedocs
+- 2018-06-13 - 2.7.8 - #1460 fix to new project
+- 2018-06-13 - 2.7.8 - #1496 I1476 retrofit potential tool keyerror qhsf mwhyr @martin-mosteiro great thanks for this!
+- 2018-06-13 - 2.7.8 - #1371 I1279 update pressure loss calculation in thermal network matrix
+- 2018-06-12 - 2.7.8 - #1490 1335 import arcgisscripting ImportError: DLL load failed: %1 is not a valid Win32 application.
+- 2018-06-12 - 2.7.8 - #1453 1451/1368 fix databases copy working well and passing the tests in the Arcgis interface
+- 2018-06-12 - 2.7.8 - #1485 Various additions to thermal network matrix @roglen it passess the unittests and the plots look good
+- 2018-06-12 - 2.7.8 - #1459 fix to config and radiation
+- 2018-06-12 - 2.7.8 - #1484 fix to operation_costs script location
+- 2018-06-11 - 2.7.8 - #1474 update documentation with new names for solar collectors
+- 2018-06-11 - 2.7.8 - #1468 Fixes to stack plots
+- 2018-06-11 - 2.7.8 - #1462 Updated LCA infrastructure database for Singapore
+- 2018-06-08 - 2.7.8 - #1456 Limit number of processes of multiprocessing @roglen it works quite good thanks!
+- 2018-06-08 - 2.7.8 - #1454 I1364 change final to sys
+- 2018-06-07 - 2.7.8 - #1431 967 interface and dashboard for the cea. VERY VERY cool stuff. I am loving the editing capabilities. Some of the plots do not work but i guess we can create an issue for that after the next PR passes
+- 2018-06-07 - 2.7.8 - #1427 1238 glossary terms and databases
+- 2018-06-06 - 2.7.8 - #1448 1261 - add note to installation guide
+- 2018-06-05 - 2.7.8 - #1447 Urgent fix for a h5py error that just showed up (failing jenkins tests)
+- 2018-06-05 - 2.7.8 - #1443 fix to ensure a folder is created before it is called
+- 2018-06-05 - 2.7.8 - #1429 I1244 modify solar technology plots and interface. tested and the plots work
+- 2018-06-05 - 2.7.8 - #1438 minor fixes to issues raised in optimization and toolbox
+- 2018-06-05 - 2.7.8 - #1439 update ceajenkins.py to use ngrok.io instead of localtunnel.me
+- 2018-06-05 - 2.7.8 - #1411 I1410 benchmark values
+- 2018-06-05 - 2.7.8 - #1414 fixes #1386 - ArcGIS interface: Plotting tool only works if at least one scenario for comparison is selected
+- 2018-06-04 - 2.7.8 - #1434 1063 issues into rst
+- 2018-06-04 - 2.7.8 - #1424 I928b recovering SuS calibration
+- 2018-06-04 - 2.7.8 - #1432 IMPORTANT SOLAR RADIATION FIX!
+- 2018-06-01 - 2.7.8 - #1397 1263 api build debug
+- 2018-06-01 - 2.7.8 - #1428 1298 api demand building properties
+- 2018-05-31 - 2.7.8 - #1380 I1281 implement reduced time step option for thermal network matrix
+- 2018-05-31 - 2.7.8 - #1358 Cost analysis plots @BhargavaKrishnaSreepathi great job! I created a small issue about a plot. but the rest looks good.
+- 2018-05-30 - 2.7.8 - #1420 this should fix the failing jenkins tests
+- 2018-05-29 - 2.7.8 - #1405 1404 api demand occupancy model
+- 2018-05-28 - 2.7.8 - #1403 907-minor additions
+- 2018-05-25 - 2.7.8 - #1400 fixes #1399
+- 2018-05-25 - 2.7.6 - #1398 1390 arcgis interface should update the config file
+- 2018-05-24 - 2.7.5 - #1396 fixes #1323
+- 2018-05-24 - 2.7.5 - #1395 adding region to data-helper tool
+- 2018-05-24 - 2.7.5 - #1393 1389 weather file cannot be changed from arcgis interface
+- 2018-05-23 - 2.7.4 - #1383 fixed comfort plot: pass down locator and config, fix type
+- 2018-05-23 - 2.7.4 - #1381 I1289 improve solar technology tools
+- 2018-05-23 - 2.7.3 - #1379 1321 arcgis interface plotting of scenario comparison not interactive @daren-thomas it works perfectly fine. I tested it with the open case and the new singaporean case.
+- 2018-05-23 - 2.7.3 - #1378 I1377 cpg problem
+- 2018-05-23 - 2.7.3 - #1356 Fix mobility issue again
+- 2018-05-23 - 2.7.3 - #1372 fix so we do not double account emissions
+- 2018-05-22 - 2.7.1 - #1370 i1369 fix solar technology potential plot when there the total potential is zero
+- 2018-05-21 - 2.7.1 - #1366 fixing issue @martin-mosteiro all the issues regarding the demand plots were merged into master. thanks to @gabriel-happle for quick testing.
+- 2018-05-21 - 2.7.1 - #1362 I1361 fix zero hot water demand
+- 2018-05-21 - 2.7.1 - #1360 I1352 end use plots
+- 2018-05-21 - 2.7.1 - #1348 Solves call from ArcGis
+- 2018-05-18 - 2.7 - #1347 fixes #1346 - Plot tool doesn't work on ArcScene
+- 2018-05-18 - 2.7 - #1299 I1288 substation calling only cooling for design
+- 2018-05-17 - 2.7 - #1345 Demand script output csv columns
+- 2018-05-17 - 2.7 - #1338 I1331 pv panels fail to run
+- 2018-05-17 - 2.7 - #1334 I1305 bug in master
+- 2018-05-17 - 2.7 - #1273 1116 Automated setup of looped networks
+- 2018-05-17 - 2.7 - #1304 Fixes issue in mobility.py
+- 2018-05-17 - 2.7 - #1324 1222 ploting interface for arcgis should show list of buildings
+- 2018-05-15 - 2.7 - #1306 fixing guide
+- 2018-05-15 - 2.7 - #1268 Minimum mass flow
+- 2018-05-14 - 2.7 - #1284 I 1055 more legible plots
+- 2018-05-14 - 2.7 - #1287 i1192-i1286-clean-total-demands-fixed-comfort-plot all plots run correctly
+- 2018-05-09 - 2.7 - #1283 import all functions from math library
+- 2018-05-08 - 2.7 - #1276 done
+- 2018-05-08 - 2.7 - #1274 Quick fix to environment. It helps to get plotly correctly installed.
+- 2018-05-07 - 2.7 - #1266 I 1255 refactoring solar plots
+- 2018-04-27 - 2.7 - #1250 I1248 update thermal network plots
+- 2018-04-27 - 2.7 - #1236 907 update the role of the cea core developers
+- 2018-04-27 - 2.7 - #1251 Integrating cooling technologies into CEA
+- 2018-04-27 - 2.7 - #1265 I1223 issue cooling calc
+- 2018-04-25 - 2.7 - #1260 Removing unnecessary lines in the Zurich-2015.epw
+- 2018-04-20 - 2.7 - #1257 1252-cea-installation
+- 2018-04-19 - 2.7 - #1172 I1138 plots cea arcgis
+- 2018-04-19 - 2.7 - #1249 1225 - Fix arcgis interface folder path pop-up
+- 2018-04-18 - 2.7 - #1235 Minor changes to Windows install
+- 2018-04-18 - 2.7 - #1241 I1233 larger pipe diameters
+- 2018-04-18 - 2.7 - #1237 Updated installation doc
+- 2018-04-17 - 2.7 - #1228 I1169 integrating thermal network matrix with the new demand outputs
+- 2018-04-16 - 2.7 - #1226 fix mcp_kWperK list type
+- 2018-04-13 - 2.7 - #1216 I 209 clean and documented comfort plot
+- 2018-04-13 - 2.7 - #1168 I1152 linking thermal pressure losses to dhn
+- 2018-04-13 - 2.7 - #1206 I 209 psychroplotting for cea
+- 2018-04-13 - 2.7 - #1207 I1193 electricity bug
+- 2018-04-13 - 2.7 - #1208 Fix to unit problem in thermal network matrix
+- 2018-04-11 - 2.7 - #1189 removing faulty control from legacy
+- 2018-04-11 - 2.7 - #1190 I1184 fixing outputs of solar scripts
+- 2018-04-10 - 2.7 - #1203 I1202 fix
+- 2018-04-09 - 2.7 - #1174 I1173 atot calculation
+- 2018-04-09 - 2.7 - #1178 Fix _get_region_specific_db_file
+- 2018-04-05 - 2.7 - #1165 I1024 absorption chiller
+- 2018-04-05 - 2.7 - #1181 adding T4 back to domestic hot water emission system
+- 2018-03-29 - 2.7 - #1171 update test data
+- 2018-03-28 - 2.7 - #1167 Two versions of CEA logo and one MUSES
+- 2018-03-28 - 2.7 - #1133 I1073 stochastic
+- 2018-03-28 - 2.7 - #1159 Cea global constants file creation
+- 2018-03-26 - 2.7 - #1160 I1076 revert to last working
+- 2018-03-23 - 2.7 - #1158 Readthedocs
+- 2018-03-23 - 2.7 - #1157 1156 fix jenkins bug in master
+- 2018-03-22 - 2.7 - #1151 refactoring and re-adding final heating and cooling demand calc
+- 2018-03-22 - 2.7 - #1149 Thermal network plots alternate
+- 2018-03-21 - 2.7 - #1084 Optimization tool box for ArcGIS
+- 2018-03-21 - 2.7 - #1140 I1090 multiprocessing for thermal network
+- 2018-03-16 - 2.7 - #1126 I1058 heat load balance PR apart from optimization folder structure changes @BhargavaKrishnaSreepathi great stuff!
+- 2018-03-16 - 2.7 - #1135 I1132 refix energy balance graph
+- 2018-03-16 - 2.7 - #1122 I1100 longitude problem
+- 2018-03-12 - 2.7 - #1120 I1070 update building energy balance dashboard
+- 2018-03-12 - 2.7 - #1118 I1099 change temperature outputs in sc total and pvt total
+- 2018-03-12 - 2.7 - #1096 Cea open case study updated
+- 2018-03-09 - 2.7 - #1119 Update README.rst
+- 2018-03-08 - 2.7 - #1098 fixes bug with jenkins tests on master (updates radiation data for zurich reference cases)
+- 2018-03-05 - 2.7 - #1097 fixes #1094 @daren-thomas great fix!
+- 2018-03-05 - 2.7 - #1095 fixing path so Singapore case study works
+- 2018-03-05 - 2.7 - #1062 I1018 simple indoor humidity
+- 2018-03-02 - 2.7 - #1077 I1031 implement looped networks
+- 2018-03-02 - 2.7 - #1083 Add a test for sensitivity analysis to the Jenkins tests
+- 2018-03-02 - 2.7 - #1082 I665 export ubg to cea files
+- 2018-03-02 - 2.7 - #1089 implements #957 (Add a "restore defaults" button to the config editor
+- 2018-02-27 - 2.7 - #1056 I985 activation curve
+- 2018-02-26 - 2.7 - #1068 Release 2 7
+- 2018-02-19 - 2.6 - #1051 fix according to calc_temperature_ground
+- 2018-02-15 - 2.6 - #1057 I1052 scenario comparison
+- 2018-02-14 - 2.6 - #1050 I1049 life cycle
+- 2018-02-13 - 2.6 - #1045 Add Zurich 2015 & 2016 weather files
+- 2018-02-08 - 2.6 - #991 966 try plotly dash
+- 2018-02-08 - 2.6 - #1036 I998 update shp for zug
+- 2018-02-08 - 2.6 - #1038 I 974 review thermal network
+- 2018-02-07 - 2.6 - #1030 1013 cea launch tool
+- 2018-02-07 - 2.6 - #1037 994 dashboard building does not work for reference case zug
+- 2018-02-07 - 2.6 - #995 I982 update network shp files
+- 2018-02-05 - 2.6 - #1019 I1015 tutorials movement
+- 2018-02-05 - 2.6 - #1028 Use appropriate InputLocator to list building names
+- 2018-02-02 - 2.6 - #1026 I1014 fix shapefiles create new project
+- 2018-02-02 - 2.6 - #1016 I1012 inconsistent saving of files opt
+- 2018-02-01 - 2.6 - #1009 I1007 radiation prerequisite
+- 2018-02-01 - 2.6 - #1002 I1001 economic plots
+- 2018-01-31 - 2.6 - #1011 I977 solar pot graph
+- 2018-01-31 - 2.6 - #996 fixing errors in electricity load
+- 2018-01-30 - 2.6 - #1004 i997_thermal_network_matrix_does_not_run_for_DH
+- 2018-01-30 - 2.6 - #1006 this should fix #999
+- 2018-01-30 - 2.6 - #993 I987 cea workflow
+- 2018-01-26 - 2.6 - #990 colors added as a class
+- 2018-01-25 - 2.6 - #981 I 975 detailed heat balance
+- 2018-01-25 - 2.6 - #984 I968 opt graphs
+- 2018-01-24 - 2.6 - #980 Incorporating changes to optimization_main file to handle intermediate generations
+- 2018-01-23 - 2.6 - #972 I971 new project tool
+- 2018-01-22 - 2.6 - #976 Renaming tools for ArcGIS
+- 2018-01-18 - 2.6 - #961 created `locator.get_zone_building_names()` and updated most usages
+- 2018-01-17 - 2.6 - #965 I905 dashboard
+- 2018-01-15 - 2.6 - #959 951 chisqprob is deprecated
+- 2018-01-12 - 2.6 - #947 fixes #353
+- 2018-01-10 - 2.6 - #956 quick fix to epwreader
+- 2018-01-10 - 2.6 - #954 904 config file editor
+- 2018-01-10 - 2.6 - #939 937 config calibration
+- 2018-01-09 - 2.6 - #953 steps to avoid Nan's and 0K temperature values
+- 2018-01-09 - 2.6 - #949 i forgot to comment out the creation of test.pyt on `cea install-toolbox`
+- 2017-12-20 - 2.6 - #946 945 modify dynamic supply systems interface
+- 2017-12-18 - 2.6 - #938 heating and cooling season is now extracted from a location specific …
+- 2017-12-14 - 2.6 - #929 Modifying parts of optimization to comply with new config file format
+- 2017-12-11 - 2.6 - #924 Create the release v2.6
+- 2017-12-08 - 2.6rc1 - #932 20171214 bugfixes for master
+- 2017-12-07 - 2.5a4 - #933 930 sensitivity broken
+- 2017-12-04 - 2.5a4 - #916 902 update documentation to reflect cli changes
+- 2017-12-04 - 2.5rc2 - #913 #909 h5py cea
+- 2017-12-01 - 2.5rc1 - #899 I797 daysim for demand2
+- 2017-12-01 - 2.5a2 - #914 excel/shapefiles, references in config file
+- 2017-11-28 - 2.5a1 - #912 adjust office occupant density in SG
+- 2017-11-27 - 2.5a1 - #910 relaxing restrictions on some packages
+- 2017-11-23 - 2.5a0 - #898 Add multiple network cal procedure
+- 2017-11-23 - 2.5a0 - #896 timeseries fix to be compliant with new config file
+- 2017-11-23 - 2.5a0 - #903 Great stuff, thanks for this
+- 2017-11-23 - 2.5a0 - #901 I works fine :-)
+- 2017-11-20 - 2.5a0 - #893 i833 - ArcGIS interfaces
+- 2017-11-14 - 2.4a4 - #889 Removing unnecessary saving of files
+- 2017-11-14 - 2.4a4 - #892 Calculate radiation total from insolation files
+- 2017-11-14 - 2.4a4 - #890 I837 ecocampus demand check
+- 2017-11-13 - 2.4a4 - #835 I833 switch databases
+- 2017-11-10 - 2.4a4 - #884 conversion into hexadecimal notation
+- 2017-11-10 - 2.4a4 - #887 changing the mutation strategy
+- 2017-11-10 - 2.4a4 - #886 fixes #885
+- 2017-11-08 - 2.4a4 - #883 @BhargavaKrishnaSreepathi working good
+- 2017-11-08 - 2.4a4 - #882 changes to incorporate geothermal potential calculations
+- 2017-11-06 - 2.4a4 - #879 Automated file generation which further can be used for plots
+- 2017-11-06 - 2.4a4 - #881 Fixes to optimization to run with new config file
+- 2017-10-27 - 2.4a4 - #878 including centralized supply systems in building HP electricity calculation
+- 2017-10-19 - 2.4a4 - #873 I351x calibrator nn based
+- 2017-10-19 - 2.4a4 - #870 I839 simulate cooling network for ecocampus
+- 2017-10-19 - 2.4a4 - #871 updating reference case open fixing control system of B06
+- 2017-10-19 - 2.4a4 - #869 Small fix to radiation script
+- 2017-10-16 - 2.4a4 - #859 I838 network ecocampus
+- 2017-10-12 - 2.4a4 - #798 I724 daylight saving
+- 2017-10-11 - 2.4a4 - #857 Fix thermal network to match demand columns
+- 2017-10-10 - 2.4a4 - #855 695 document the jenkins setup
+- 2017-10-09 - 2.4a4 - #853 695 document the jenkins setup - think it is now working!
+- 2017-10-09 - 2.4a4 - #852 695 document the jenkins setup - does this change trigger the `run cea test on merge to master` jenkins item?
+- 2017-10-09 - 2.4a4 - #851 695 document the jenkins setup - does the merge-to-master trigger work now?
+- 2017-10-09 - 2.4a4 - #831 695 document the jenkins setup - this should trigger the job "run cea test on merge to master"
+- 2017-10-09 - 2.4a4 - #843 Fix solar technology scripts
+- 2017-10-09 - 2.4a4 - #842 I840 dx minisplit
+- 2017-10-05 - 2.4a4 - #783 437 remove multiprocessing from gv
+- 2017-10-04 - 2.4a4 - #834 I832 minisplit
+- 2017-10-02 - 2.4a4 - #781 I712 sensitivity analysis tool
+- 2017-10-02 - 2.4a4 - #760 I351 calibrator cea
+- 2017-09-27 - 2.4a4 - #788 711 launch tool energy potential analysis
+- 2017-09-27 - 2.4a4 - #791 684 launch tool urban solar radiation
+- 2017-09-27 - 2.4a4 - #784 I268 technology cost database
+- 2017-09-27 - 2.4a4 - #793 723 grasshopper modules for cea
+- 2017-09-27 - 2.4a4 - #725 i636 connect solar collector and pvt with new radiation results. test pass so merging it
+- 2017-09-27 - 2.4a4 - #826 825 test failing in master
+- 2017-09-26 - 2.4a4 - #796 Readthedocs - fix build errors in rtd
+- 2017-09-25 - 2.4a4 - #795 adding guide
+- 2017-08-28 - 2.4a4 - #778 Refactoring labels in saved files to include units
+- 2017-08-22 - 2.4a4 - #779 updates to the documentation - sphinx now builds without warnings
+- 2017-08-16 - 2.4a4 - #777 731 port cea to arcgis 10 5 for computerroom hil e65
+- 2017-08-11 - 2.4a2 - #780 2017 08 09 easier installation guide
+- 2017-07-31 - 2.4a2 - #767 I766 Remove unnecessary error message
+- 2017-07-31 - 2.3 - #765 761 port cea to 64 bit python
+- 2017-07-27 - 2.3 - #763 I672 xls2dbf
+- 2017-07-26 - 2.3 - #716 Adding solution for case when V=0
+- 2017-07-20 - 2.3a1 - #700 I694 archetype application
+- 2017-07-20 - 2.3a1 - #741 I733 cooling conditioned buildings
+- 2017-07-19 - 2.3a1 - #740 I649 decentralized buildings preprocessing
+- 2017-07-14 - 2.3a1 - #686 642 arcgis remember last options
+- 2017-07-14 - 2.3a1 - #732 changes to dhw in database
+- 2017-07-14 - 2.3a1 - #678 I633 interface for solar potential @shanshanhsieh good job!!
+- 2017-07-14 - 2.3a1 - #685 radiation arcgis for ecocampus - giving up, we need this only for the ecocampus case.
+- 2017-07-12 - 2.3a1 - #728 I643 retrofit analysis
+- 2017-07-05 - 2.3a1 - #708 I663 lca tools subfolders
+- 2017-07-05 - 2.3a1 - #707 I383 process heat
+- 2017-07-05 - 2.3a1 - #690 I673 cea optimization workflow
+- 2017-06-30 - 2.3a1 - #680 566 code the program to call cea from gh
+- 2017-06-30 - 2.3a1 - #715 Revert "xls2dbf_new_branch"
+- 2017-06-30 - 2.3a1 - #714 @Khayatian thanks and congrats on your first contrib to CEA!
+- 2017-06-30 - 2.3a1 - #677 I662 ciao citygml
+- 2017-06-29 - 2.3a1 - #702 fixing special case radiation
+- 2017-06-27 - 2.3a1 - #696 cool stuff!, thanks for this, it is much clear
+- 2017-06-23 - 2.3a1 - #693 I372 data helper discrepancy
+- 2017-06-22 - 2.3a1 - #689 I688 fix broken build
+- 2017-06-20 - 2.3a1 - #675 I612 preprocessing multiuse buildings
+- 2017-06-15 - 2.3a1 - #674 645 switch between infiltration models, working like a charm
+- 2017-06-12 - 2.3a1 - #671 Cascading config files
+- 2017-06-12 - 2.3a1 - #656 I655 ctrl vent changes
+- 2017-05-25 - 2.3a1 - #659 minimalistic first stab at a documentation guide
+- 2017-05-24 - 2.3a1 - #653 I648 radaition working
+- 2017-05-19 - 2.3a1 - #627 I613 guide on how files are saved
+- 2017-05-18 - 2.3a1 - #624 607 document steps to create arelease
+- 2017-05-15 - 2.2 - #635 correct conversion of string to integer if dbf file is defined as double accidentally
+- 2017-05-15 - 2.2 - #616 I615 modifying import of dataframes
+- 2017-05-10 - 2.2 - #623 I526 archetypes singapore
+- 2017-05-10 - 2.2 - #629 updated installation-guide because new pandas version breaks geopandas
+- 2017-05-09 - 2.2 - #424 I336 add pv script to the core. @shanshanhsieh great refactoring, I also created a technology database in databases/CH/systems which helps to take out the constant variables of PV technologies, in this way we can try many other PV technologies. Please check it out. Could you also apply this for the sollar collector and PVT script? are there issues already created for this?
+- 2017-05-09 - 2.2 - #631 :-D so the line was just commented...
+- 2017-05-03 - 2.2 - #625 I622 data cleaning ipynb
+- 2017-04-26 - 2.2 - #621 Singapore weather 2015 ok
+- 2017-04-26 - 2.2 - #619 changes naming
+- 2017-04-25 - 2.2 - #567 I9 new radiation engine daysim by paul
+- 2017-04-21 - 2.2 - #611 removing NUS_weather file
+- 2017-04-19 - 2.2a4 - #572 Uncertainty analysis and individual evaluation
+- 2017-04-19 - 2.2a4 - #597 I596 occupancy density
+- 2017-04-18 - 2.2 - #602 I601 installation guide doc
+- 2017-04-18 - 2.2 - #595 I573 fix sax opt
+- 2017-04-18 - 2.2 - #553 Fix errors caused by tank size 0
+- 2017-04-18 - 2.2 - #600 fix environment for running fiona.ogrext - this should fix a lot of installation problems
+- 2017-04-11 - 2.2 - #594 proposal for fixing credits/licenses
+- 2017-04-05 - 2.1 - #588 I587 ventilation bugfix for cisbat
+- 2017-04-03 - 2.1 - #580 i558 Recirculation error fix - replaces PR #559
+- 2017-04-03 - 2.1 - #581 i560 RC model inconsistent inputes - replaces PR #561
+- 2017-04-03 - 2.1 - #579 Replacing #576
+- 2017-04-03 - 2.1 - #582 fixing the arcgis toolbox (import arcpy)
+- 2017-03-31 - 2.1a5 - #578 small fix to sensitivity
+- 2017-03-31 - 2.1a5 - #577 Adding more info on running on Euler
+- 2017-03-31 - 2.1a5 - #557 Adding ETH heating network
+- 2017-03-31 - 2.1a5 - #574 added clarification as per issue #571
+- 2017-03-31 - 2.1a5 - #545 changes to getting started documentation
+- 2017-03-28 - 2.1a5 - #564 Adding missing libraries to the documentation on Euler
+- 2017-03-27 - 2.1a5 - #565 Revert "I9 new radiation engine daysim by paul"
+- 2017-03-27 - 2.1a5 - #500 I9 new radiation engine daysim by paul
+- 2017-03-27 - 2.1a5 - #563 556 fix broken build on master
+- 2017-03-23 - 1.1a7 - #554 403 conda install cea
+- 2017-03-22 - 0.1 - #551 Correcting weather file path in the euler readme
+- 2017-03-22 - 0.1 - #549 I531 new database structure
+- 2017-03-22 - 0.1 - #548 I529 hideblenght bwidth
+- 2017-03-21 - 0.1 - #547 I529 hideblenght bwidth
+- 2017-03-21 - 0.1 - #523 add schedule of Library
+- 2017-03-21 - 0.1 - #546 Wrong filepath for the weather in the final example
+- 2017-03-15 - 0.1 - #534 Singapore weather file 2016
+- 2017-03-08 - 0.1 - #497 Bhargava and daren refactoring
+- 2017-03-06 - 0.1 - #491 Changing 'DEPO' occupancy to 'PARKING'
+- 2017-03-03 - 0.1 - #490 I472 sensitivity
+- 2017-03-03 - 0.1 - #496 I464 technology documentation
+- 2017-02-24 - 0.1 - #503 Added `LAB` and `MUSEUM` archetypes
+- 2017-02-24 - 0.1 - #493 Correcting citation
+- 2017-02-24 - 0.1 - #502 I486 small load bug
+- 2017-02-23 - 0.1 - #501 added grasshopper file
+- 2017-02-22 - 0.1 - #499 Fix import arcpy error in ScenarioPlotsTool
+- 2017-02-10 - 0.1 - #485 I464 analysis
+- 2017-02-09 - 0.1 - #477 386 create readthedocs style api documentation
+- 2017-01-27 - 0.1 - #469 I453 optimization refactor
+- 2017-01-24 - 0.1 - #448 441 create call graph
+- 2016-12-21 - 0.1 - #434 I416 expand sensitivity
+- 2016-12-14 - 0.1 - #433 235 move weather files to separate directory
+- 2016-12-14 - 0.1 - #435 222 check for radiation input in demand script
+- 2016-12-14 - 0.1 - #432 fixed error handling. error still get's thrown, but the files do not stay open.
+- 2016-12-08 - 0.1 - #431 split all the tools into separate files
+- 2016-12-08 - 0.1 - #429 Finished installer for ArcGIS integration
+- 2016-12-08 - 0.1 - #428 423 fix optimization use of inputlocator
+- 2016-11-30 - 0.1 - #426 147 refactor embodied.py
+- 2016-11-30 - 0.1 - #425 I387 ventilation systems
+- 2016-11-30 - 0.1 - #422 fixes #247 by updating unit tests to reflect changes that had already been made
+- 2016-11-29 - 0.1 - #419 I415 finish documentation for sensitivity analysis
+- 2016-11-29 - 0.1 - #413 1270 document optimization
+- 2016-11-28 - 0.1 - #421 fixes issue #362
+- 2016-11-15 - 0.1 - #402 Radiation script GUI with longitude and latitude fields
+- 2016-11-14 - 0.1 - #396 new open case study
+- 2016-11-10 - 0.1 - #391 I389 embodied energy
+- 2016-11-02 - 0.1 - #390 I351 the calibrator
+- 2016-10-17 - 0.1 - #367 I360 calc eaf should be calculated based on aef
+- 2016-10-17 - 0.1 - #364 I297 tabs temperature
+- 2016-10-17 - 0.1 - #363 fixes #350
+- 2016-10-14 - 0.1 - #365 Documentation and refactoring
+- 2016-10-13 - 0.1 - #361 Documentation and refactoring
+- 2016-10-12 - 0.1 - #357 Jenkins - adds continuous integration
+- 2016-10-05 - 0.1 - #348 create the solar radiation folder if it does not yet exist
+- 2016-09-22 - 0.1 - #340 building_info.py script
+- 2016-09-22 - 0.1 - #342 I341 demand calculation hq masterplan
+- 2016-09-07 - 0.1 - #335 I329 bugfix latent cooling load
+- 2016-09-05 - 0.1 - #325 I35 preserve order of columns when writing out to excel
+- 2016-08-31 - 0.1 - #328 Rename and column order
+- 2016-08-30 - 0.1 - #326 fixes #250
+- 2016-08-26 - 0.1 - #319 I-318 - timeseries interactive graphs
+- 2016-08-26 - 0.1 - #317 I301 embodied and operational energy
+- 2016-08-26 - 0.1 - #321 I288 moved requirement for numba to a separate compile script
+- 2016-08-26 - 0.1 - #316 I282 settingwithcopywarning in cea analysis embodied
+- 2016-08-26 - 0.1 - #314 I305 running emissions operation error
+- 2016-08-24 - 0.1 - #313 I286 reduce calculation time for demand graphs
+- 2016-08-24 - 0.1 - #302 fixes #293 (Full reports not working with tsd as dict)
+- 2016-08-23 - 0.1 - #311 Removed ExtendInputLocator
+- 2016-08-23 - 0.1 - #307 i287-problem-demand-graphs
+- 2016-08-23 - 0.1 - #299 separated electricity demands in output files
+- 2016-08-23 - 0.1 - #298 I055 floor heating model
+- 2016-08-22 - 0.1 - #294 start with demand calculation before the beginning of the heating season (dynamic warm up phase)
+- 2016-08-18 - 0.1 - #284 I257 test py script not working with multiprocessing
+- 2016-08-17 - 0.1 - #281 I279 investigate numba aot to spead up calc tm
+- 2016-08-15 - 0.1 - #278 I277 bugfix thermal load
+- 2016-08-15 - 0.1 - #266 Port to ArcGIS 10.4
+- 2016-08-08 - 0.1 - #265 I 262 tds creating high overhead
+- 2016-08-08 - 0.1 - #263 I 262 tds creating high overhead
+- 2016-07-22 - 0.1 - #260 final remarks in refactoring
+- 2016-07-22 - 0.1 - #259 I258 refactor functions
+- 2016-07-18 - 0.1 - #252 Thermal loads with dataframes (and parallelization)
+- 2016-06-08 - 0.1 - #239 I016 2 simplified new ventilation and thermal loads
+- 2016-06-07 - 0.1 - #226 I016 thermal loads new ventilation
+- 2016-06-07 - 0.1 - #229 Scenario plots @daren-thomas great work
+- 2016-06-07 - 0.1 - #230 I182 benchmark plots @martin-mosteiro great graphs buddy and super interface @daren-thomas
+- 2016-06-07 - 0.1 - #232 Igraphs totals
+- 2016-06-06 - 0.1 - #227 I064 1 update results on emission and control system
+- 2016-06-01 - 0.1 - #225 Changes to reference case folder structure
+- 2016-05-30 - 0.1 - #223 I221 class for calc loads input
+- 2016-05-27 - 0.1 - #219 I218 move technical
+- 2016-05-25 - 0.1 - #216 I215 buxfix ve schedule
+- 2016-05-25 - 0.1 - #212 I126 ventilation properties to archetypes db
+- 2016-05-25 - 0.1 - #211 I178 epw data file
+- 2016-05-24 - 0.1 - #213 I137 radiation script
+- 2016-05-24 - 0.1 - #199 I137 radiation script
+- 2016-05-20 - 0.1 - #197 I191 solar to radiation
+- 2016-05-20 - 0.1 - #195 I181 schedulemaker
+- 2016-05-18 - 0.1 - #194 I192 full reports
+- 2016-05-18 - 0.1 - #198 i49-Y-renaming
+- 2016-05-09 - 0.1 - #176 added `log` method to `GlobalVariables`
+- 2016-05-04 - 0.1 - #172 I171 refactor calcthermalloads
+- 2016-05-04 - 0.1 - #175 I173 move storagetank script to core
+- 2016-05-04 - 0.1 - #174 move storagetank_mixed.py into cea folder
+- 2016-05-04 - 0.1 - #170 implemented toolbox for heatmaps
+- 2016-05-04 - 0.1 - #168 I157 update toolbox for graphs
+- 2016-05-02 - 0.1 - #167 i163-fix-heatmaps (toolbox still needs to be implemented)
+- 2016-04-25 - 0.1 - #155 I06 archetypes shading fw - with some changes (@JIMENOFONSECA can you check these?)
+- 2016-04-25 - 0.1 - #153 I027 seperate dhw and sh supply
+- 2016-04-22 - 0.1 - #152 this should solve the MemoryError shanshan is having
+- 2016-04-21 - 0.1 - #151 I135 update toolbox new reference case
+- 2016-04-20 - 0.1 - #150 I114 update scripts
+- 2016-04-20 - 0.1 - #149 I114 update scripts
+- 2016-04-13 - 0.1 - #140 Fixed paths to new reference case location
+- 2016-04-11 - 0.1 - #133 folder 3
+- 2016-04-11 - 0.1 - #132 folders 2nd modification
+- 2016-04-11 - 0.1 - #131 folders
+- 2016-04-08 - 0.1 - #129 delete sensible files
+- 2016-04-01 - 0.1 - #116 Merge remote-tracking branch 'refs/remotes/origin/master' into i37_Extract_PropertiesTool_etc
+- 2016-04-01 - 0.1 - #115 I37 extract properties tool etc
+- 2016-03-31 - 0.1 - #106 Ii023 atot
+- 2016-03-30 - 0.1 - #103 I099 new properties - seems to be working for now...

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -9,6 +9,43 @@ The CEA team
 Starting from version 2.9.1 the credits are structured alphabetically (surname) and split into the categories of developers,
 scrum master, project owner, project sponsor and collaborators.
 
+- Version 2.31.0 - February 2020
+
+    Developers:
+    * [Amr Elesawy](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/amr-elesawy.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+    * [Gabriel Happle](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/gabriel-happle.html)
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+    * [Reynold Mok](http://https://cityenergyanalyst.com/community)
+    * [Martín Mosteiro Romero](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/martin-mosteiro-romero.html)
+    * [Zhongming Shi](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/zhongming-shi.html)
+    * [Bhargava Krishna Sreepathi ](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/sreepathi-bhargava-krishna.html)
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Scrum master:
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Project owner:
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+
+    Project sponsor:
+    * [Arno Schlueter](http://www.systems.arch.ethz.ch/about-us/team/arno-schlueter.html)
+
+    Collaborators:
+    * Sebastian Troiztsch
+    * Jose Bello
+    * Kian Wee Chen
+    * Jack Hawthorne
+    * Fazel Khayatian
+    * Victor Marty
+    * Paul Neitzel
+    * Thuy-An Nguyen
+    * Bo Lie Ong
+    * Lennart Rogenhofer
+    * Toivo Säwén
+    * Tim Vollrath
+
+
 - Version 2.30.0 - February 2020
 
     Developers:

--- a/bin/create-changelog.py
+++ b/bin/create-changelog.py
@@ -107,7 +107,7 @@ def main():
                 continue
             title = read_title(git_output)
             version = read_version(commit_id)
-            print('{date} - {version} - {pr} {title}'.format(
+            print('- {date} - {version} - {pr} {title}'.format(
                 date=date,
                 version=version,
                 pr=pr,

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.30.0"
+__version__ = "2.31.0"
 
 
 class ConfigError(Exception):


### PR DESCRIPTION
This is the result of the M2.31 sprint. We restructured the databases shipped with CEA and fixed some bugs.

**NOTE:** This version uses a scenario format that is incompatible with the one in 2.29.0 (the databases were restructured). If you have an existing scenario, please wait for the next release which will include a migration script to convert it to the new format.

To install it on windows, download and run the attached [Setup_CityEnergyAnalyst_2.30.0.exe](https://github.com/architecture-building-systems/CityEnergyAnalyst/releases/download/v2.30.0/Setup_CityEnergyAnalyst_2.30.0.exe). 
[See the guide for more options.](https://city-energy-analyst.readthedocs.io/en/latest/getting-started.html#install-and-set-up)

From the CHANGELOG:

- 2020-02-21 - 2.30.0 - #2590 2586 add electric vehicles and embodied emissions as part of construction
- 2020-02-21 - 2.30.0 - #2588 2586 plot fixes
- 2020-02-21 - 2.30.0 - #2587 fixes to database
- 2020-02-20 - 2.30.0 - #2581 Fix for radiation
- 2020-02-20 - 2.30.0 - #2579 Separate archetypes into construction_standard and occupancy
- 2020-02-19 - 2.30.0 - #2571 fix skytemp