### PR TITLE
Return empty list if unable to find project

### DIFF
--- a/cea/config.py
+++ b/cea/config.py
@@ -1044,6 +1044,10 @@ class CoordinateListParameter(ListParameter):
 
 
 def get_scenarios_list(project_path):
+    # return empty list if project path does not exist
+    if not os.path.exists(project_path):
+        return []
+
     def is_valid_scenario(project_path, folder_name):
         folder_path = os.path.join(project_path, folder_name)
         # a scenario must be a valid path

--- a/cea/interfaces/dashboard/api/project.py
+++ b/cea/interfaces/dashboard/api/project.py
@@ -311,12 +311,5 @@ class ScenarioImage(Resource):
 
 
 def list_scenario_names_for_project(config):
-    try:
-        return config.get_parameter('general:scenario-name')._choices
-    except WindowsError:
-        # Return empty list if unable to find project
-        return []
-    except Exception as e:
-        raise e
-
+    return config.get_parameter('general:scenario-name')._choices
 

--- a/cea/interfaces/dashboard/api/project.py
+++ b/cea/interfaces/dashboard/api/project.py
@@ -311,5 +311,12 @@ class ScenarioImage(Resource):
 
 
 def list_scenario_names_for_project(config):
-    return config.get_parameter('general:scenario-name')._choices
+    try:
+        return config.get_parameter('general:scenario-name')._choices
+    except WindowsError:
+        # Return empty list if unable to find project
+        return []
+    except Exception as e:
+        raise e
+
 


### PR DESCRIPTION
This PR fixes #2765 by returning an empty list of scenarios if project is non-existent.

TODO:
- Update GUI to show error messages of api calls (exception or unable to contact server) in some sort of popup so user know what to do.