### PR TITLE
update the district-cooling-system workflow to use SG weather

### DIFF
--- a/cea/tests/workflow_slow.yml
+++ b/cea/tests/workflow_slow.yml
@@ -12,9 +12,6 @@
   parameters:
     databases-path: CH
     databases: [archetypes, assemblies, components]
-- script: archetypes-mapper
-  parameters:
-    input-databases: [comfort, architecture, air-conditioning, internal-loads, supply, schedules]
 - script: weather-helper
   parameters:
     weather: Zug_inducity_2009
@@ -43,15 +40,23 @@
   parameters:
     network-type: DH
     network-model: simplified
+- script: network-layout
+  parameters:
+    network-type: DC
+    network-model: simplified
 - script: thermal-network
   parameters:
     network-type: DH
+    network-model: simplified
+- script: thermal-network
+  parameters:
+    network-type: DC
     network-model: simplified
 - script: decentralized
 - script: optimization
   parameters:
     district-heating-network: true
-    district-cooling-network: false
+    district-cooling-network: true
     number-of-generations: 2
     population-size: 5
     random-seed: 100
@@ -61,4 +66,8 @@
 - script: run-all-plots
   parameters:
     network-type: DH
+    network-name: ""
+- script: run-all-plots
+  parameters:
+    network-type: DC
     network-name: ""

--- a/cea/tests/workflow_slow.yml
+++ b/cea/tests/workflow_slow.yml
@@ -1,72 +1,18 @@
-- config: .
+- config: default
   "general:multiprocessing": on
+  "general:project": "${CEA_general_project}/../reference-case-open"
   "radiation:daysim-bin-directory": "${CEA_radiation_daysim-bin-directory}"
 - script: run-unit-tests
-- script: extract-reference-case
+- script: workflow
   parameters:
-    destination: "{general:project}/.."
-    case: open
-- config: .
-  "general:scenario-name": baseline
-- script: data-initializer
-  parameters:
-    databases-path: CH
-    databases: [archetypes, assemblies, components]
-- script: weather-helper
-  parameters:
-    weather: Zug_inducity_2009
-- script: radiation
-- script: schedule-maker
-- script: demand
-- script: emissions
-- script: system-costs
-- script: water-body-potential
-- script: sewage-potential
-- script: shallow-geothermal-potential
-- script: photovoltaic
-- script: solar-collector
-  parameters:
-    type-scpanel: FP
-- script: solar-collector
-  parameters:
-    type-scpanel: ET
-- script: photovoltaic-thermal
-  parameters:
-    type-scpanel: FP
-- script: photovoltaic-thermal
-  parameters:
-    type-scpanel: ET
-- script: network-layout
-  parameters:
-    network-type: DH
-    network-model: simplified
-- script: network-layout
-  parameters:
-    network-type: DC
-    network-model: simplified
-- script: thermal-network
-  parameters:
-    network-type: DH
-    network-model: simplified
-- script: thermal-network
-  parameters:
-    network-type: DC
-    network-model: simplified
-- script: decentralized
-- script: optimization
-  parameters:
-    district-heating-network: true
-    district-cooling-network: true
-    number-of-generations: 2
-    population-size: 5
-    random-seed: 100
-- script: multi-criteria-analysis
-  parameters:
-    generation: 2
+    workflow: district-heating-system
 - script: run-all-plots
   parameters:
     network-type: DH
     network-name: ""
+- script: workflow
+  parameters:
+    workflow: district-cooling-system
 - script: run-all-plots
   parameters:
     network-type: DC

--- a/cea/workflows/district_cooling_system.yml
+++ b/cea/workflows/district_cooling_system.yml
@@ -10,14 +10,14 @@
   "general:scenario-name": baseline
 - script: data-initializer
   parameters:
-    databases-path: CH
+    databases-path: SG
     databases: [archetypes, assemblies, components]
 - script: archetypes-mapper
   parameters:
     input-databases: [comfort, architecture, air-conditioning, internal-loads, supply, schedules]
 - script: weather-helper
   parameters:
-    weather: Zug-inducity_1990_2010_TMY
+    weather: Singapore-Changi_1990_2010_TMY
 - script: radiation
   parameters:
     consider-intersections: false

--- a/cea/workflows/district_heating_system.yml
+++ b/cea/workflows/district_heating_system.yml
@@ -12,9 +12,6 @@
   parameters:
     databases-path: CH
     databases: [archetypes, assemblies, components]
-- script: archetypes-mapper
-  parameters:
-    input-databases: [comfort, architecture, air-conditioning, internal-loads, supply, schedules]
 - script: weather-helper
   parameters:
     weather: Zug-inducity_1990_2010_TMY


### PR DESCRIPTION
This PR includes some updates to the `district-cooling-system` workflow - reverting back to using SG weather and databases to force cooling.

To test, use `cea workflow --workflow district-cooling-system`.

The `cea test --workflow slow` is also slightly altered - I'm not sure if it runs through yet. But I think we can merge it anyway.