### PR TITLE
2811 can t delete scenario

### DIFF
--- a/cea/interfaces/dashboard/api/project.py
+++ b/cea/interfaces/dashboard/api/project.py
@@ -244,9 +244,6 @@ class Scenario(Resource):
         config = current_app.cea_config
         scenario_path = os.path.join(config.project, scenario)
         try:
-            if config.scenario_name == scenario:
-                config.scenario_name = ''
-                config.save()
             shutil.rmtree(scenario_path)
             return {'scenarios': list_scenario_names_for_project(config)}
         except OSError:


### PR DESCRIPTION
This PR goes in tandem with a CityEnergyAnalyst-GUI PR (for a branch with the same name)

It solves the issue in #2811 (Scenarios couldn't be deleted anymore). The main problem was that the GUI keeps it's own state for project / scenario-name and when looking up the `scenario-name` on the cea server side, the "old" project was being used.

The HTTP DELETE method now uses a payload ("project") in the wrapper function `check_scenario_exists` to set the project to the value of the payload if it is present.