### PR TITLE
2597 gdal daysim variables from pycharm

### DIFF
--- a/cea/resources/radiation_daysim/daysim_main.py
+++ b/cea/resources/radiation_daysim/daysim_main.py
@@ -157,7 +157,12 @@ def isolation_daysim(chunk_n, rad, geometry_3D_zone, locator, settings, max_glob
     # folder for data work
     daysim_dir = locator.get_temporary_file("temp" + str(chunk_n))
     print('isolation_daysim: daysim_dir={daysim_dir}'.format(daysim_dir=daysim_dir))
-    rad.initialise_daysim(daysim_dir, os.path.join(settings.daysim_bin_directory, ''))
+
+    # daysim_bin_directory might contain two paths (e.g. "C:\Daysim\bin;C:\Daysim\lib") - in which case, only
+    # use the "bin" folder
+    bin_directory = [d for d in settings.daysim_bin_directory.split(";") if not d.endswith("lib")][0]
+
+    rad.initialise_daysim(daysim_dir, os.path.join(bin_directory, ''))
     print("\tisolation_daysim: rad.hea_file: {}".format(rad.hea_file))
     print("\tisolation_daysim: rad.hea_filename: {}".format(rad.hea_filename))
     print("\tisolation_daysim: rad.daysimdir_ies: {}".format(rad.daysimdir_ies))

--- a/cea/resources/radiation_daysim/geometry_generator.py
+++ b/cea/resources/radiation_daysim/geometry_generator.py
@@ -44,16 +44,6 @@ __email__ = "cea@arch.ethz.ch"
 __status__ = "Production"
 
 
-# Disable
-def blockPrint():
-    sys.stdout = open(os.devnull, 'w')
-
-
-# Restore
-def enablePrint():
-    sys.stdout = sys.__stdout__
-
-
 def identify_surfaces_type(occface_list):
     roof_list = []
     footprint_list = []
@@ -268,9 +258,8 @@ def building_2d_to_3d(locator, geometry_terrain, config, height_col, nfloor_col)
     return geometry_3D_zone, geometry_3D_surroundings
 
 
-def print_progress(i, n, args, result):
-    print(
-        "Generating geometry for building {i} completed out of {n}: {building}".format(i=i + 1, n=n, building=args[0]))
+def print_progress(i, n, args, _):
+    print("Generating geometry for building {i} completed out of {n}: {b}".format(i=i + 1, n=n, b=args[0]))
 
 
 def are_buildings_close_to_eachother(x_1, y_1, solid2):
@@ -302,7 +291,6 @@ def calc_building_geometry_zone(name, building_solid, data_preprocessed):
             potentially_intersecting_solids.append(solid)
     data_preprocessed.potentially_intersecting_solids = potentially_intersecting_solids
 
-    blockPrint()  # disable annoying printing of Python OCC
     # identify building surfaces according to angle:
     face_list = py3dmodel.fetch.faces_frm_solid(building_solid)
     facade_list_north, facade_list_west, \
@@ -497,7 +485,10 @@ def calc_windows_walls(facade_list, wwr, data_processed):
 
 
 def calc_intersection_face_solid(index, data_processed):
-    if calculate.point_in_solid(data_processed.point_to_evaluate, data_processed.potentially_intersecting_solids[index]):
+    with cea.utilities.devnull():
+        point_in_solid = calculate.point_in_solid(data_processed.point_to_evaluate,
+                                                  data_processed.potentially_intersecting_solids[index])
+    if point_in_solid:
         intersects = 1
     else:
         intersects = 0

--- a/cea/resources/radiation_daysim/radiation_main.py
+++ b/cea/resources/radiation_daysim/radiation_main.py
@@ -463,6 +463,10 @@ def main(config):
     # BUGFIX for PyCharm: the PATH variable might not include the daysim-bin-directory, so we add it here
     os.environ["PATH"] = config.radiation.daysim_bin_directory + os.pathsep + os.environ["PATH"]
     os.environ["RAYPATH"] = config.radiation.daysim_bin_directory
+    if not "PROJ_LIB" in os.environ:
+        os.environ["PROJ_LIB"] = os.path.join(os.path.dirname(sys.executable), "Library", "share")
+    if not "GDAL_DATA" in os.environ:
+        os.environ["GDAL_DATA"] = os.path.join(os.path.dirname(sys.executable), "Library", "share", "gdal")
 
     print("verifying geometry files")
     print(locator.get_zone_geometry())

--- a/cea/resources/radiation_daysim/radiation_main.py
+++ b/cea/resources/radiation_daysim/radiation_main.py
@@ -202,8 +202,7 @@ def check_daysim_bin_directory(path_hint):
     :param str path_hint: The path to check first, according to the `cea.config` file.
     :return: path_hint, contains the Daysim binaries - otherwise an exception occurrs.
     """
-    required_binaries = ["ds_illum", "epw2wea", "gen_dc", "isotrop_sky", "oconv", "radfiles2daysim", "rayinit",
-                         "rtrace_dc"]
+    required_binaries = ["ds_illum", "epw2wea", "gen_dc", "oconv", "radfiles2daysim", "rtrace_dc"]
     required_libs = ["rayinit.cal", "isotrop_sky.cal"]
 
     def contains_binaries(path):
@@ -274,7 +273,7 @@ class CEARad(py2radiance.Rad):
             print('`{}` completed'.format(cmd))
         else:
             # Stops script if commands fail (i.e non-zero exit code)
-            subprocess.check_call(cmd, cwd=cwd, stderr=subprocess.STDOUT)
+            subprocess.check_call(cmd, cwd=cwd, stderr=subprocess.STDOUT, env=os.environ)
 
     def execute_epw2wea(self, epwweatherfile, ground_reflectance=0.2):
         daysimdir_wea = self.daysimdir_wea

--- a/cea/utilities/__init__.py
+++ b/cea/utilities/__init__.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 
 def remap(x, in_min, in_max, out_min, out_max):
@@ -36,3 +37,20 @@ class pushd(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         os.chdir(self.old_path)
+
+
+class devnull(object):
+    """
+    Suppress sys.stdout so that it goes to devnull for duration of the with block
+    """
+    def __init__(self):
+        self.stdout = sys.stdout
+
+    def __enter__(self):
+        sys.stdout = self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        sys.stdout = self.stdout
+
+    def write(self, _):
+        pass


### PR DESCRIPTION
This PR fixes 

- #2597 (GDAL and DAYSIM environment variables are not set for users running scripts from PyCharm) 
- #2589 (Function checking for DAYSIM binaries for radiation script does not pass binaries installed by DAYSIM installer)

I've tried a bunch of combinations, but please try to break this:

- remove the folder `C:\Daysim` (e.g. rename it to `C:\Daysim.bak`
- remove the Daysim installation from the CEA installer (check the `Dependencies` folder)

Running the scripts works from PyCharm as well as from the command line. I think we're done here.


