### PR TITLE
2739 Allow running of demand when selecting buildings

### DIFF
--- a/cea/demand/building_properties.py
+++ b/cea/demand/building_properties.py
@@ -1,11 +1,10 @@
-from __future__ import division
-from __future__ import print_function
-
 """
 Classes of building properties
 """
 
 from __future__ import division
+from __future__ import print_function
+
 
 import numpy as np
 import pandas as pd
@@ -15,6 +14,16 @@ from collections import namedtuple
 from cea.demand import constants
 from cea.utilities.dbf import dbf_to_dataframe
 from cea.technologies import blinds
+from typing import List
+
+__author__ = "Gabriel Happle"
+__copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"
+__credits__ = ["Gabriel Happle", "Jimeno A. Fonseca", "Daren Thomas", "Jack Hawthorne", "Reynold Mok"]
+__license__ = "MIT"
+__version__ = "0.1"
+__maintainer__ = "Daren Thomas"
+__email__ = "cea@arch.ethz.ch"
+__status__ = "Production"
 
 # import constants
 H_F = constants.H_F
@@ -40,8 +49,7 @@ class BuildingProperties(object):
         :param locator: an InputLocator for locating the input files
         :type locator: cea.inputlocator.InputLocator
 
-        :param building_names: list of buildings to read properties
-        :type building_names: List
+        :param List[str] building_names: list of buildings to read properties
 
         :returns: BuildingProperties
         :rtype: BuildingProperties
@@ -245,16 +253,13 @@ class BuildingProperties(object):
         df = df.merge(typology, left_index=True, right_index=True)
         df = df.merge(hvac_temperatures, left_index=True, right_index=True)
 
-
         from cea.demand.control_heating_cooling_systems import has_heating_system, has_cooling_system
-        class prov(object):
-            def __init__(self, hvac):
-                self.hvac = hvac
+
         for building in self.building_names:
-            data = prov({'class_hs':hvac_temperatures.loc[building, 'class_hs'], 'class_cs': hvac_temperatures.loc[building, 'class_cs']})
-            has_system_heating_flag = has_heating_system(data)
-            has_system_cooling_flag = has_cooling_system(data)
-            if has_system_heating_flag == False and has_system_cooling_flag == False and np.max([df.loc[building, 'Hs_ag'], df.loc[building, 'Hs_bg']]) <= 0.0:
+            has_system_heating_flag = has_heating_system(hvac_temperatures.loc[building, 'class_hs'])
+            has_system_cooling_flag = has_cooling_system(hvac_temperatures.loc[building, 'class_cs'])
+            if (not has_system_heating_flag and not has_system_cooling_flag  and
+                    np.max([df.loc[building, 'Hs_ag'], df.loc[building, 'Hs_bg']]) <= 0.0):
                 df.loc[building, 'Hs_ag'] = 0.0
                 df.loc[building, 'Hs_bg'] = 0.0
                 print('Building {building} has no heating and cooling system, Hs corrected to 0.'.format(

--- a/cea/demand/building_properties.py
+++ b/cea/demand/building_properties.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import division
 from __future__ import print_function
 
@@ -34,20 +33,21 @@ class BuildingProperties(object):
     G. Happle   BuildingPropsThermalLoads   27.05.2016
     """
 
-    def __init__(self, locator):
+    def __init__(self, locator, building_names):
         """
         Read building properties from input shape files and construct a new BuildingProperties object.
 
         :param locator: an InputLocator for locating the input files
         :type locator: cea.inputlocator.InputLocator
 
-        :param override_variables: override_variables from config
-        :type override_variables: bool
+        :param building_names: list of buildings to read properties
+        :type building_names: List
 
         :returns: BuildingProperties
         :rtype: BuildingProperties
         """
 
+        self.building_names = building_names
         print("read input files")
         prop_geometry = Gdf.from_file(locator.get_zone_geometry())
         prop_geometry['footprint'] = prop_geometry.area
@@ -79,7 +79,7 @@ class BuildingProperties(object):
                                                 prop_geometry, prop_HVAC_result)
 
         # get solar properties
-        solar = get_prop_solar(locator, prop_rc_model, prop_envelope).set_index('Name')
+        solar = get_prop_solar(locator, building_names, prop_rc_model, prop_envelope).set_index('Name')
 
         # df_windows = geometry_reader.create_windows(surface_properties, prop_envelope)
         # TODO: to check if the Win_op and height of window is necessary.
@@ -121,11 +121,11 @@ class BuildingProperties(object):
 
     def __len__(self):
         """return length of list_building_names"""
-        return len(self.list_building_names())
+        return len(self.building_names)
 
     def list_building_names(self):
         """get list of all building names"""
-        return self._prop_RC_model.index
+        return self.building_names
 
     def list_uses(self):
         """get list of all uses (typology types)"""
@@ -247,7 +247,7 @@ class BuildingProperties(object):
         class prov(object):
             def __init__(self, hvac):
                 self.hvac = hvac
-        for building in locator.get_zone_building_names():
+        for building in self.building_names:
             data = prov({'class_hs':hvac_temperatures.loc[building, 'class_hs'], 'class_cs': hvac_temperatures.loc[building, 'class_cs']})
             has_system_heating_flag = has_heating_system(data)
             has_system_cooling_flag = has_cooling_system(data)
@@ -336,7 +336,7 @@ class BuildingProperties(object):
         envelope['Aroof'] = np.nan
 
         # call all building geometry files in a loop
-        for building_name in locator.get_zone_building_names():
+        for building_name in self.building_names:
             geometry_data = pd.read_csv(locator.get_radiation_building(building_name))
             envelope.ix[building_name, 'Awall_ag'] = geometry_data['walls_east_m2'][0] + \
                                                   geometry_data['walls_west_m2'][0] + \
@@ -906,12 +906,13 @@ def get_envelope_properties(locator, prop_architecture):
     return envelope_prop
 
 
-def get_prop_solar(locator, prop_rc_model, prop_envelope):
+def get_prop_solar(locator, building_names, prop_rc_model, prop_envelope):
     """
     Gets the sensible solar gains from calc_Isol_daysim and stores in a dataframe containing building 'Name' and
     I_sol (incident solar gains).
 
     :param locator: an InputLocator for locating the input files
+    :param building_names: List of buildings
     :param prop_rc_model: RC model properties of a building by name.
     :param prop_envelope: dataframe containing the building envelope properties.
     :return: dataframe containing the sensible solar gains for each building by name called result.
@@ -924,11 +925,11 @@ def get_prop_solar(locator, prop_rc_model, prop_envelope):
     list_Isol = []
 
     # for every building
-    for building_name in locator.get_zone_building_names():
+    for building_name in building_names:
         I_sol = calc_Isol_daysim(building_name, locator, prop_envelope, prop_rc_model, thermal_resistance_surface)
         list_Isol.append(I_sol)
 
-    result = pd.DataFrame({'Name': list(locator.get_zone_building_names()), 'I_sol': list_Isol})
+    result = pd.DataFrame({'Name': list(building_names), 'I_sol': list_Isol})
 
     return result
 

--- a/cea/demand/building_properties.py
+++ b/cea/demand/building_properties.py
@@ -33,7 +33,7 @@ class BuildingProperties(object):
     G. Happle   BuildingPropsThermalLoads   27.05.2016
     """
 
-    def __init__(self, locator, building_names):
+    def __init__(self, locator, building_names=None):
         """
         Read building properties from input shape files and construct a new BuildingProperties object.
 
@@ -46,6 +46,9 @@ class BuildingProperties(object):
         :returns: BuildingProperties
         :rtype: BuildingProperties
         """
+
+        if building_names is None:
+            building_names = locator.get_zone_building_names()
 
         self.building_names = building_names
         print("read input files")

--- a/cea/demand/control_heating_cooling_systems.py
+++ b/cea/demand/control_heating_cooling_systems.py
@@ -16,43 +16,43 @@ __email__ = "thomas@arch.ethz.ch"
 __status__ = "Production"
 
 
-def has_heating_system(bpr):
+def has_heating_system(hvac_class_hs):
     """
     determines whether a building has a heating system installed or not
 
-    :param bpr: BuildingPropertiesRow
-    :type bpr: cea.demand.building_properties.BuildingPropertiesRow
-    :return: True or False
+    :param str hvac_class_hs: Heating system class of the HVAC unit
+    :return: True, if the building has a (supported) heating system or False
     :rtype: bool
     """
 
-    supported1 = ['RADIATOR', 'FLOOR_HEATING', 'CENTRAL_AC']
-    supported2 = ['NONE']
-    if bpr.hvac['class_hs'] in supported1:
+    supported = ['RADIATOR', 'FLOOR_HEATING', 'CENTRAL_AC']
+    unsupported = ['NONE']
+    if hvac_class_hs in supported:
         return True
-    elif bpr.hvac['class_hs'] in supported2:
+    elif hvac_class_hs in unsupported:
         return False
     else:
-        raise ValueError('Invalid value for class_cs: %s. CEA only supports the following systems %s' %(bpr.hvac['class_hs'], supported1.extend(supported2)))
+        raise ValueError('Invalid value for class_cs: %s. CEA only supports the following systems %s' % (
+            hvac_class_hs, supported.extend(unsupported)))
 
 
-def has_cooling_system(bpr):
+def has_cooling_system(hvac_class_cs):
     """
     determines whether a building has a cooling system installed or not
 
-    :param bpr: BuildingPropertiesRow
-    :type bpr: cea.demand.building_properties.BuildingPropertiesRow
-    :return: True or False
+    :param str hvac_class_cs: Cooling system class of the HVAC unit
+    :return: True, if the building has a (supported) cooling system or False
     :rtype: bool
     """
-    supported1 = ['CEILING_COOLING', 'FLOOR_COOLING', 'DECENTRALIZED_AC', 'CENTRAL_AC', 'HYBRID_AC']
-    supported2 = ['NONE']
-    if bpr.hvac['class_cs'] in supported1:
+    supported = ['CEILING_COOLING', 'FLOOR_COOLING', 'DECENTRALIZED_AC', 'CENTRAL_AC', 'HYBRID_AC']
+    unsupported = ['NONE']
+    if hvac_class_cs in supported:
         return True
-    elif bpr.hvac['class_cs'] in supported2:
+    elif hvac_class_cs in unsupported:
         return False
     else:
-        raise ValueError('Invalid value for class_cs: %s. CEA only supports the following systems %s' %(bpr.hvac['class_cs'], supported1.extend(supported2)))
+        raise ValueError('Invalid value for class_cs: %s. CEA only supports the following systems %s' % (
+            hvac_class_cs, supported.extend(unsupported)))
 
 
 def has_radiator_heating_system(bpr):

--- a/cea/demand/demand_main.py
+++ b/cea/demand/demand_main.py
@@ -132,7 +132,7 @@ def demand_calculation(locator, config):
     return totals, time_series
 
 
-def print_progress(i, n, args, result):
+def print_progress(i, n, args, _):
     print("Building No. {i} completed out of {n}: {building}".format(i=i + 1, n=n, building=args[0]))
 
 

--- a/cea/demand/electrical_loads.py
+++ b/cea/demand/electrical_loads.py
@@ -229,7 +229,7 @@ def calc_Eaux_Qhs_Qcs(tsd, bpr):
     else:
         b = 2
 
-    if control_heating_cooling_systems.has_heating_system(bpr):
+    if control_heating_cooling_systems.has_heating_system(bpr.hvac["class_hs"]):
 
         # for all subsystems
         Eaux_hs_ahu = np.vectorize(calc_Eauxf_hs_dis)(Qhs_sys_ahu, Qhs_sys_0_ahu, deltaP_kPa, b, Ths_sup_ahu,
@@ -242,7 +242,7 @@ def calc_Eaux_Qhs_Qcs(tsd, bpr):
     else:
         tsd['Eaux_hs'] = np.zeros(HOURS_IN_YEAR)
 
-    if control_heating_cooling_systems.has_cooling_system(bpr):
+    if control_heating_cooling_systems.has_cooling_system(bpr.hvac["class_cs"]):
 
         # for all subsystems
         Eaux_cs_ahu = np.vectorize(calc_Eauxf_cs_dis)(Qcs_sys_ahu, Qcs_sys_0_ahu, deltaP_kPa, b, Tcs_sup_ahu,

--- a/cea/demand/hourly_procedure_heating_cooling_system_load.py
+++ b/cea/demand/hourly_procedure_heating_cooling_system_load.py
@@ -40,7 +40,7 @@ def calc_heating_cooling_loads(bpr, tsd, t):
         # +++++++++++++++++++++++++++++++++++++++++++
 
         # check system
-        if not control_heating_cooling_systems.has_heating_system(bpr) \
+        if not control_heating_cooling_systems.has_heating_system(bpr.hvac["class_hs"]) \
                 or not control_heating_cooling_systems.heating_system_is_active(tsd, t):
 
             # no system = no loads
@@ -82,8 +82,8 @@ def calc_heating_cooling_loads(bpr, tsd, t):
         # +++++++++++++++++++++++++++++++++++++++++++
 
         # check system
-        if not control_heating_cooling_systems.has_cooling_system(bpr)\
-                or not control_heating_cooling_systems.cooling_system_is_active(bpr, tsd, t):
+        if (not control_heating_cooling_systems.has_cooling_system(bpr.hvac["class_cs"])
+                or not control_heating_cooling_systems.cooling_system_is_active(bpr, tsd, t)):
 
             # no system = no loads
             rc_model_temperatures = calc_rc_no_loads(bpr, tsd, t)

--- a/cea/demand/sensible_loads.py
+++ b/cea/demand/sensible_loads.py
@@ -178,7 +178,7 @@ def calc_temperatures_emission_systems(bpr, tsd):
     #
     # TEMPERATURES HEATING SYSTEMS
     #
-    if not control_heating_cooling_systems.has_heating_system(bpr):
+    if not control_heating_cooling_systems.has_heating_system(bpr.hvac["class_hs"]):
         # if no heating system
 
         tsd['Ths_sys_sup_ahu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
@@ -287,8 +287,8 @@ def calc_temperatures_emission_systems(bpr, tsd):
     #
     # TEMPERATURES COOLING SYSTEMS
     #
-    if not control_heating_cooling_systems.has_cooling_system(bpr):
-        # if no heating system
+    if not control_heating_cooling_systems.has_cooling_system(bpr.hvac["class_cs"]):
+        # if no cooling system
 
         tsd['Tcs_sys_sup_ahu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0
         tsd['Tcs_sys_re_ahu'] = np.zeros(HOURS_IN_YEAR) * np.nan  # in C  #FIXME: I don't like that non-existing temperatures are 0

--- a/cea/demand/space_emission_systems.py
+++ b/cea/demand/space_emission_systems.py
@@ -227,7 +227,8 @@ def calc_delta_theta_int_inc_heating(bpr):
     __credits__ = ["Shanshan Hsieh", "Daren Thomas"]
 
     try:
-        delta_theta_int_inc_heating = 0.0 if has_heating_system(bpr) == False else (bpr.hvac['dT_Qhs'] + bpr.hvac['dThs_C'])
+        delta_theta_int_inc_heating = (0.0 if not has_heating_system(bpr.hvac["class_hs"])
+                                       else (bpr.hvac['dT_Qhs'] + bpr.hvac['dThs_C']))
 
     except KeyError:
         raise ValueError(
@@ -262,7 +263,8 @@ def calc_delta_theta_int_inc_cooling(bpr):
 
     try:
 
-        delta_theta_int_inc_cooling = 0.0 if has_cooling_system(bpr) == False else (bpr.hvac['dT_Qcs'] + bpr.hvac['dTcs_C'])
+        delta_theta_int_inc_cooling = (0.0 if not has_cooling_system(bpr.hvac["class_cs"])
+                                       else (bpr.hvac['dT_Qcs'] + bpr.hvac['dTcs_C']))
     except KeyError:
         raise ValueError(
             'Invalid system / control combination: %s, %s' % (bpr.hvac['class_cs'], bpr.hvac['type_ctrl']))

--- a/cea/interfaces/dashboard/dashboard.py
+++ b/cea/interfaces/dashboard/dashboard.py
@@ -1,5 +1,5 @@
 from flask import Flask
-from flask_socketio import SocketIO, emit
+from flask_socketio import SocketIO
 
 import cea.config
 import cea.plots
@@ -28,7 +28,6 @@ def main(config):
     app.cea_config = config
     app.plot_cache = plot_cache
     app.socketio = socketio
-
 
     print("start socketio.run")
     socketio.run(app, host='localhost', port=5050)


### PR DESCRIPTION
This PR fixes #2739 by changing `BuildingProperties` to load input files (e.g. radiation) of selected buildings instead of all buildings in the zone when running **demand**.

Testing:
- Create new scenario with all required input files
- Run radiation for only one building
- Run demand for that one building