### PR TITLE
Plot data export

### DIFF
--- a/cea/interfaces/dashboard/api/dashboard.py
+++ b/cea/interfaces/dashboard/api/dashboard.py
@@ -246,4 +246,7 @@ class DashboardPlotInputFiles(Resource):
         dashboard = dashboards[dashboard_index]
         plot = dashboard.plots[plot_index]
 
-        return [locator_method(*args) for locator_method, args in plot.input_files]
+        data_path = plot.plot_data_to_file()
+        input_paths = [locator_method(*args) for locator_method, args in plot.input_files]
+
+        return {'inputs': input_paths, 'data': [data_path] if data_path else []}

--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -165,7 +165,31 @@ class PlotBase(object):
         fig['layout'] = dict(fig['layout'], **{'margin': dict(l=50, r=50, t=50, b=50), 'hovermode': 'closest', 'font': dict(size=10)})
         fig['layout']['yaxis'] = dict(fig['layout']['yaxis'], **{'hoverformat': ".2f"})
         div = plotly.offline.plot(fig, output_type='div', include_plotlyjs=False, show_link=False)
+        df = self._plot_data_to_dataframe(fig.data)
         return div
+
+    def _plot_data_to_dataframe(self, plotly_data):
+        from pprint import pprint
+        import pandas as pd
+
+        data = []
+        for trace in plotly_data:
+            name = trace.get('name')
+            x = trace.get('x')
+            y = trace.get('y')
+            if x is not None and y is not None:
+                if trace.type not in ['scattergl']:
+                    df = pd.DataFrame({name: list(y)}, index=list(x))
+                    data.append(df)
+                else:
+                    print(trace.type)
+        if data:
+            data = pd.concat(data, axis=1)
+            data.to_csv(os.path.splitext(self.output_path)[0] + '.csv')
+        else:
+            data = None
+        print(data)
+        return data
 
     def table_div(self):
         """Returns the html div for a table, or an empty string if no table is to be produced"""

--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -161,13 +161,12 @@ class PlotBase(object):
         return self.cache.lookup_plot_div(self, self._plot_div_producer)
 
     def _plot_div_producer(self):
-        fig = self._plot_figure_producer()
-        fig['layout'].update({
-            'margin': dict(l=50, r=50, t=50, b=50),
-            'hovermode': 'closest',
-            'font': dict(size=10),
-            'yaxis': dict(hoverformat=".2f")
-        })
+        fig = plotly.graph_objs.Figure(data=self._plot_data_producer(), layout=self.layout)
+        fig['layout'].update(dict(hovermode='closest'))
+        fig['layout']['yaxis'].update(dict(hoverformat=".2f"))
+        fig['layout']['margin'].update(dict(l=50, r=50, t=50, b=50))
+        fig['layout']['font'].update(dict(size=10))
+
         div = plotly.offline.plot(fig, output_type='div', include_plotlyjs=False, show_link=False)
         return div
 

--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -185,9 +185,11 @@ class PlotBase(object):
 
         # Return None if plotly data does not exist
         if plotly_data is None:
+            print("Unable to find plot data found for '{}'".format(self.name))
             return None
 
         x_axis = self.layout['xaxis']['title'] if 'xaxis' in self.layout else ''
+        y_axis = self.layout['yaxis']['title']
 
         data = []
         scatter_plots = collections.OrderedDict()
@@ -198,7 +200,9 @@ class PlotBase(object):
             if x is not None and y is not None and len(x) == len(y):
                 if 'yaxis' in trace:  # Assign correct title if plot contains multiple y_axis
                     y_axis_num = trace['yaxis'].split('y')[1]
+                    y_axis = self.layout['yaxis{}'.format(y_axis_num)]['title'] or y_axis
 
+                if trace['type'] == 'bar':
                     column_name = name
                     units = re.search(r'\[.*?\]', y_axis)
                     if units:
@@ -231,6 +235,7 @@ class PlotBase(object):
         else:  # Return None if could not parse any data from plot
             output_path = None
 
+        print("Written '{}' plot data to {}".format(self.name, output_path))
         return output_path
 
     def table_div(self):

--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -224,16 +224,19 @@ class PlotBase(object):
                 except Exception as e:
                     print(e)
             # Export data as .csv
-            data.to_csv(os.path.splitext(self.output_path)[0] + '.csv')
+            output_path = os.path.splitext(self.output_path)[0] + '.csv'
+            data.to_csv(output_path)
         elif scatter_plots:
             # Export data as .xlsx
-            with pd.ExcelWriter(os.path.splitext(self.output_path)[0] + '.xlsx') as writer:
+            output_path = os.path.splitext(self.output_path)[0] + '.xlsx'
+            with pd.ExcelWriter(output_path) as writer:
                 for data_name, scatter_data in scatter_plots.items():
                     sheet_name = data_name[:31]  # Sheet name cannot be more than 31 characters
                     scatter_data.to_excel(writer, sheet_name=sheet_name)
         else:  # Return None if could not parse any data from plot
-            data = None
-        return data
+            output_path = None
+
+        return output_path
 
     def table_div(self):
         """Returns the html div for a table, or an empty string if no table is to be produced"""

--- a/cea/plots/cache.py
+++ b/cea/plots/cache.py
@@ -81,22 +81,22 @@ class PlotCache(object):
         return table_div
 
     def lookup_plot_data(self, plot, producer):
-        """Lookup the cache of a plot_figure created with plot._plot_figure_producer"""
+        """Lookup the cache of a plotly graph data created with plot.calc_graph"""
         data_path = os.path.join(plot.category_name, plot.id())
-        figure_file = self._cached_data_file(data_path, plot.parameters) + '.figure'
-        cache_timestamp = self.cache_timestamp(figure_file)
+        data_file = self._cached_data_file(data_path, plot.parameters) + '.graphdata'
+        cache_timestamp = self.cache_timestamp(data_file)
         if cache_timestamp < self.newest_dependency(plot.input_files):
-            plot_figure_data = producer()
-            folder = os.path.dirname(figure_file)
+            plot_data = producer()
+            folder = os.path.dirname(data_file)
             if not os.path.exists(folder):
                 os.makedirs(folder)
-            with open(figure_file, 'w') as figure_json:
-                data_json = json.dumps(plot_figure_data, cls=PlotlyJSONEncoder)
-                figure_json.write(data_json)
+            with open(data_file, 'w') as data_json_path:
+                data_json = json.dumps(plot_data, cls=PlotlyJSONEncoder)
+                data_json_path.write(data_json)
         else:
-            with open(figure_file, 'r') as figure_json:
-                plot_figure_data = json.loads(figure_json.read())
-        return plot_figure_data
+            with open(data_file, 'r') as data_json_path:
+                plot_data = json.loads(data_json_path.read())
+        return plot_data
 
     def cache_timestamp(self, path):
         """Return a timestamp (like ``os.path.getmtime``) to compare to. Returns 0 if there is no data in the cache"""

--- a/cea/plots/categories.py
+++ b/cea/plots/categories.py
@@ -103,18 +103,24 @@ class PlotCategory(object):
 if __name__ == '__main__':
     config = cea.config.Configuration()
     cache = cea.plots.cache.NullPlotCache()
+    errors = []
 
     for category in list_categories():
         print('category:', category.name, ':', category.label)
         for plot_class in category.plots:
-            print('plot_class:', plot_class)
-            parameters = {
-                k: config.get(v) for k, v in plot_class.expected_parameters.items()
-            }
-            plot = plot_class(config.project, parameters=parameters, cache=cache)
-            assert plot.name, 'plot missing name: %s' % plot
-            assert plot.category_name == category.name
-            print('plot:', plot.name, '/', plot.id(), '/', plot.title)
+            try:
+                print('plot_class:', plot_class)
+                parameters = {
+                    k: config.get(v) for k, v in plot_class.expected_parameters.items()
+                }
+                plot = plot_class(config.project, parameters=parameters, cache=cache)
+                assert plot.name, 'plot missing name: %s' % plot
+                assert plot.category_name == category.name
+                print('plot:', plot.name, '/', plot.id(), '/', plot.title)
 
-            # plot the plot!
-            plot.plot()
+                # plot the plot!
+                plot.plot()
+            except Exception as e:
+                errors.append(e)
+
+    print('errors', errors)

--- a/cea/plots/categories.py
+++ b/cea/plots/categories.py
@@ -101,6 +101,7 @@ class PlotCategory(object):
 
 
 if __name__ == '__main__':
+    from pprint import pprint
     config = cea.config.Configuration()
     cache = cea.plots.cache.NullPlotCache()
     errors = []
@@ -120,7 +121,11 @@ if __name__ == '__main__':
 
                 # plot the plot!
                 plot.plot()
-            except Exception as e:
-                errors.append(e)
 
-    print('errors', errors)
+                # write plot data
+                plot.plot_data_to_file()
+
+            except Exception as e:
+                errors.append({'plot': plot_class, 'error': e})
+
+    pprint(errors)


### PR DESCRIPTION
This PR resolves #2628 and add the ability to export plot data to .csv/.xlsx files for users.

This is done by parsing the data found in the plots that are encoded in the Plotly format to pandas dataframes and then exported. That means that this is actually an extra step since we are already calculating the data using dataframes before converting them to the Plotly format. If I'm not wrong, Plotly v3 actually has methods to plot straight from dataframes instead using Plotly graph objects in v2 that we are using now.

The current way it is implemented is more of a workaround than an actual solution. It would not exactly work on mostly plots but works best on plots that are purely made up of bar graph objects. However this should be sufficient for our needs now. I did not want to over-engineer this solution in the hopes that refactoring the plot classes and upgrading Plotly python library to be the wiser solution moving forward.