### PR TITLE
ConfigParser error in workflow

### DIFF
--- a/cea/api.py
+++ b/cea/api.py
@@ -11,13 +11,14 @@ def register_scripts():
     import cea.scripts
     import importlib
 
-    config = cea.config.Configuration()
 
     def script_wrapper(cea_script):
         module_path = cea_script.module
         script_module = importlib.import_module(module_path)
 
-        def script_runner(config=config, **kwargs):
+        def script_runner(config=None, **kwargs):
+            if config is None:
+                config = cea.config.Configuration()
             option_list = cea_script.parameters
             config.restrict_to(option_list)
             for section, parameter in config.matching_parameters(option_list):

--- a/cea/config.py
+++ b/cea/config.py
@@ -36,8 +36,9 @@ class Configuration(object):
         self.sections = collections.OrderedDict([(section_name, Section(section_name, self))
                                                  for section_name in self.default_config.sections()])
 
-        # update cea.config with new options
-        self.save(config_file)
+        # Only write user config if it does not exist
+        if not os.path.exists(CEA_CONFIG):
+            self.save(config_file)
 
     def __getattr__(self, item):
         """Return either a Section object or the value of a Parameter"""


### PR DESCRIPTION
This PR tries to fix #2606 which is caused by some race condition of **multiprocessing** reading/writing `cea.config` file at the same time when running **workflow** script with scripts with  **multiprocessing** on. 

This is caused by multiple factors:
- **multiprocessing** re-importing **workflow** and `cea.api` for each process (how **multiprocessing** works for **Windows** machines)
- `cea.api` creating a new instance of **Configuration** when it is being imported
- `__init__` of **Configuration** object _reads_ then _writes_ the `cea.config` file
- since `cea.config` file is not locked multiple processes could access and modify the file at the same time

This rarely happens but the chance of it happening increases with more processes being used.

To reduce the number of writes by config, it is now only written to disk when it does not exist in the specified path i.e. `~/cea.config`.

Not sure how to test this since this error happens by chance, but based on the logic above, it should be enough to fix this issue.