### PR TITLE
move os.chdir to cea.utilities.pushd

### DIFF
--- a/cea/utilities/__init__.py
+++ b/cea/utilities/__init__.py
@@ -1,6 +1,23 @@
+import os
+
 def remap(x, in_min, in_max, out_min, out_max):
     """
     Scale x from range [in_min, in_max] to [out_min, out_max]
     Based on this StackOverflow answer: https://stackoverflow.com/a/43567380/2260
     """
     return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min
+
+
+class pushd(object):
+    """
+    Manage an os.chdir so that at the end of a with block, the path is set back to what it was
+    """
+    def __init__(self, path):
+        self.old_path = os.getcwd()
+        self.new_path = path
+
+    def __enter__(self):
+        os.chdir(self.new_path)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        os.chdir(self.old_path)


### PR DESCRIPTION
This PR addresses a problem with the Jenkins merge-on-master test: It kept failing in the `decentralized` stage. Turns out, the problem can be traced back to an `os.chdir` in the `thermal-network` script. I've added a utility function `pushd` that can be used with a `with` block that sets the path back to what it was after the `wintr` module is used.