### PR TITLE
i2830 Update release documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ of the first open-source computational tools for the design of low-carbon and hi
 The CEA combines knowledge of urban planning and energy systems engineering in an integrated framework. This
 allows to study the effects, trade-offs and synergies of urban design options, building retrofits and energy infrastructure plans.
 
-* Click `here <http://city-energy-analyst.readthedocs.io/en/latest/getting-started.html>`__  for installation manual and tutorials
+* Click `here <https://city-energy-analyst.readthedocs.io/en/latest/index.html>`__  for installation manual and tutorials
 
 * Click `here <https://github.com/architecture-building-systems/CityEnergyAnalyst/issues>`__ to report an issue
 
@@ -37,8 +37,8 @@ allows to study the effects, trade-offs and synergies of urban design options, b
 Cite us:
 --------
 
-For V2.9.1 (stable):    |V2.9.1|
+For V3.10.0 (stable):    |V3.10.0|
 
-.. |V2.9.1| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1487867.svg
-   :target: https://doi.org/10.5281/zenodo.1487867
+.. |V3.10.0| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4032169.svg
+   :target: https://doi.org/10.5281/zenodo.4032169
 

--- a/docs/how-to-create-a-new-release.rst
+++ b/docs/how-to-create-a-new-release.rst
@@ -60,11 +60,28 @@ The repository admin merging a pull request to master is responsible for updatin
 .. _GitHub issues milestones list: https://github.com/architecture-building-systems/CityEnergyAnalyst/milestones
 
 
+Create a Release Branch
+-----------------------
+- Create a branch ``Release-x.x.x`` from master.
+
+
 Update the CREDITS.md file
 --------------------------
 
 For each minor release (2.2, 2.3, ...) the ``CREDITS.md`` file needs to be updated to include all the authors that
 worked on that release.
+
+
+Update CHANGELOG
+----------------
+
+- Run ``create-changelog.py`` in ``CityEnergyAnalyst\bin``
+
+
+Merge the Release Branch
+-------------------------
+
+- Merge the branch ``Release-x.x.x`` into master.
 
 
 Creating the installer

--- a/docs/how-to-create-a-new-release.rst
+++ b/docs/how-to-create-a-new-release.rst
@@ -84,6 +84,11 @@ Merge the Release Branch
 - Merge the branch ``Release-x.x.x`` into master.
 
 
+Create a Release Draft on GitHub
+--------------------------------
+- Tag the release with the correct version number.
+
+
 Creating the installer
 ----------------------
 
@@ -107,6 +112,26 @@ Creating the installer
 
 .. _7z: https://www.7-zip.org/7z.html
 
+
+Updating the CEA GUI interface
+------------------------------
+
+For the installer to be able to pick up the newest version of the CEA GUI interface, you need to build it,
+create a release and attach a ``win-unpacked.7z`` to the release. Here are the steps:
+
+- pull the newest version of the ``CityEnergyAnalyst-GUI`` repository
+- open CEA Console, navigate to the GitHub repo of the ``CityEnergyAnalyst-GUI`` repository
+- type ``yarn dist:dir``, wait for the command to complete
+- the subfolder ``dist`` will contain a folder ``win-unpacked``
+- compress the folder ``win-unpacked`` to ``win-unpacked.7z``
+- attach the ``win-unpacked.7z`` file to the CityEnergyAnalyst release
+
+
+Publish the Release on GitHub
+-----------------------------
+The release should be published so that it could be found on GitHub for testing (the next step).
+
+
 Testing in a virtual machine
 ----------------------------
 
@@ -116,6 +141,7 @@ is still working. This test goes a bit further than the regular test in that it 
 still work on a new installation. This is important because it can find missing packages in the dependency lists etc.
 
 .. _VirtualBox: https://www.virtualbox.org/
+
 
 Building the documentation
 --------------------------
@@ -145,6 +171,7 @@ For more information, check out the :doc:`how-to-document-cea`.
 .. _sphinx: https://www.sphinx-doc.org/en/master/usage/installation.html
 .. _GraphViz: http://www.graphviz.org/Download.php
 
+
 Uploading to PyPI
 -----------------
 
@@ -173,25 +200,12 @@ Uploading to PyPI
 
 .. _twine: https://pypi.python.org/pypi/twine
 
-Updating the CEA GUI interface
-------------------------------
 
-For the installer to be able to pick up the newest version of the CEA GUI interface, you need to build it,
-create a release and attach a ``win-unpacked.7z`` to the release. Here are the steps:
-
-- pull the newest version of the ``CityEnergyAnalyst-GUI`` repository
-- open CEA Console, navigate to the GitHub repo of the ``CityEnergyAnalyst-GUI`` repository
-- type ``yarn dist:dir``, wait for the command to complete
-- the subfolder ``dist`` will contain a folder ``win-unpacked``
-- compress the folder ``win-unpacked`` to ``win-unpacked.7z``
-- attach the ``win-unpacked.7z`` file to the CityEnergyAnalyst release
-
-
-Updating Link in www.cityenergyanalyst.com/tryit
+Updating Link in www.cityenergyanalyst.com/try-cea
 --------------------------------------------------
 
 - go to http://www.cityenergyanalyst.com
-- press Esc and try logging into squarespace (the credentials are here_)
+- press Esc and try logging into squarespace
 - go to Pages/Try CEA  (it is the last page in the list)
 - go to edit 'Page content'
 - go to edit 'Form'

--- a/docs/installation/installation-on-windows.rst
+++ b/docs/installation/installation-on-windows.rst
@@ -6,7 +6,7 @@ Follow these instructions to install the CityEnergyAnalyst (CEA) on a Windows sy
 1. `Download the latest version of CEA in here`_.
 2. Open the installer and follow the instructions
 
-.. _`Download the latest version of CEA in here`: https://cityenergyanalyst.com/tryit
+.. _`Download the latest version of CEA in here`: https://cityenergyanalyst.com/try-cea
 
 .. note:: For installing the development version of CEA, tick the box "development version" during the installation.
 


### PR DESCRIPTION
This PR solved #2830 .
The main changes are in the documentation page `How to create a release?`
This updated documentation shows how @reyery and I were able to create the release for v3.10.0.
It would be great if @daren-thomas could verify if that is the correct sequence. 

Also, some links are updated (see file changes).