### PR TITLE
Clean geometries from OpenStreetMap in zone-helper

### DIFF
--- a/cea/datamanagement/databases_verification.py
+++ b/cea/datamanagement/databases_verification.py
@@ -80,12 +80,23 @@ def assert_input_geometry_acceptable_values_floor_height_surroundings(surroundin
                         'to simulate in CEA at the moment. Please verify your Zone or Surroundings shapefile file')
 
 
+def assert_input_geometry_only_polygon(buildings_df):
+    not_polygon = buildings_df.geometry.type != 'Polygon'
+    invalid_buildings = buildings_df[not_polygon]['Name'].values
+    if len(invalid_buildings):
+        raise Exception(
+            'Some buildings are not of type "Polygon": {buildings}'.format(buildings=', '.join(invalid_buildings)))
+
+
 def verify_input_geometry_zone(zone_df):
     # Verification 1. verify if all the column names are correct
     assert_columns_names(zone_df, COLUMNS_ZONE_GEOMETRY)
 
     # Verification 2. verify if the floor_height ratio is correct
     assert_input_geometry_acceptable_values_floor_height(zone_df)
+
+    # Verification 3. verify geometries only contain Polygon
+    assert_input_geometry_only_polygon(zone_df)
 
 
 def verify_input_geometry_surroundings(surroundings_df):
@@ -94,6 +105,9 @@ def verify_input_geometry_surroundings(surroundings_df):
 
     # Verification 2. verify if the floor_height ratio is correct
     assert_input_geometry_acceptable_values_floor_height_surroundings(surroundings_df)
+
+    # Verification 3. verify geometries only contain Polygon
+    assert_input_geometry_only_polygon(surroundings_df)
 
 
 def verify_input_typology(typology_df):


### PR DESCRIPTION
This PR fixes #2764 by adding a new function to clean geometries from **OpenStreetMap** before processing it.

The issue is mainly caused by `geopandas` not able to export a GeoPandas DataFrame to a shapefile if any of its geometries are of type **`MultiPolygon`**. It solves it by trying to flatten any **`MultiPolygon`** into a single **`Polygon`**.