### PR TITLE
update pip, skipping over the broken version of pip

### DIFF
--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -173,8 +173,9 @@ Section "Base Installation" Base_Installation_Section
     WriteINIStr "$INSTDIR\Dependencies\Python\qt.conf" Paths Libraries "$0/Dependencies/Python/Library/lib"
     WriteINIStr "$INSTDIR\Dependencies\Python\qt.conf" Paths Headers "$0/Dependencies/Python/Library/include/qt"
 
-    # DetailPrint "Updating Pip"
-    # nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip install -U --force-reinstall pip'
+    DetailPrint "Updating Pip"
+    nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip install -U --force-reinstall "pip>=2.20.2"'
+
     DetailPrint "Pip installing CityEnergyAnalyst==${VER}"
     nsExec::ExecToLog '"$INSTDIR\Dependencies\Python\python.exe" -m pip install -U cityenergyanalyst==${VER}'
 


### PR DESCRIPTION
This PR addresses #2596 - it updates the installer to skip a version of pip that was creating an error (`ImportError: Cannot import name 'PackageFinder'`).

Users that have already run into this error will need to uninstall and reinstall the CEA as the faulty version of pip makes bootstrapping its own update impossible.