### PR TITLE
CityEnergyAnalyst v3.0.3a0

### DIFF
--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.0.2"
+__version__ = "3.0.3a0"
 
 
 class ConfigError(Exception):


### PR DESCRIPTION
This PR addresses #2690 by creating a new Installer based on the current master status.

- I was able to reproduce the bug in #2690 (v3.0.2) after uninstalling and re-installing that version
- based on master, I created the release v3.0.3a0 and tested it (again, after uninstalling v3.0.2)
- I was NOT able to reproduce the bug with the new installer, further, the error I suspected (missing `inputs.yml` in `MANIFEST.in`) has since been fixed in master.

I suggest this PR can be merged as the only change is the new version number.