### PR TITLE
added a fix for _ensure_folder method in /cea/inputlocator.py

### DIFF
--- a/cea/inputlocator.py
+++ b/cea/inputlocator.py
@@ -4,8 +4,7 @@ inputlocator.py - locate input files by name based on the reference folder struc
 import os
 import shutil
 import tempfile
-
-import cea.config
+import time
 
 __author__ = "Daren Thomas"
 __copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"
@@ -35,7 +34,12 @@ class InputLocator(object):
         If it doesn't exist yet, attempt to make it with `os.makedirs`."""
         folder = os.path.join(*components)
         if not os.path.exists(folder):
-            os.makedirs(folder)
+            try:
+                os.makedirs(folder)
+            except OSError as e:
+                time.sleep(0.5)
+                if not os.path.exists(folder):
+                    raise e
         return folder
 
     def ensure_parent_folder_exists(self, file_path):


### PR DESCRIPTION
As discussed in issue #2687 this fix attempts to catch the situation where multiple processes attempt to create the same folder simultaneously. The fix catches a generic OSError, forces a time.sleep of 500ms and checks if the folder was indeed created. 

Since the error is difficult to catch, the following test script can be used (script might need to be run several times in order to catch the error).

```
import os
import time
from multiprocessing import Pool

THIS_DIR = os.path.dirname(os.path.realpath(__file__))


##################################################
def return_folder_name(_):
    folder = os.path.join(THIS_DIR, "test_folder")
    if not os.path.exists(folder):
        try:
            print "making a folder"
            os.mkdir(folder)
        except OSError as e:
            print "failed to make a folder"
            time.sleep(0.5)
            if not os.path.exists(folder):
                raise e
    return folder


##################################################
def main():
    folder = "test_folder"
    if os.path.exists(folder):
        os.rmdir(folder)
    p = Pool(4)
    p.map(return_folder_name, [None for i in range(4)])
    p.close()


##################################################
if __name__ == "__main__":
    for i in range(250):
        print "main is at iter [%d]" %i
        main()

```