### PR TITLE
added test_technologies.config to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ recursive-include cea/databases *.xlsx *.xls *.txt *.csv
 include cea/default.config
 include cea/tests/test_calc_thermal_loads.config
 include cea/tests/test_schedules.config
+include cea/tests/test_technologies.config
 include cea/tests/radiation_data/*.csv
 include cea/examples/*.zip
 


### PR DESCRIPTION
The file `test_technologies.config` (used by the unit test `cea/tests/test_technologies.config`) needs to be in MANIFEST.in for it to be packaged by pip. Adding this to fix master in Jenkins.