### PR TITLE
Release 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+- 2020-07-27 - 3.4.0 - #2807 Select all technologies in optimization if none is selected
+- 2020-07-27 - 3.4.0 - #2806 Properly parse `building:levels` data from OSM
+- 2020-07-27 - 3.4.0 - #2767 Clean geometries from OpenStreetMap in zone-helper
+- 2020-07-09 - 3.4.0 - #2799 2751 cleanup hardcoded values
+- 2020-06-19 - 3.4.0 - #2780 Fix some timeseries plots not showing
+- 2020-06-12 - 3.4.0 - #2770 Release 3.4.0
 - 2020-06-12 - 3.3.0 - #2771 Update range values
 - 2020-06-12 - 3.3.0 - #2766 Return empty list if unable to find project
 - 2020-06-12 - 3.3.0 - #2768 Fixing electro-mobility documentation

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -9,6 +9,46 @@ The CEA team
 Starting from version 2.9.1 the credits are structured alphabetically (surname) and split into the categories of developers,
 scrum master, project owner, project sponsor and collaborators.
 
+- Version 3.7.0 - July 2020
+
+    Developers:
+    * [Amr Elesawy](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/amr-elesawy.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+    * [Gabriel Happle](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/gabriel-happle.html)
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+    * [Reynold Mok](http://https://cityenergyanalyst.com/community)
+    * [Martín Mosteiro Romero](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/martin-mosteiro-romero.html)
+    * [Zhongming Shi](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/zhongming-shi.html)
+    * [Bhargava Krishna Sreepathi ](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/sreepathi-bhargava-krishna.html)
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Scrum master:
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Project owner:
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+
+    Project sponsor:
+    * [Arno Schlueter](http://www.systems.arch.ethz.ch/about-us/team/arno-schlueter.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+
+    Collaborators:
+    * Jose Bello
+    * Anastasiya Bosova
+    * Kian Wee Chen
+    * Jack Hawthorne
+    * Fazel Khayatian
+    * Victor Marty
+    * Paul Neitzel
+    * Thuy-An Nguyen
+    * Bo Lie Ong
+    * Emanuel Riegelbauer
+    * Lennart Rogenhofer
+    * Toivo Säwén
+    * Sebastian Troiztsch    
+    * Tim Vollrath
+
+
 - Version 3.4.0 - June 2020
 
     Developers:

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.4.0"
+__version__ = "3.7.0"
 
 
 class ConfigError(Exception):

--- a/cea/config.py
+++ b/cea/config.py
@@ -1114,7 +1114,7 @@ def parse_string_coordinate_list(string_tuples):
 def validate_coord_tuple(coord_tuple):
     """Validates a (lat, long) tuple, throws exception if not valid"""
 
-    lat, lon = coord_tuple
+    lon, lat = coord_tuple
     if lat < -90 or lat > 90:
         raise ValueError('Latitude must be between -90 and 90. Got {}'.format(lat))
     if lon < -180 or lon > 180:

--- a/cea/workflows/coverage.yml
+++ b/cea/workflows/coverage.yml
@@ -1,0 +1,159 @@
+# try to run as much of the CEA as possible for coverage / testing
+# (requires cea-workflow-utils plugin)
+- config: user
+  "general:multiprocessing": False
+  "general:project": "${userprofile}/Documents/CEA-Projects/testing"
+  "radiation:daysim-bin-directory": "${CEA_radiation_daysim-bin-directory}"
+- config: .
+  "general:scenario-name": "heating"
+- script: run-command
+  parameters:
+    command: 'if not exist "{general:project}\\{general:scenario-name}\\inputs\\building-geometry\\" mkdir "{general:project}\\{general:scenario-name}\\inputs\\building-geometry"'
+- script: data-initializer
+  parameters:
+    databases-path: CH
+- script: create-polygon
+  parameters:
+    # coordinates are kleinalbis, zurich, 4 buildings
+    coordinates: "(8.506395769175878, 47.35805575665319), (8.506760549601978, 47.35792978000122), (8.506581736104215, 47.35767782601688), (8.506395769175878, 47.35805575665319)"
+    filename: site
+- script: zone-helper
+- script: surroundings-helper
+- script: streets-helper
+- script: terrain-helper
+- script: weather-helper
+  parameters:
+    weather: Zuerich-Kloten_1990_2010_TMY
+- script: archetypes-mapper
+  parameters:
+      input-databases: ['comfort', 'architecture', 'air-conditioning', 'internal-loads', 'supply', 'schedules']
+      buildings: []
+- script: radiation
+  parameters:
+    consider-intersections: false
+- script: schedule-maker
+- script: demand
+- script: emissions
+- script: system-costs
+- script: water-body-potential
+- script: sewage-potential
+- script: shallow-geothermal-potential
+- script: photovoltaic
+- script: solar-collector
+  parameters:
+    type-scpanel: FP
+- script: solar-collector
+  parameters:
+    type-scpanel: ET
+- script: photovoltaic-thermal
+  parameters:
+    type-scpanel: FP
+- script: photovoltaic-thermal
+  parameters:
+    type-scpanel: ET
+- script: network-layout
+  parameters:
+    network-type: DH
+- script: thermal-network
+  parameters:
+    network-type: DH
+    network-model: detailed
+#    stop-t: 744 # run for one month
+    start-t: 0
+    stop-t: 24 # run for one day
+- script: thermal-network
+  parameters:
+    network-type: DH
+    network-model: simplified
+- script: decentralized
+- script: optimization
+  parameters:
+    network-type: DH
+    number-of-generations: 2
+    population-size: 5
+    random-seed: 100
+- script: multi-criteria-analysis
+  parameters:
+    generation: 2
+- script: run-all-plots
+  parameters:
+    network-type: DH
+    network-name: ""
+
+
+# Run cooling
+- config: .
+  "general:scenario-name": "cooling"
+- script: run-command
+  parameters:
+    command: 'if not exist "{general:project}\\{general:scenario-name}\\inputs\\building-geometry\\" mkdir "{general:project}\\{general:scenario-name}\\inputs\\building-geometry"'
+- script: data-initializer
+  parameters:
+    databases-path: SG
+- script: create-polygon
+  parameters:
+    # coordinates are singapore
+    coordinates: "(103.8276659476768, 1.355675107613739), (103.8280062305375, 1.355983066896414), (103.827873699494, 1.35553903230245), (103.8276659476768, 1.355675107613739)"
+    filename: site
+- script: zone-helper
+- script: surroundings-helper
+- script: streets-helper
+- script: terrain-helper
+- script: weather-helper
+  parameters:
+    weather: Singapore-Changi_1990_2010_TMY
+- script: archetypes-mapper
+  parameters:
+      input-databases: ['comfort', 'architecture', 'air-conditioning', 'internal-loads', 'supply', 'schedules']
+      buildings: []
+- script: radiation
+  parameters:
+    consider-intersections: false
+- script: schedule-maker
+- script: demand
+- script: emissions
+- script: system-costs
+- script: water-body-potential
+- script: sewage-potential
+- script: shallow-geothermal-potential
+- script: photovoltaic
+- script: solar-collector
+  parameters:
+    type-scpanel: FP
+- script: solar-collector
+  parameters:
+    type-scpanel: ET
+- script: photovoltaic-thermal
+  parameters:
+    type-scpanel: FP
+- script: photovoltaic-thermal
+  parameters:
+    type-scpanel: ET
+- script: network-layout
+  parameters:
+    network-type: DC
+- script: thermal-network
+  parameters:
+    network-type: DC
+    network-model: detailed
+#    stop-t: 744 # run for one month
+    start-t: 0
+    stop-t: 24 # run for one day
+- script: thermal-network
+  parameters:
+    network-type: DC
+    network-model: simplified
+- script: decentralized
+- script: optimization
+  parameters:
+    network-type: DC
+    number-of-generations: 2
+    population-size: 5
+    random-seed: 100
+- script: multi-criteria-analysis
+  parameters:
+    generation: 2
+- script: run-all-plots
+  parameters:
+    network-type: DC
+    network-name: ""


### PR DESCRIPTION
This is the result of the M3.7 sprint. We skipped a few releases while we worked on a Python 3 port of the CEA, but felt we need to do at least one more Python 2.7 release with updates and bug fixes.

To install it on windows, download and run the attached [Setup_CityEnergyAnalyst_3.7.0.exe](https://github.com/architecture-building-systems/CityEnergyAnalyst/releases/download/v3.7.0/Setup_CityEnergyAnalyst_3.7.0.exe). See [the installation guide](https://city-energy-analyst.readthedocs.io/en/latest/getting-started.html#install-and-set-up) for more options.

From the CHANGELOG:

- 2020-07-27 - 3.4.0 - #2807 Select all technologies in optimization if none is selected
- 2020-07-27 - 3.4.0 - #2806 Properly parse `building:levels` data from OSM
- 2020-07-27 - 3.4.0 - #2767 Clean geometries from OpenStreetMap in zone-helper
- 2020-07-09 - 3.4.0 - #2799 2751 cleanup hardcoded values
- 2020-06-19 - 3.4.0 - #2780 Fix some timeseries plots not showing
- 2020-06-12 - 3.4.0 - #2770 Release 3.4.0