### PR TITLE
Release 3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- 2020-09-14 - 3.7.0 - #2828 Introduce new Daysim binaries
+- 2020-08-18 - 3.7.0 - #2818 2817 ventilation rate
+- 2020-08-13 - 3.7.0 - #2814 Ventilation loads not present in the output, the issue was tested by @lguilhermers all works as expected
+- 2020-07-27 - 3.7.0 - #2809 Release 3.7.0
 - 2020-07-27 - 3.4.0 - #2807 Select all technologies in optimization if none is selected
 - 2020-07-27 - 3.4.0 - #2806 Properly parse `building:levels` data from OSM
 - 2020-07-27 - 3.4.0 - #2767 Clean geometries from OpenStreetMap in zone-helper

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -9,6 +9,47 @@ The CEA team
 Starting from version 2.9.1 the credits are structured alphabetically (surname) and split into the categories of developers,
 scrum master, project owner, project sponsor and collaborators.
 
+- Version 3.10.0 - September 2020
+
+    Developers:
+    * [Amr Elesawy](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/amr-elesawy.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+    * [Gabriel Happle](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/gabriel-happle.html)
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+    * [Reynold Mok](http://https://cityenergyanalyst.com/community)
+    * [Martín Mosteiro Romero](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/martin-mosteiro-romero.html)
+    * [Zhongming Shi](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/zhongming-shi.html)
+    * [Bhargava Krishna Sreepathi](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/sreepathi-bhargava-krishna.html)
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Scrum master:
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Project owner:
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+
+    Project sponsor:
+    * [Arno Schlueter](http://www.systems.arch.ethz.ch/about-us/team/arno-schlueter.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+    * [Christian Schaffner](https://esc.ethz.ch/people/person-detail.schaffner.html)
+
+    Collaborators:
+    * Jose Bello
+    * Anastasiya Bosova
+    * Kian Wee Chen
+    * Jack Hawthorne
+    * Fazel Khayatian
+    * Victor Marty
+    * Paul Neitzel
+    * Thuy-An Nguyen
+    * Bo Lie Ong
+    * Emanuel Riegelbauer
+    * Lennart Rogenhofer
+    * Toivo Säwén
+    * Sebastian Troiztsch    
+    * Tim Vollrath
+
+
 - Version 3.7.0 - July 2020
 
     Developers:

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.7.0"
+__version__ = "3.10.0"
 
 
 class ConfigError(Exception):


### PR DESCRIPTION
This is the result of the M3.10 sprint. We skipped a few releases while we worked on a Python 3 port of the CEA, but felt we need to do at least one more Python 2.7 release with updates and bug fixes.

Additionally, we improved radiation script runtime using multiprocessing and the new binaries. Users are now able to switch between the old Daysim binaries and the new one.

To install it on windows, download and run the attached [Setup_CityEnergyAnalyst_3.10.0.exe](https://github.com/architecture-building-systems/CityEnergyAnalyst/releases/download/v3.10.0/Setup_CityEnergyAnalyst_3.10.0.exe). See the [installation guide](https://city-energy-analyst.readthedocs.io/en/latest/installation/installation.html) for more options.

From the CHANGELOG:
- 2020-09-14 - 3.7.0 - #2828 Introduce new Daysim binaries
- 2020-08-18 - 3.7.0 - #2818 2817 ventilation rate
- 2020-08-13 - 3.7.0 - #2814 Ventilation loads not present in the output, the issue was tested by @lguilhermers all works as expected
- 2020-07-27 - 3.7.0 - #2809 Release 3.7.0