### PR TITLE
Add construction standards as input dependency of zone-helper

### DIFF
--- a/cea/scripts.yml
+++ b/cea/scripts.yml
@@ -356,6 +356,8 @@ default:
     interfaces: [cli]
     module: cea.datamanagement.zone_helper
     parameters: ['general:scenario', zone-helper]
+    input-files:
+      - [get_database_construction_standards]
 
   - name: create-polygon
     label: Create Polygon


### PR DESCRIPTION
A small fix to make sure construction standards database file exists for `zone-helper` to run.