### PR TITLE
Fix some timeseries plots not showing

### DIFF
--- a/cea/plots/base.py
+++ b/cea/plots/base.py
@@ -184,10 +184,15 @@ class PlotBase(object):
         fig['layout']['font'].update(dict(size=10))
 
         if self.timeframe is not None:
+            import datetime
             # Try to get plot year from data
             try:
                 plot_year = fig['data'][0]['x'][0].year
-                fig['layout']['xaxis']['rangebreaks'] = [dict(values=["{year}-02-29".format(year=plot_year)])]
+                fig.update_xaxes(
+                    rangebreaks=[
+                        dict(values=[datetime.datetime(plot_year, 2, 29)])
+                    ]
+                )
             except Exception as e:
                 print(e)
 


### PR DESCRIPTION
This PR fixes #2773 #2774 #2775 where 'hourly', 'daily' and 'weekly' plots where not being shown. This is likely caused by `rangebreaks` having a value that is in a different format of the plot data.

Testing:
- Remember to clean plot cache
- Try creating time series bar plots i.e. solar radiation, solar collector, photovoltaic
- Switch to each date frame i.e. hourly, daily, weekly, monthly, yearly