### PR TITLE
CityEnergyAnalyst v3.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+- 2020-12-01 - 3.14.0 - #2873 2852 After merging docker image, change the url used to track master
+- 2020-11-19 - 3.14.0 - #2853 Add option for user-supplied PV tilt angle and maximum roof coverage
+- 2020-11-19 - 3.14.0 - #2857 cea-doc html now works again
+- 2020-11-18 - 3.14.0 - #2870 Add construction standards as input dependency of zone-helper
+- 2020-11-18 - 3.14.0 - #2824 Change surroundings-helper to use a concave instead of a convex hull
+- 2020-11-13 - 3.14.0 - #2866 CityEnergyAnalyst v3.14.0
 - 2020-11-13 - 3.13.0 - #2867 Add missing floor assemblies and update construction standards
 - 2020-11-11 - 3.13.0 - #2856 Empty columns fixed
 - 2020-11-02 - 3.13.0 - #2854 Release 3.13.0

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -9,6 +9,47 @@ The CEA team
 Starting from version 2.9.1 the credits are structured alphabetically (surname) and split into the categories of developers,
 scrum master, project owner, project sponsor and collaborators.
 
+- Version 3.15.0 - November 2020
+
+    Developers:
+    * [Amr Elesawy](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/amr-elesawy.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+    * [Gabriel Happle](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/gabriel-happle.html)
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+    * [Reynold Mok](http://https://cityenergyanalyst.com/community)
+    * [Martín Mosteiro Romero](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/martin-mosteiro-romero.html)
+    * [Zhongming Shi](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/zhongming-shi.html)
+    * [Bhargava Krishna Sreepathi](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/sreepathi-bhargava-krishna.html)
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Scrum master:
+    * [Daren Thomas](http://www.systems.arch.ethz.ch/about-us/team/team-zurich/daren-thomas.html)
+
+    Project owner:
+    * [Shanshan Hsieh](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/shanshan-hsieh.html)
+
+    Project sponsor:
+    * [Arno Schlueter](http://www.systems.arch.ethz.ch/about-us/team/arno-schlueter.html)
+    * [Jimeno A. Fonseca](http://www.systems.arch.ethz.ch/about-us/team/team-singapore/jimeno-fonseca.html)
+    * [Christian Schaffner](https://esc.ethz.ch/people/person-detail.schaffner.html)
+
+    Collaborators:
+    * Jose Bello
+    * Anastasiya Bosova
+    * Kian Wee Chen
+    * Jack Hawthorne
+    * Fazel Khayatian
+    * Victor Marty
+    * Paul Neitzel
+    * Thuy-An Nguyen
+    * Bo Lie Ong
+    * Emanuel Riegelbauer
+    * Lennart Rogenhofer
+    * Toivo Säwén
+    * Sebastian Troiztsch    
+    * Tim Vollrath
+
+
 - Version 3.14.0 - November 2020
 
     Developers:

--- a/cea/__init__.py
+++ b/cea/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.14.0"
+__version__ = "3.15.0"
 
 
 class ConfigError(Exception):

--- a/cea/scripts.yml
+++ b/cea/scripts.yml
@@ -208,7 +208,8 @@ Energy potentials:
     parameters: ['general:scenario', 'general:multiprocessing',
                  'general:number-of-cpus-to-keep-free', 'solar:type-scpanel',
                  'solar:panel-on-roof', 'solar:panel-on-wall', 'solar:annual-radiation-threshold',
-                 'solar:solar-window-solstice', 'solar:t-in-sc', 'solar:buildings']
+                 'solar:solar-window-solstice', 'solar:t-in-sc', 'solar:buildings', 'solar:custom-tilt-angle',
+                 'solar:custom-roof-coverage']
     input-files:
       - [get_radiation_metadata, building_name]
       - [get_zone_geometry]


### PR DESCRIPTION
This is the result of the M3.15 sprint. We added an option for user-supplied PV tilt angle and maximum roof coverage and fixed some bugs.

To install it on windows, download and run the attached `Setup_CityEnergyAnalyst_3.15.0.exe`. See the [installation guide](https://city-energy-analyst.readthedocs.io/en/latest/installation/installation.html) for more options.

From the CHANGELOG:

- 2020-12-01 - 3.14.0 - #2873 2852 After merging docker image, change the url used to track master
- 2020-11-19 - 3.14.0 - #2853 Add option for user-supplied PV tilt angle and maximum roof coverage
- 2020-11-19 - 3.14.0 - #2857 cea-doc html now works again
- 2020-11-18 - 3.14.0 - #2870 Add construction standards as input dependency of zone-helper
- 2020-11-18 - 3.14.0 - #2824 Change surroundings-helper to use a concave instead of a convex hull
- 2020-11-13 - 3.14.0 - #2866 CityEnergyAnalyst v3.14.0