### PR TITLE
Small performance optimization for detailed thermal-network script

### DIFF
--- a/cea/datamanagement/database_migrator.py
+++ b/cea/datamanagement/database_migrator.py
@@ -124,7 +124,7 @@ def migrate_2_29_to_2_31(scenario):
     os.remove(occupancy_dbf_path)
     print("- removing invalid input-tables (NOTE: run archetypes-mapper again)")
     for fname in {"supply_systems.dbf", "internal_loads.dbf", "indoor_comfort.dbf",
-                  "air_conditioning_systems.dbf", "architecture.dbf"}:
+                  "air_conditioning.dbf", "architecture.dbf"}:
         fpath = os.path.join(scenario, "inputs", "building-properties", fname)
         if os.path.exists(fpath):
             print("  - removing {fname}".format(fname=fname))

--- a/cea/technologies/thermal_network/thermal_network.py
+++ b/cea/technologies/thermal_network/thermal_network.py
@@ -1004,7 +1004,8 @@ def calc_mass_flow_edges(edge_node_df, mass_flow_substation_df, all_nodes_df, pi
     edge_node_df = edge_node_df.copy()
     loops, graph = find_loops(edge_node_df)  # identifies all linear independent loops
     if loops:
-        # print('Fundamental loops in the network:', loops) #returns nodes that define loop, useful for visiual verification in testing phase,
+        # print('Fundamental loops in the network:', loops)  # returns nodes that define loop, useful for visiual
+        # verification in testing phase,
 
         sum_delta_m_num = np.zeros((1, len(loops)))[0]
 
@@ -1092,7 +1093,7 @@ def calc_mass_flow_edges(edge_node_df, mass_flow_substation_df, all_nodes_df, pi
         # print('Looped massflows converged after ', iterations, ' iterations.')
 
     else:  # no loops
-        ## remove one equation (at plant node) to build a well-determined matrix, A.
+        # remove one equation (at plant node) to build a well-determined matrix, A.
         plant_index = np.where(all_nodes_df['Type'] == 'PLANT')[0][0]  # find index of the first plant node
         A = edge_node_df.drop(edge_node_df.index[plant_index])
         b = np.nan_to_num(mass_flow_substation_df.T)
@@ -1153,6 +1154,7 @@ def find_loops(edge_node_df):
     loops = nx.cycle_basis(graph, 0)  # identifies all linear independent loops
 
     return loops, graph
+
 
 def calc_assign_diameter(max_flow, pipe_catalog):
     if max_flow < pipe_catalog['mdot_min_kgs'].min():


### PR DESCRIPTION
While working on #2667, I made a small performance optimization to the detailed version of the thermal-network script: The results of the `find_loops` method can be cached for a specific input df. This saves a bit of time (maybe 20%). It's still very slow and as far as I can tell, most of that is performing a `np.isclose` call. Those are not really avoidable, _unless_ we can figure out that logically some are redundant. That's an exercise for another day!