### PR TITLE
Release 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- 2020-06-12 - 3.3.0 - #2771 Update range values
 - 2020-06-12 - 3.3.0 - #2766 Return empty list if unable to find project
 - 2020-06-12 - 3.3.0 - #2768 Fixing electro-mobility documentation
 - 2020-06-12 - 3.3.0 - #2762 2761 Fix network layout error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+- 2020-06-12 - 3.3.0 - #2766 Return empty list if unable to find project
+- 2020-06-12 - 3.3.0 - #2768 Fixing electro-mobility documentation
+- 2020-06-12 - 3.3.0 - #2762 2761 Fix network layout error
+- 2020-06-10 - 3.3.0 - #2763 2699 guide for modifying scripts
+- 2020-06-10 - 3.3.0 - #2754 Prevent scenario name from being empty string
+- 2020-06-04 - 3.3.0 - #2733 #2732 - VCC Partial load COP
+- 2020-05-29 - 3.3.0 - #2748 2667 clean up unnamed in schemas yml
+- 2020-05-27 - 3.3.0 - #2731 CEA plugin architecture
+- 2020-05-25 - 3.3.0 - #2741 2739 Allow running of demand when selecting buildings
+- 2020-05-21 - 3.3.0 - #2740 Run code coverage on CEA test
+- 2020-05-15 - 3.3.0 - #2737 Avoid setting index for empty building_capacities
+- 2020-05-15 - 3.3.0 - #2736 release-3.3.0
 - 2020-05-15 - 3.2.0 - #2735 cea test --workflow slow now runs through
 - 2020-05-15 - 3.2.0 - #2723 Remove inputs.yaml
 - 2020-05-15 - 3.2.0 - #2728 Remove "Unnamed: 0" columns in output files of optimization, decentralized and mulit-criteria-analysis scripts

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -9,6 +9,46 @@ The CEA team
 Starting from version 2.9.1 the credits are structured alphabetically (surname) and split into the categories of developers,
 scrum master, project owner, project sponsor and collaborators.
 
+- Version 3.4.0 - June 2020
+
+    Developers:
+    * [Amr Elesawy](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/amr-elesawy.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+    * [Gabriel Happle](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/gabriel-happle.html)
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+    * [Reynold Mok](http://https://cityenergyanalyst.com/community)
+    * [Martín Mosteiro Romero](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/martin-mosteiro-romero.html)
+    * [Zhongming Shi](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/zhongming-shi.html)
+    * [Bhargava Krishna Sreepathi ](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/sreepathi-bhargava-krishna.html)
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Scrum master:
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Project owner:
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+
+    Project sponsor:
+    * [Arno Schlueter](http://www.systems.arch.ethz.ch/about-us/team/arno-schlueter.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+
+    Collaborators:
+    * Jose Bello
+    * Anastasiya Bosova
+    * Kian Wee Chen
+    * Jack Hawthorne
+    * Fazel Khayatian
+    * Victor Marty
+    * Paul Neitzel
+    * Thuy-An Nguyen
+    * Bo Lie Ong
+    * Emanuel Riegelbauer
+    * Lennart Rogenhofer
+    * Toivo Säwén
+    * Sebastian Troiztsch    
+    * Tim Vollrath
+
+
 - Version 3.3.0 - Mai 2020
 
     Developers:

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.3.0"
+__version__ = "3.4.0"
 
 
 class ConfigError(Exception):

--- a/cea/constants.py
+++ b/cea/constants.py
@@ -17,9 +17,10 @@ __email__ = "cea@arch.ethz.ch"
 __status__ = "Production"
 
 
-#Shapefiles precision of decimals
-SHAPEFILE_TOLERANCE = 20 #this is precision of milimiters
-SNAP_TOLERANCE = 0.1 # this is precision in meters increase if having problems.
+# Shapefiles precision of decimals
+
+SHAPEFILE_TOLERANCE = 6  # this is precision in millimeters
+SNAP_TOLERANCE = 0.1  # this is precision in meters increase if having problems.
 
 HEAT_CAPACITY_OF_WATER_VAPOR_JPERKGK = 1859  # specific heat capacity of water vapor in KJ/kgK
 ASPECT_RATIO = 3.3  # tank height aspect ratio, H=(4*V*AR^2/pi)^(1/3), taken from commercial tank geometry (jenni.ch)

--- a/cea/workflows/workflow.py
+++ b/cea/workflows/workflow.py
@@ -81,7 +81,7 @@ def main(config):
                 # skip steps already completed while resuming
                 print("Skipping workflow step {i}: script={script}".format(i=i, script=step["script"]))
                 continue
-            do_script_step(config, step, trace_input)
+            do_script_step(config, i, step, trace_input)
         elif "config" in step:
             config = do_config_step(config, step)
         else:
@@ -91,6 +91,7 @@ def main(config):
         resume_dict[workflow_yml] = i
         with open(resume_yml, 'w') as resume_fp:
             yaml.dump(resume_dict, resume_fp, indent=4)
+
 
 def read_resume_info(resume_yml, workflow_yml):
     try:
@@ -153,12 +154,12 @@ def set_parameter(config, parameter, value):
         parameter.set(parameter.decode(expanded_value))
 
 
-def do_script_step(config, step, trace_input):
+def do_script_step(config, i, step, trace_input):
     """Run a script based on the step's "script" and "parameters" (optional) keys."""
     script = cea.scripts.by_name(step["script"], plugins=config.plugins)
     print("")
     print("=" * 80)
-    print("Workflow step: script={script}".format(script=script.name))
+    print("Workflow step {i}: script={script}".format(i=i, script=script.name))
     print("=" * 80)
     parameters = {p.name: p.get() for s, p in config.matching_parameters(script.parameters)}
     if "parameters" in step:

--- a/docs/graphviz/archetypes_mapper.gv
+++ b/docs/graphviz/archetypes_mapper.gv
@@ -64,7 +64,7 @@ digraph archetypes_mapper {
         fontsize = 20;
         rank=same;
         label="technology/archetypes/schedules";
-        get_database_standard_schedules_use[label="{use}.csv"];
+        get_database_standard_schedules_use[label="RESTAURANT.csv"];
     }
     subgraph cluster_5_in {
         style = filled;

--- a/docs/graphviz/data_initializer.gv
+++ b/docs/graphviz/data_initializer.gv
@@ -48,7 +48,7 @@ digraph data_initializer {
         fontsize = 20;
         rank=same;
         label="technology/archetypes/schedules";
-        get_database_standard_schedules_use[label="{use}.csv"];
+        get_database_standard_schedules_use[label="RESTAURANT.csv"];
     }
     subgraph cluster_4_out {
         style = filled;

--- a/docs/graphviz/optimization.gv
+++ b/docs/graphviz/optimization.gv
@@ -107,8 +107,8 @@ digraph optimization {
         fontsize = 20;
         rank=same;
         label="optimization/slave/gen_0";
-        get_optimization_district_scale_heating_capacity[label="ind_2_district_scale_heating_capacity.csv"];
         get_optimization_building_scale_heating_capacity[label="ind_1_building_scale_heating_capacity.csv"];
+        get_optimization_district_scale_heating_capacity[label="ind_2_district_scale_heating_capacity.csv"];
         get_optimization_slave_total_performance[label="ind_2_total_performance.csv"];
     }
     subgraph cluster_10_out {
@@ -117,11 +117,11 @@ digraph optimization {
         fontsize = 20;
         rank=same;
         label="optimization/slave/gen_1";
-        get_optimization_district_scale_cooling_capacity[label="ind_1_district_scale_cooling_capacity.csv"];
         get_optimization_building_scale_cooling_capacity[label="ind_0_building_scale_cooling_capacity.csv"];
+        get_optimization_district_scale_cooling_capacity[label="ind_1_district_scale_cooling_capacity.csv"];
         get_optimization_generation_district_scale_performance[label="gen_1_district_scale_performance.csv"];
-        get_optimization_slave_district_scale_performance[label="ind_2_buildings_district_scale_performance.csv"];
         get_optimization_slave_cooling_activation_pattern[label="ind_2_Cooling_Activation_Pattern.csv"];
+        get_optimization_slave_district_scale_performance[label="ind_2_buildings_district_scale_performance.csv"];
         get_optimization_slave_electricity_activation_pattern[label="ind_1_Electricity_Activation_Pattern.csv"];
         get_optimization_slave_electricity_requirements_data[label="ind_1_Electricity_Requirements_Pattern.csv"];
     }
@@ -192,21 +192,21 @@ digraph optimization {
     get_water_body_potential -> "optimization"[label="(get_water_body_potential)"];
     get_weather_file -> "optimization"[label="(get_weather_file)"];
     get_zone_geometry -> "optimization"[label="(get_zone_geometry)"];
+    "optimization" -> get_optimization_building_scale_cooling_capacity[label="(get_optimization_building_scale_cooling_capacity)"];
+    "optimization" -> get_optimization_building_scale_heating_capacity[label="(get_optimization_building_scale_heating_capacity)"];
     "optimization" -> get_optimization_checkpoint[label="(get_optimization_checkpoint)"];
     "optimization" -> get_optimization_district_scale_cooling_capacity[label="(get_optimization_district_scale_cooling_capacity)"];
     "optimization" -> get_optimization_district_scale_electricity_capacity[label="(get_optimization_district_scale_electricity_capacity)"];
     "optimization" -> get_optimization_district_scale_heating_capacity[label="(get_optimization_district_scale_heating_capacity)"];
-    "optimization" -> get_optimization_building_scale_cooling_capacity[label="(get_optimization_building_scale_cooling_capacity)"];
-    "optimization" -> get_optimization_building_scale_heating_capacity[label="(get_optimization_building_scale_heating_capacity)"];
-    "optimization" -> get_optimization_generation_district_scale_performance[label="(get_optimization_generation_district_scale_performance)"];
     "optimization" -> get_optimization_generation_building_scale_performance[label="(get_optimization_generation_building_scale_performance)"];
+    "optimization" -> get_optimization_generation_district_scale_performance[label="(get_optimization_generation_district_scale_performance)"];
     "optimization" -> get_optimization_generation_total_performance[label="(get_optimization_generation_total_performance)"];
     "optimization" -> get_optimization_generation_total_performance_pareto[label="(get_optimization_generation_total_performance_pareto)"];
     "optimization" -> get_optimization_individuals_in_generation[label="(get_optimization_individuals_in_generation)"];
     "optimization" -> get_optimization_slave_building_connectivity[label="(get_optimization_slave_building_connectivity)"];
-    "optimization" -> get_optimization_slave_district_scale_performance[label="(get_optimization_slave_district_scale_performance)"];
-    "optimization" -> get_optimization_slave_cooling_activation_pattern[label="(get_optimization_slave_cooling_activation_pattern)"];
     "optimization" -> get_optimization_slave_building_scale_performance[label="(get_optimization_slave_building_scale_performance)"];
+    "optimization" -> get_optimization_slave_cooling_activation_pattern[label="(get_optimization_slave_cooling_activation_pattern)"];
+    "optimization" -> get_optimization_slave_district_scale_performance[label="(get_optimization_slave_district_scale_performance)"];
     "optimization" -> get_optimization_slave_electricity_activation_pattern[label="(get_optimization_slave_electricity_activation_pattern)"];
     "optimization" -> get_optimization_slave_electricity_requirements_data[label="(get_optimization_slave_electricity_requirements_data)"];
     "optimization" -> get_optimization_slave_heating_activation_pattern[label="(get_optimization_slave_heating_activation_pattern)"];

--- a/docs/how-to-create-a-new-release.rst
+++ b/docs/how-to-create-a-new-release.rst
@@ -147,13 +147,9 @@ Uploading to PyPI
     - cityenergyanalyst-2.2-py2-none-any.whl
     - cityenergyanalyst-2.2.tar.gz
 
-- use twine to upload to PyPI
+- use twine to upload to PyPI (``twine upload dist/*``)
 
-::
-
-    twine upload dist/*
-
-  - you can get twine_ with ``pip install twine``
+  - you can get twine_ with ``pip install twine`` (it should be pre-installed in the CEA Console)
   - the command above assumes you have set the ``TWINE_PASSWORD`` and ``TWINE_USERNAME`` environment variables
     if not, use the ``--username`` and ``--password`` positional arguments
   - ask the repository admins for username and password

--- a/docs/output_methods.rst
+++ b/docs/output_methods.rst
@@ -92,7 +92,7 @@ The following file is used by these scripts: ``demand``, ``schedule_maker``
     ``Ed_Wm2``, "Peak specific electrical load due to servers/data centres"
     ``El_Wm2``, "Peak specific electrical load due to artificial lighting"
     ``Epro_Wm2``, "Peak specific electrical load due to industrial processes"
-    ``Ev_kWveh``, "Peak specific cooling load due to electromobility"
+    ``Ev_kWveh``, "Peak capacity of electric battery per vehicle"
     ``Name``, "Unique building ID. It must start with a letter."
     ``Occ_m2pax``, "Occupancy density"
     ``Qcpro_Wm2``, "Peak specific process cooling load"
@@ -1087,30 +1087,30 @@ The following file is used by these scripts: ``archetypes_mapper``
 .. csv-table:: Worksheet: ``ELECTROMOBILITY``
     :header: "Variable", "Description"
 
-    ``1``, 
-    ``2``, 
-    ``3``, 
-    ``4``, 
-    ``5``, 
-    ``6``, 
-    ``7``, 
-    ``8``, 
-    ``9``, 
-    ``10``, 
-    ``11``, 
-    ``12``, 
-    ``13``, 
-    ``14``, 
-    ``15``, 
-    ``16``, 
-    ``17``, 
-    ``18``, 
-    ``19``, 
-    ``20``, 
-    ``21``, 
-    ``22``, 
-    ``23``, 
-    ``24``, 
+    ``1``, Average number of electric vehicles in this hour
+    ``2``, Average number of electric vehicles in this hour
+    ``3``, Average number of electric vehicles in this hour
+    ``4``, Average number of electric vehicles in this hour
+    ``5``, Average number of electric vehicles in this hour
+    ``6``, Average number of electric vehicles in this hour
+    ``7``, Average number of electric vehicles in this hour
+    ``8``, Average number of electric vehicles in this hour
+    ``9``, Average number of electric vehicles in this hour
+    ``10``, Average number of electric vehicles in this hour
+    ``11``, Average number of electric vehicles in this hour
+    ``12``, Average number of electric vehicles in this hour
+    ``13``, Average number of electric vehicles in this hour
+    ``14``, Average number of electric vehicles in this hour
+    ``15``, Average number of electric vehicles in this hour
+    ``16``, Average number of electric vehicles in this hour
+    ``17``, Average number of electric vehicles in this hour
+    ``18``, Average number of electric vehicles in this hour
+    ``19``, Average number of electric vehicles in this hour
+    ``20``, Average number of electric vehicles in this hour
+    ``21``, Average number of electric vehicles in this hour
+    ``22``, Average number of electric vehicles in this hour
+    ``23``, Average number of electric vehicles in this hour
+    ``24``, Average number of electric vehicles in this hour
     ``DAY``, 
     
 
@@ -1448,7 +1448,7 @@ The following file is used by these scripts: ``archetypes_mapper``
     ``Ed_Wm2``, Peak specific electrical load due to servers/data centres
     ``El_Wm2``, Peak specific electrical load due to artificial lighting
     ``Epro_Wm2``, Peak specific electrical load due to industrial processes
-    ``Ev_kWveh``, Peak specific cooling load due to electromobility
+    ``Ev_kWveh``, Peak capacity of electrical battery per vehicle
     ``Occ_m2pax``, Occupancy density
     ``Qcpro_Wm2``, Peak specific process cooling load
     ``Qcre_Wm2``, Peak specific cooling load due to refrigeration (cooling rooms)

--- a/docs/script-data-flow.rst
+++ b/docs/script-data-flow.rst
@@ -405,7 +405,7 @@ archetypes_mapper
         fontsize = 20;
         rank=same;
         label="technology/archetypes/schedules";
-        get_database_standard_schedules_use[label="{use}.csv"];
+        get_database_standard_schedules_use[label="RESTAURANT.csv"];
     }
     subgraph cluster_5_in {
         style = filled;
@@ -1010,7 +1010,7 @@ data_initializer
         fontsize = 20;
         rank=same;
         label="technology/archetypes/schedules";
-        get_database_standard_schedules_use[label="{use}.csv"];
+        get_database_standard_schedules_use[label="RESTAURANT.csv"];
     }
     subgraph cluster_4_out {
         style = filled;
@@ -1433,8 +1433,8 @@ optimization
         fontsize = 20;
         rank=same;
         label="optimization/slave/gen_0";
-        get_optimization_district_scale_heating_capacity[label="ind_2_district_scale_heating_capacity.csv"];
         get_optimization_building_scale_heating_capacity[label="ind_1_building_scale_heating_capacity.csv"];
+        get_optimization_district_scale_heating_capacity[label="ind_2_district_scale_heating_capacity.csv"];
         get_optimization_slave_total_performance[label="ind_2_total_performance.csv"];
     }
     subgraph cluster_10_out {
@@ -1443,11 +1443,11 @@ optimization
         fontsize = 20;
         rank=same;
         label="optimization/slave/gen_1";
-        get_optimization_district_scale_cooling_capacity[label="ind_1_district_scale_cooling_capacity.csv"];
         get_optimization_building_scale_cooling_capacity[label="ind_0_building_scale_cooling_capacity.csv"];
+        get_optimization_district_scale_cooling_capacity[label="ind_1_district_scale_cooling_capacity.csv"];
         get_optimization_generation_district_scale_performance[label="gen_1_district_scale_performance.csv"];
-        get_optimization_slave_district_scale_performance[label="ind_2_buildings_district_scale_performance.csv"];
         get_optimization_slave_cooling_activation_pattern[label="ind_2_Cooling_Activation_Pattern.csv"];
+        get_optimization_slave_district_scale_performance[label="ind_2_buildings_district_scale_performance.csv"];
         get_optimization_slave_electricity_activation_pattern[label="ind_1_Electricity_Activation_Pattern.csv"];
         get_optimization_slave_electricity_requirements_data[label="ind_1_Electricity_Requirements_Pattern.csv"];
     }
@@ -1518,21 +1518,21 @@ optimization
     get_water_body_potential -> "optimization"[label="(get_water_body_potential)"];
     get_weather_file -> "optimization"[label="(get_weather_file)"];
     get_zone_geometry -> "optimization"[label="(get_zone_geometry)"];
+    "optimization" -> get_optimization_building_scale_cooling_capacity[label="(get_optimization_building_scale_cooling_capacity)"];
+    "optimization" -> get_optimization_building_scale_heating_capacity[label="(get_optimization_building_scale_heating_capacity)"];
     "optimization" -> get_optimization_checkpoint[label="(get_optimization_checkpoint)"];
     "optimization" -> get_optimization_district_scale_cooling_capacity[label="(get_optimization_district_scale_cooling_capacity)"];
     "optimization" -> get_optimization_district_scale_electricity_capacity[label="(get_optimization_district_scale_electricity_capacity)"];
     "optimization" -> get_optimization_district_scale_heating_capacity[label="(get_optimization_district_scale_heating_capacity)"];
-    "optimization" -> get_optimization_building_scale_cooling_capacity[label="(get_optimization_building_scale_cooling_capacity)"];
-    "optimization" -> get_optimization_building_scale_heating_capacity[label="(get_optimization_building_scale_heating_capacity)"];
-    "optimization" -> get_optimization_generation_district_scale_performance[label="(get_optimization_generation_district_scale_performance)"];
     "optimization" -> get_optimization_generation_building_scale_performance[label="(get_optimization_generation_building_scale_performance)"];
+    "optimization" -> get_optimization_generation_district_scale_performance[label="(get_optimization_generation_district_scale_performance)"];
     "optimization" -> get_optimization_generation_total_performance[label="(get_optimization_generation_total_performance)"];
     "optimization" -> get_optimization_generation_total_performance_pareto[label="(get_optimization_generation_total_performance_pareto)"];
     "optimization" -> get_optimization_individuals_in_generation[label="(get_optimization_individuals_in_generation)"];
     "optimization" -> get_optimization_slave_building_connectivity[label="(get_optimization_slave_building_connectivity)"];
-    "optimization" -> get_optimization_slave_district_scale_performance[label="(get_optimization_slave_district_scale_performance)"];
-    "optimization" -> get_optimization_slave_cooling_activation_pattern[label="(get_optimization_slave_cooling_activation_pattern)"];
     "optimization" -> get_optimization_slave_building_scale_performance[label="(get_optimization_slave_building_scale_performance)"];
+    "optimization" -> get_optimization_slave_cooling_activation_pattern[label="(get_optimization_slave_cooling_activation_pattern)"];
+    "optimization" -> get_optimization_slave_district_scale_performance[label="(get_optimization_slave_district_scale_performance)"];
     "optimization" -> get_optimization_slave_electricity_activation_pattern[label="(get_optimization_slave_electricity_activation_pattern)"];
     "optimization" -> get_optimization_slave_electricity_requirements_data[label="(get_optimization_slave_electricity_requirements_data)"];
     "optimization" -> get_optimization_slave_heating_activation_pattern[label="(get_optimization_slave_heating_activation_pattern)"];


### PR DESCRIPTION
This is the result of the M3.4 sprint. We implemented a plugin architecture - see [CEA Plugins - Part 1: Introduction](https://daren-thomas.github.io/cea-plugins-part-1/) for a preview of the documentation to the plugin architecture. We also added a refinement of the 'chiller_vapor_compression' COP by accounting for partial load operation. And more (see CHANGELOG)

To install it on windows, download and run the attached [Setup_CityEnergyAnalyst_3.4.0.exe](https://github.com/architecture-building-systems/CityEnergyAnalyst/releases/download/v3.4.0/Setup_CityEnergyAnalyst_3.4.0.exe). See [the installation guide](https://city-energy-analyst.readthedocs.io/en/latest/getting-started.html#install-and-set-up) for more options.

From the CHANGELOG:

- 2020-06-12 - 3.3.0 - #2771 Update range values
- 2020-06-12 - 3.3.0 - #2766 Return empty list if unable to find project
- 2020-06-12 - 3.3.0 - #2768 Fixing electro-mobility documentation
- 2020-06-12 - 3.3.0 - #2762 2761 Fix network layout error
- 2020-06-10 - 3.3.0 - #2763 2699 guide for modifying scripts
- 2020-06-10 - 3.3.0 - #2754 Prevent scenario name from being empty string
- 2020-06-04 - 3.3.0 - #2733 #2732 - VCC Partial load COP
- 2020-05-29 - 3.3.0 - #2748 2667 clean up unnamed in schemas yml
- 2020-05-27 - 3.3.0 - #2731 CEA plugin architecture
- 2020-05-25 - 3.3.0 - #2741 2739 Allow running of demand when selecting buildings
- 2020-05-21 - 3.3.0 - #2740 Run code coverage on CEA test
- 2020-05-15 - 3.3.0 - #2737 Avoid setting index for empty building_capacities
- 2020-05-15 - 3.3.0 - #2736 release-3.3.0