### PR TITLE
Select all technologies in optimization if none is selected

### DIFF
--- a/cea/config.py
+++ b/cea/config.py
@@ -1086,7 +1086,7 @@ def parse_string_to_list(line):
         return []
     line = line.replace('\n', ' ')
     line = line.replace('\r', ' ')
-    return [field.strip() for field in line.split(',') if field.strip()]
+    return [str(field.strip()) for field in line.split(',') if field.strip()]
 
 
 def parse_string_coordinate_list(string_tuples):

--- a/cea/config.py
+++ b/cea/config.py
@@ -878,6 +878,13 @@ class MultiChoiceParameter(ChoiceParameter):
     """Like ChoiceParameter, but multiple values from the choices list can be used"""
     typename = 'MultiChoiceParameter'
 
+    @property
+    def nullable(self):
+        try:
+            return self.config.default_config.getboolean(self.section.name, self.name + '.nullable')
+        except configparser.NoOptionError:
+            return False
+
     def encode(self, value):
         assert not isinstance(value, basestring), "Bad value for encode of parameter {pname}".format(pname=self.name)
         for choice in value:
@@ -886,6 +893,9 @@ class MultiChoiceParameter(ChoiceParameter):
         return ', '.join(map(str, value))
 
     def decode(self, value):
+        # Select all choices if empty value and not nullable (default is not nullable)
+        if not self.nullable and value == '':
+            return self._choices
         choices = parse_string_to_list(value)
         return [choice for choice in choices if choice in self._choices]
 

--- a/cea/datamanagement/archetypes_mapper.py
+++ b/cea/datamanagement/archetypes_mapper.py
@@ -97,8 +97,6 @@ def archetypes_mapper(locator,
         internal_loads_mapper(list_uses, locator, occupant_densities, building_typology_df)
 
     if update_schedule_operation_cea:
-        if not buildings:
-            buildings = locator.get_zone_building_names()
         calc_mixed_schedule(locator, building_typology_df, buildings)
 
     if update_supply_systems_dbf:

--- a/cea/default.config
+++ b/cea/default.config
@@ -257,19 +257,58 @@ buildings.help = List of buildings considered for the demand simulation (to simu
 
 loads-output =
 loads-output.type = MultiChoiceParameter
-loads-output.choices = GRID, E_sys, Eal, Ea, Ev, El, Edata, Epro, Eaux, E_ww, E_hs, E_cs, E_cre, E_cdata,Qhs_sen_shu, Qhs_sen_ahu, Qhs_lat_ahu,Qhs_sen_aru, Qhs_lat_aru, Qhs_sen_sys,Qhs_lat_sys, Qhs_em_ls, Qhs_dis_ls,Qhs_sys_shu, Qhs_sys_ahu, Qhs_sys_aru,Qcs_sys_scu, Qcs_sys_ahu, Qcs_sys_aru,DH_hs, Qhs_sys, Qhs,DH_ww, Qww_sys, Qww,DC_cs, Qcs_sys, Qcs,DC_cre, Qcre_sys, Qcre,DC_cdata, Qcdata_sys, Qcdata,NG_hs,COAL_hs,OIL_hs,WOOD_hs,NG_ww,COAL_ww,OIL_ww,WOOD_ww,Qcs_sen_scu, Qcs_sen_ahu,Qcs_lat_ahu, Qcs_sen_aru, Qcs_lat_aru,Qcs_sen_sys, Qcs_lat_sys, Qcs_em_ls,Qcs_dis_ls, Qcpro_sys, Qhpro_sys, QH_sys, QC_sys, GRID_a, GRID_l, GRID_v, GRID_data, GRID_pro, GRID_aux, GRID_ww, GRID_hs, GRID_cdata, GRID_cs, GRID_cre
+loads-output.choices = PV,
+    GRID,
+    GRID_a,
+    GRID_l,
+    GRID_v,
+    GRID_data,
+    GRID_pro,
+    GRID_aux,
+    GRID_ww,
+    GRID_hs,
+    GRID_cs,
+    GRID_cdata,
+    GRID_cre,
+    E_sys, Eal, Ea, El, Ev, Edata, Epro, Eaux,
+    E_ww, E_hs, E_cs, E_cre, E_cdata,
+    Qhs_sen_shu, Qhs_sen_ahu, Qhs_lat_ahu,
+    Qhs_sen_aru, Qhs_lat_aru, Qhs_sen_sys,
+    Qhs_lat_sys, Qhs_em_ls, Qhs_dis_ls,
+    Qhs_sys_shu, Qhs_sys_ahu, Qhs_sys_aru,
+    Qcs_sys_scu, Qcs_sys_ahu, Qcs_sys_aru,
+    DH_hs, Qhs_sys, Qhs,
+    DH_ww, Qww_sys, Qww,
+    DC_cs, Qcs_sys, Qcs,
+    DC_cre, Qcre_sys, Qcre,
+    DC_cdata, Qcdata_sys, Qcdata,
+    NG_hs,
+    COAL_hs,
+    OIL_hs,
+    WOOD_hs,
+    SOLAR_hs,
+    NG_ww,
+    COAL_ww,
+    OIL_ww,
+    WOOD_ww,
+    SOLAR_ww,
+    Qcs_sen_scu, Qcs_sen_ahu,
+    Qcs_lat_ahu, Qcs_sen_aru, Qcs_lat_aru,
+    Qcs_sen_sys, Qcs_lat_sys, Qcs_em_ls,
+    Qcs_dis_ls, Qhpro_sys, Qcpro_sys,
+    QH_sys, QC_sys
 loads-output.help = List of loads output by the demand simulation (to simulate all load types in demand_writer, leave blank).
 loads-output.category = Advanced
 
 massflows-output =
 massflows-output.type = MultiChoiceParameter
-massflows-output.choices = mcpww_sys,mcptw,mcpcs_sys,mcphs_sys,mcpcs_sys_ahu,mcpcs_sys_aru,mcpcs_sys_scu,mcphs_sys_ahu,mcphs_sys_aru,mcphs_sys_shu,mcpcre_sys,mcpcdata_sys
+massflows-output.choices = mcpww_sys, mcptw, mcpcs_sys, mcphs_sys, mcpcs_sys_ahu, mcpcs_sys_aru, mcpcs_sys_scu, mcphs_sys_ahu, mcphs_sys_aru, mcphs_sys_shu, mcpcre_sys, mcpcdata_sys
 massflows-output.help = List of mass flow rates output by the demand simulation (to simulate all system mass flow rates in demand_writer, leave blank).
 massflows-output.category = Advanced
 
 temperatures-output =
 temperatures-output.type = MultiChoiceParameter
-temperatures-output.choices =  T_int, T_ext, theta_o, Tww_sys_sup, Tww_sys_re, Tcre_sys_re, Tcre_sys_sup,Tcdata_sys_re, Tcdata_sys_sup,Ths_sys_sup_aru, Ths_sys_sup_ahu, Ths_sys_sup_shu,Ths_sys_re_aru, Ths_sys_re_ahu, Ths_sys_re_shu, Tcs_sys_sup_aru, Tcs_sys_sup_ahu, Tcs_sys_sup_scu, Tcs_sys_re_aru, Tcs_sys_re_ahu, Tcs_sys_re_scu, Ths_sys_sup, Ths_sys_re, Tcs_sys_sup, Tcs_sys_re
+temperatures-output.choices =  T_int, T_ext, theta_o, Tww_sys_sup, Tww_sys_re, Tcre_sys_re, Tcre_sys_sup, Tcdata_sys_re, Tcdata_sys_sup, Ths_sys_sup_aru, Ths_sys_sup_ahu, Ths_sys_sup_shu, Ths_sys_re_aru, Ths_sys_re_ahu, Ths_sys_re_shu, Tcs_sys_sup_aru, Tcs_sys_sup_ahu, Tcs_sys_sup_scu, Tcs_sys_re_aru, Tcs_sys_re_ahu, Tcs_sys_re_scu, Ths_sys_sup, Ths_sys_re, Tcs_sys_sup, Tcs_sys_re
 temperatures-output.help = List of temperatures output by the demand simulation (to simulate all temperatures in demand_writer, leave blank).
 temperatures-output.category = Advanced
 

--- a/cea/demand/demand_main.py
+++ b/cea/demand/demand_main.py
@@ -68,7 +68,7 @@ def demand_calculation(locator, config):
     t0 = time.clock()
 
     # LOCAL VARIABLES
-    building_names = config.demand.buildings or locator.get_zone_building_names()
+    building_names = config.demand.buildings
     use_dynamic_infiltration = config.demand.use_dynamic_infiltration_calculation
     resolution_output = config.demand.resolution_output
     loads_output = config.demand.loads_output
@@ -158,7 +158,7 @@ def radiation_files_exist(locator, config):
     def daysim_results_exist(building_name):
         return os.path.exists(locator.get_radiation_building(building_name))
 
-    building_names = config.demand.buildings or locator.get_zone_building_names()
+    building_names = config.demand.buildings
 
     return all(daysim_results_exist(building_name) for building_name in building_names)
 

--- a/cea/demand/demand_writers.py
+++ b/cea/demand/demand_writers.py
@@ -24,80 +24,10 @@ class DemandWriter(object):
 
         from cea.demand.thermal_loads import TSD_KEYS_ENERGY_BALANCE_DASHBOARD, TSD_KEYS_SOLAR
 
-        if not loads:
-            self.load_vars = ['PV', 'GRID',
-                              'GRID_a',
-                              'GRID_l',
-                              'GRID_v',
-                              'GRID_data',
-                              'GRID_pro',
-                              'GRID_aux',
-                              'GRID_ww',
-                              'GRID_hs',
-                              'GRID_cs',
-                              'GRID_cdata',
-                              'GRID_cre',
-                              'E_sys', 'Eal', 'Ea', 'El', 'Ev', 'Edata', 'Epro', 'Eaux',
-                              'E_ww', 'E_hs', 'E_cs', 'E_cre', 'E_cdata',
-                              'Qhs_sen_shu', 'Qhs_sen_ahu', 'Qhs_lat_ahu',
-                              'Qhs_sen_aru', 'Qhs_lat_aru', 'Qhs_sen_sys',
-                              'Qhs_lat_sys', 'Qhs_em_ls', 'Qhs_dis_ls',
-                              'Qhs_sys_shu', 'Qhs_sys_ahu', 'Qhs_sys_aru',
-                              'Qcs_sys_scu', 'Qcs_sys_ahu', 'Qcs_sys_aru',
-                              'DH_hs', 'Qhs_sys', 'Qhs',
-                              'DH_ww', 'Qww_sys', 'Qww',
-                              'DC_cs', 'Qcs_sys', 'Qcs',
-                              'DC_cre', 'Qcre_sys', 'Qcre',
-                              'DC_cdata', 'Qcdata_sys', 'Qcdata',
-                              'NG_hs',
-                              'COAL_hs',
-                              'OIL_hs',
-                              'WOOD_hs',
-                              'SOLAR_hs',
-                              'NG_ww',
-                              'COAL_ww',
-                              'OIL_ww',
-                              'WOOD_ww',
-                              'SOLAR_ww',
-                              'Qcs_sen_scu', 'Qcs_sen_ahu',
-                              'Qcs_lat_ahu', 'Qcs_sen_aru', 'Qcs_lat_aru',
-                              'Qcs_sen_sys', 'Qcs_lat_sys', 'Qcs_em_ls',
-                              'Qcs_dis_ls', 'Qhpro_sys', 'Qcpro_sys',
-                              'QH_sys', 'QC_sys']
-
-        else:
-            self.load_vars = loads
-
+        self.load_vars = loads
         self.load_plotting_vars = TSD_KEYS_ENERGY_BALANCE_DASHBOARD + TSD_KEYS_SOLAR
-
-        if not massflows:
-            self.mass_flow_vars = ['mcpww_sys',
-                                   'mcptw',
-                                   'mcpcs_sys',
-                                   'mcphs_sys',
-                                   'mcpcs_sys_ahu',
-                                   'mcpcs_sys_aru',
-                                   'mcpcs_sys_scu',
-                                   'mcphs_sys_ahu',
-                                   'mcphs_sys_aru',
-                                   'mcphs_sys_shu',
-                                   'mcpcre_sys',
-                                   'mcpcdata_sys']
-        else:
-            self.mass_flow_vars = massflows
-
-        if not temperatures:
-            self.temperature_vars = ['T_int', 'T_ext', 'theta_o',
-                                     'Tww_sys_sup', 'Tww_sys_re',
-                                     'Tcre_sys_re', 'Tcre_sys_sup',
-                                     'Tcdata_sys_re', 'Tcdata_sys_sup',
-                                     'Ths_sys_sup_aru', 'Ths_sys_sup_ahu', 'Ths_sys_sup_shu',
-                                     'Ths_sys_re_aru', 'Ths_sys_re_ahu', 'Ths_sys_re_shu',
-                                     'Tcs_sys_sup_aru', 'Tcs_sys_sup_ahu', 'Tcs_sys_sup_scu',
-                                     'Tcs_sys_re_aru', 'Tcs_sys_re_ahu', 'Tcs_sys_re_scu',
-                                     'Ths_sys_sup', 'Ths_sys_re', 'Tcs_sys_sup', 'Tcs_sys_re']
-        else:
-            self.temperature_vars = temperatures
+        self.mass_flow_vars = massflows
+        self.temperature_vars = temperatures
 
         self.OTHER_VARS = ['Name', 'Af_m2', 'Aroof_m2', 'GFA_m2', 'Aocc_m2', 'people0']
 

--- a/cea/demand/schedule_maker/schedule_maker.py
+++ b/cea/demand/schedule_maker/schedule_maker.py
@@ -43,8 +43,6 @@ def schedule_maker_main(locator, config, building=None):
     else:
         raise ValueError("Invalid schedule model: {schedule_model}".format(**locals()))
 
-    if buildings == []:
-        buildings = locator.get_zone_building_names()
     if building != None:
         buildings = [building] #this is to run the tests
 

--- a/cea/optimization/master/master_main.py
+++ b/cea/optimization/master/master_main.py
@@ -169,6 +169,12 @@ def non_dominated_sorting_genetic_algorithm(locator,
     crossover_method_integer = config.optimization.crossover_method_integer
     crossover_method_continuous = config.optimization.crossover_method_continuous
 
+    # Select all technologies if empty
+    if not technologies_heating_allowed:
+        technologies_heating_allowed = config.get_parameter('optimization:technologies-dh')._choices
+    if not technologies_cooling_allowed:
+        technologies_cooling_allowed = config.get_parameter('optimization:technologies-dc')._choices
+
     # SET-UP EVOLUTIONARY ALGORITHM
     # Hyperparameters
     P = 12

--- a/cea/optimization/master/master_main.py
+++ b/cea/optimization/master/master_main.py
@@ -169,12 +169,6 @@ def non_dominated_sorting_genetic_algorithm(locator,
     crossover_method_integer = config.optimization.crossover_method_integer
     crossover_method_continuous = config.optimization.crossover_method_continuous
 
-    # Select all technologies if empty
-    if not technologies_heating_allowed:
-        technologies_heating_allowed = config.get_parameter('optimization:technologies-dh')._choices
-    if not technologies_cooling_allowed:
-        technologies_cooling_allowed = config.get_parameter('optimization:technologies-dc')._choices
-
     # SET-UP EVOLUTIONARY ALGORITHM
     # Hyperparameters
     P = 12

--- a/cea/resources/geothermal.py
+++ b/cea/resources/geothermal.py
@@ -55,12 +55,8 @@ def calc_area_buildings(locator, buildings_list):
     prop_geometry = Gdf.from_file(locator.get_zone_geometry())
     prop_geometry['footprint'] = prop_geometry.area
 
-    if buildings_list == []:  # the user selected all buildings
-        area_below_buildings = prop_geometry['footprint'].sum()
-
-    else:  # the user selected more buildings
-        areas = prop_geometry[prop_geometry["Name"].isin(buildings_list)]
-        area_below_buildings = areas.sum()
+    footprint = prop_geometry[prop_geometry["Name"].isin(buildings_list)]['footprint']
+    area_below_buildings = footprint.sum()
 
     return area_below_buildings
 

--- a/cea/schemas.py
+++ b/cea/schemas.py
@@ -49,10 +49,15 @@ def schemas(plugins):
         schemas_pickle = os.path.expanduser("~/schemas.yml.pickle")
 
         # compare the dates of the two files - use the pickle if it's newer
+        schemas_dict = None
         if os.path.exists(schemas_pickle) and os.path.getmtime(schemas_pickle) > os.path.getmtime(schemas_yml):
             with open(schemas_pickle, "r") as schemas_pickle_fp:
-                schemas_dict = cPickle.load(schemas_pickle_fp)
-        else:
+                try:
+                    schemas_dict = cPickle.load(schemas_pickle_fp)
+                except:
+                    schemas_dict = None
+
+        if not schemas_dict:
             # ok. this will take a while to read...
             schemas_dict = yaml.load(open(schemas_yml), Loader=OrderedDictYAMLLoader)
             # ... so write out a pickle for next time

--- a/cea/technologies/network_layout/main.py
+++ b/cea/technologies/network_layout/main.py
@@ -56,12 +56,8 @@ def layout_network(network_layout, locator, plant_building_names=None, output_na
     path_output_nodes_shp = locator.get_network_layout_nodes_shapefile(type_network, output_name_network)
     output_network_folder = locator.get_input_network_folder(type_network, output_name_network)
 
-    if list_district_scale_buildings != []:
-        building_names = locator.get_zone_building_names()
-        disconnected_building_names = [x for x in list_district_scale_buildings if x not in building_names]
-    else:
-        # if list_district_scale_buildings is left blank, we assume all buildings are connected (no disconnected buildings)
-        disconnected_building_names = []
+    disconnected_building_names = [x for x in list_district_scale_buildings if x not in list_district_scale_buildings]
+
     calc_steiner_spanning_tree(crs_projected,
                                temp_path_potential_network_shp,
                                output_network_folder,

--- a/cea/technologies/network_layout/substations_location.py
+++ b/cea/technologies/network_layout/substations_location.py
@@ -28,10 +28,8 @@ def calc_building_centroids(input_buildings_shp,
                             total_demand=False):
     # # get coordinate system and project to WSG 84
     zone_df = gdf.from_file(input_buildings_shp)
-    if list_district_scale_buildings != []:
-        # get only buildings described
-        zone_df = zone_df.loc[zone_df['Name'].isin(list_district_scale_buildings)]
-        zone_df = zone_df.reset_index(drop=True)
+    zone_df = zone_df.loc[zone_df['Name'].isin(list_district_scale_buildings)]
+    zone_df = zone_df.reset_index(drop=True)
 
     # get only buildings with a demand, send out a message if there are less than 2 buildings.
     if consider_only_buildings_with_demand:

--- a/cea/technologies/solar/photovoltaic_thermal.py
+++ b/cea/technologies/solar/photovoltaic_thermal.py
@@ -675,8 +675,6 @@ def main(config):
     print('Running photovoltaic-thermal with type-pvpanel = %s' % config.solar.type_pvpanel)
 
     building_names = config.solar.buildings
-    if not building_names:
-        building_names = locator.get_zone_building_names()
 
     hourly_results_per_building = gdf.from_file(locator.get_zone_geometry())
     latitude, longitude = get_lat_lon_projected_shapefile(hourly_results_per_building)

--- a/cea/technologies/solar/solar_collector.py
+++ b/cea/technologies/solar/solar_collector.py
@@ -967,8 +967,6 @@ def main(config):
     print('Running solar-collector with type-scpanel = %s' % config.solar.type_scpanel)
 
     building_names = config.solar.buildings
-    if not building_names:
-        building_names = locator.get_zone_building_names()
 
     zone_geometry = gdf.from_file(locator.get_zone_geometry())
     latitude, longitude = get_lat_lon_projected_shapefile(zone_geometry)


### PR DESCRIPTION
This PR solves #2752 by returning all default technologies for optimization parameters `technologies_DH` and `technologies_DC` if they are empty.

It was also observed that the class `MultiChoiceParameter` in config does not default to using `_choices` if the value in config is empty. Instead, they are manually handled in the scripts. Some examples are `input-databases` for **archetypes-mapper** and `loads-output` for **demand**. I'm not sure if this should be the default behavior but this could be added to the class in another issue.

To test:
Remove all choices in both `technologies_DH` and `technologies_DC` in optimization config and run optimization
