### PR TITLE
Release 3.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- 2020-10-29 - 3.11.0 - #2850 2834 docker container for remap
+- 2020-10-29 - 3.11.0 - #2848 2844 database editor bug
+- 2020-10-28 - 3.11.0 - #2846 Predefined hourly setpoints definition
+- 2020-09-25 - 3.11.0 - #2837 Release 3.11.0
 - 2020-09-25 - 3.11.0a5 - #2802 2745 CEA Python3 port (expected release: v3.11.0)
 - 2020-09-16 - 3.10.0 - #2831 i2830 Update release documentation
 - 2020-09-16 - 3.10.0 - #2829 Release 3.10.0

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -9,6 +9,46 @@ The CEA team
 Starting from version 2.9.1 the credits are structured alphabetically (surname) and split into the categories of developers,
 scrum master, project owner, project sponsor and collaborators.
 
+- Version 3.13.0 - October 2020
+
+    Developers:
+    * [Amr Elesawy](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/amr-elesawy.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+    * [Gabriel Happle](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/gabriel-happle.html)
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+    * [Reynold Mok](http://https://cityenergyanalyst.com/community)
+    * [Martín Mosteiro Romero](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/martin-mosteiro-romero.html)
+    * [Zhongming Shi](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/zhongming-shi.html)
+    * [Bhargava Krishna Sreepathi](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/sreepathi-bhargava-krishna.html)
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Scrum master:
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Project owner:
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+
+    Project sponsor:
+    * [Arno Schlueter](http://www.systems.arch.ethz.ch/about-us/team/arno-schlueter.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+    * [Christian Schaffner](https://esc.ethz.ch/people/person-detail.schaffner.html)
+
+    Collaborators:
+    * Jose Bello
+    * Anastasiya Bosova
+    * Kian Wee Chen
+    * Jack Hawthorne
+    * Fazel Khayatian
+    * Victor Marty
+    * Paul Neitzel
+    * Thuy-An Nguyen
+    * Bo Lie Ong
+    * Emanuel Riegelbauer
+    * Lennart Rogenhofer
+    * Toivo Säwén
+    * Sebastian Troiztsch    
+    * Tim Vollrath
+
 
 - Version 3.11.0 - September 2020
 

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.11.0"
+__version__ = "3.13.0"
 
 
 class ConfigError(Exception):


### PR DESCRIPTION
This is the result of the M3.13 sprint. We fixed a bug in the Database Editor - an artefact of the move to Python 3. We're sorry for any inconveniences that might have cause. We also have a working Dockerfile for running the CEA as a headless server.

To install it on windows, download and run the attached Setup_CityEnergyAnalyst_3.13.0.exe. See the installation guide for more options.

From the CHANGELOG:

- 2020-10-29 - 3.11.0 - #2850 2834 docker container for remap
- 2020-10-29 - 3.11.0 - #2848 2844 database editor bug
- 2020-10-28 - 3.11.0 - #2846 Predefined hourly setpoints definition
- 2020-09-25 - 3.11.0 - #2837 Release 3.11.0
