### PR TITLE
Update plotly version

### DIFF
--- a/cea/interfaces/dashboard/plots/routes.py
+++ b/cea/interfaces/dashboard/plots/routes.py
@@ -52,6 +52,7 @@ def route_div(dashboard_index, plot_index):
         return render_missing_data(plot.missing_input_files())
     except NotImplementedError as e:
         return make_response('<p>{message}</p>'.format(message=e.message), 404)
+    # Remove parent <div> if exists due to plotly v4
     if plot_div.startswith("<div>"):
         plot_div = plot_div[5:-5].strip()
     # BUGFIX for (#2102 - Can't add the same plot twice in a dashboard)

--- a/cea/interfaces/dashboard/plots/routes.py
+++ b/cea/interfaces/dashboard/plots/routes.py
@@ -52,6 +52,8 @@ def route_div(dashboard_index, plot_index):
         return render_missing_data(plot.missing_input_files())
     except NotImplementedError as e:
         return make_response('<p>{message}</p>'.format(message=e.message), 404)
+    if plot_div.startswith("<div>"):
+        plot_div = plot_div[5:-5].strip()
     # BUGFIX for (#2102 - Can't add the same plot twice in a dashboard)
     # update id of div to include dashboard_index and plot_index
     if plot_div.startswith("<div id="):

--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -181,7 +181,7 @@ class PlotBase(object):
         fig['layout']['margin'].update(dict(l=50, r=50, t=50, b=50))
         fig['layout']['font'].update(dict(size=10))
 
-        if self.timeframe in ['daily', 'weekly']:
+        if self.timeframe is not None:
             # Try to get plot year from data
             try:
                 plot_year = fig['data'][0]['x'][0].year

--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -224,6 +224,11 @@ class PlotBase(object):
                     y_axis_num = trace['yaxis'].split('y')[1]
                     y_axis = self.layout['yaxis{}'.format(y_axis_num)]['title'] or y_axis
 
+                # Fix for plotly v4
+                if hasattr(x_axis, 'text'):
+                    x_axis = x_axis.text
+                    y_axis = y_axis.text
+
                 if trace['type'] == 'bar':
                     column_name = name
                     units = re.search(r'\[.*?\]', y_axis)

--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -168,6 +168,13 @@ class PlotBase(object):
         return self.cache.lookup_plot_div(self, self._plot_div_producer)
 
     def _plot_div_producer(self):
+        # Set default color template to 'none' for plotly version 4
+        try:
+            import plotly.io as pio
+            pio.templates.default = 'none'
+        except ImportError:
+            pass
+
         fig = plotly.graph_objs.Figure(data=self._plot_data_producer(), layout=self.layout)
         fig['layout'].update(dict(hovermode='closest'))
         fig['layout']['yaxis'].update(dict(hoverformat=".2f"))

--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -181,6 +181,14 @@ class PlotBase(object):
         fig['layout']['margin'].update(dict(l=50, r=50, t=50, b=50))
         fig['layout']['font'].update(dict(size=10))
 
+        if self.timeframe in ['daily', 'weekly']:
+            # Try to get plot year from data
+            try:
+                plot_year = fig['data'][0]['x'][0].year
+                fig['layout']['xaxis']['rangebreaks'] = [dict(values=["{year}-02-29".format(year=plot_year)])]
+            except Exception as e:
+                print(e)
+
         div = plotly.offline.plot(fig, output_type='div', include_plotlyjs=False, show_link=False)
         return div
 

--- a/cea/plots/demand/comfort_chart.py
+++ b/cea/plots/demand/comfort_chart.py
@@ -268,7 +268,7 @@ def create_relative_humidity_lines():
     for rh_line in rh_lines:
 
         y_data = calc_constant_rh_curve(t_axis, rh_line, P_ATM)
-        trace = go.Scattergl(x=t_axis, y=y_data, mode='line', name="{:.0%} relative humidity".format(rh_line),
+        trace = go.Scattergl(x=t_axis, y=y_data, mode='lines', name="{:.0%} relative humidity".format(rh_line),
                            line=dict(color=COLORS_TO_RGB['grey_light'], width=1), showlegend=False)
         traces.append(trace)
 

--- a/cea/plots/demand/peak_load.py
+++ b/cea/plots/demand/peak_load.py
@@ -37,7 +37,7 @@ class PeakLoadCurvePlot(cea.plots.demand.DemandPlotBase):
             building_data = self.data.iloc[0]
             traces = []
             area = building_data["GFA_m2"]
-            x = ["Absolute [kW]", "Relative [kW/m2]"]
+            x = ["Absolute [kW]", "Relative [W/m2]"]
             for field in analysis_fields:
                 name = NAMING[field]
                 y = [building_data[field], building_data[field] / area * 1000]

--- a/cea/plots/optimization/a_pareto_curve.py
+++ b/cea/plots/optimization/a_pareto_curve.py
@@ -101,7 +101,7 @@ class ParetoCurveForOneGenerationPlot(cea.plots.optimization.GenerationPlotBase)
         ys = data_today[self.objectives[1]].values
         name = "Today"
         trace = go.Scattergl(x=xs, y=ys, mode='markers', name="Today's system", text=name,
-                             marker=dict(size='18', color='black', line=dict(color='black',width=2)))
+                             marker=dict(size=18, color='black', line=dict(color='black',width=2)))
         graph.append(trace)
 
         # PUT THE PARETO CURVE INSIDE
@@ -114,7 +114,7 @@ class ParetoCurveForOneGenerationPlot(cea.plots.optimization.GenerationPlotBase)
         individual_names = data['individual_name'].values
 
         trace = go.Scattergl(x=xs, y=ys, mode='markers', name='Pareto optimal systems', text=individual_names,
-                             marker=dict(size='18', color=zs,
+                             marker=dict(size=18, color=zs,
                                          colorbar=go.ColorBar(title=self.titlez, titleside='bottom'),
                                          colorscale='Jet', showscale=True, opacity=0.8))
         graph.append(trace)
@@ -125,7 +125,7 @@ class ParetoCurveForOneGenerationPlot(cea.plots.optimization.GenerationPlotBase)
         ys = final_dataframe[self.objectives[1]].values
         name = final_dataframe["Attribute"].values
         trace = go.Scattergl(x=xs, y=ys, mode='markers', name="Multi-criteria system", text=name,
-                             marker=dict(size='18', color='white', line=dict(
+                             marker=dict(size=18, color='white', line=dict(
                                  color='black',
                                  width=2)))
         graph.append(trace)

--- a/cea/plots/solar_potential/a_solar_radiation.py
+++ b/cea/plots/solar_potential/a_solar_radiation.py
@@ -83,7 +83,7 @@ def main():
     import cea.plots.cache
     config = cea.config.Configuration()
     locator = cea.inputlocator.InputLocator(config.scenario)
-    cache = cea.plots.cache.PlotCache(config.project)
+    cache = cea.plots.cache.NullPlotCache()
     SolarRadiationPlot(config.project, {'buildings': None,
                                         'scenario-name': config.scenario_name,
                                         'timeframe': config.plots.timeframe,

--- a/cea/plots/thermal_networks/b_demand_curve.py
+++ b/cea/plots/thermal_networks/b_demand_curve.py
@@ -35,7 +35,7 @@ class LossCurvePlot(cea.plots.thermal_networks.ThermalNetworksPlotBase):
     def layout(self):
         return dict(yaxis=dict(title=self.yaxis_title), xaxis=dict(rangeselector=dict(buttons=list([
             dict(count=1, label='1d', step='day', stepmode='backward'),
-            dict(count=1, label='1w', step='week', stepmode='backward'),
+            dict(count=7, label='1w', step='day', stepmode='backward'),
             dict(count=1, label='1m', step='month', stepmode='backward'),
             dict(count=6, label='6m', step='month', stepmode='backward'),
             dict(count=1, label='1y', step='year', stepmode='backward'),


### PR DESCRIPTION
This PR fixes #2682 and #2683. It changes the **Relative** units for **Peak Demand** from `kW/m2` to `W/m2`. Also updates code to be compatible with the latest **Plotly** version (v4) which allows us to use `rangebreaks` to hide leap day from the x-axis.

Testing:
- Run **Peak Demand** from **Demand** and check the plot on the right
- Use data from a leap year and run `run_all_plots` test to make sure that all plots can be plotted. Solar radiation plot should still have the leap day.
- Update `plotly` using `pip install -U plotly` in the CEA console.
-  Run `run_all_plots` test to make sure that all plots can be plotted. Solar radiation plot should not have the leap day.

Would need to update **Dependencies.7z** to include the new version of **Plotly**