### PR TITLE
Simplify preview image for scenarios with large number of buildings

### DIFF
--- a/cea/interfaces/dashboard/api/project.py
+++ b/cea/interfaces/dashboard/api/project.py
@@ -264,6 +264,8 @@ class Scenario(Resource):
 class ScenarioImage(Resource):
     @api.doc(params={'project': 'Path of Project (Leave blank to use path in config)'})
     def get(self, scenario):
+        building_limit = 500
+
         project = request.args.get('project')
         if project is None:
             config = current_app.cea_config
@@ -297,11 +299,17 @@ class ScenarioImage(Resource):
                         zone_df = zone_df.to_crs(get_geographic_coordinate_system())
                         polygons = zone_df['geometry']
 
-                        polygons = [list(polygons.geometry.exterior[row_id].coords) for row_id in range(polygons.shape[0])]
-
                         m = StaticMap(256, 160)
-                        for polygon in polygons:
-                            out = Polygon(polygon, 'blue', 'black', False)
+                        if len(polygons) <= building_limit:
+                            polygons = [list(polygons.geometry.exterior[row_id].coords) for row_id in
+                                        range(polygons.shape[0])]
+                            for polygon in polygons:
+                                out = Polygon(polygon, 'blue', 'black', False)
+                                m.add_polygon(out)
+                        else:
+                            convex_hull = polygons.unary_union.convex_hull
+                            polygon = convex_hull.exterior.coords
+                            out = Polygon(polygon, None, 'black', False)
                             m.add_polygon(out)
 
                         image = m.render()

--- a/cea/interfaces/dashboard/api/project.py
+++ b/cea/interfaces/dashboard/api/project.py
@@ -313,7 +313,7 @@ class ScenarioImage(Resource):
                             # Generate only the shape outline of the zone area
                             convex_hull = polygons.unary_union.convex_hull
                             polygon = convex_hull.exterior.coords
-                            out = Polygon(polygon, None, 'black', False)
+                            out = Polygon(polygon, None, 'blue', False)
                             m.add_polygon(out)
 
                         image = m.render()

--- a/cea/interfaces/dashboard/api/project.py
+++ b/cea/interfaces/dashboard/api/project.py
@@ -290,6 +290,7 @@ class ScenarioImage(Resource):
                     image_modified = os.path.getmtime(image_path)
 
                 if zone_modified > image_modified:
+                    print(f'Generating preview image for scenario: {scenario}')
                     # Make sure .cache folder exists
                     if not os.path.exists(cache_path):
                         os.makedirs(cache_path)
@@ -307,6 +308,9 @@ class ScenarioImage(Resource):
                                 out = Polygon(polygon, 'blue', 'black', False)
                                 m.add_polygon(out)
                         else:
+                            print(f'Number of buildings({len(polygons)}) exceed building limit({building_limit}): '
+                                  f'Generating simplified image')
+                            # Generate only the shape outline of the zone area
                             convex_hull = polygons.unary_union.convex_hull
                             polygon = convex_hull.exterior.coords
                             out = Polygon(polygon, None, 'black', False)

--- a/cea/interfaces/dashboard/dashboard.py
+++ b/cea/interfaces/dashboard/dashboard.py
@@ -17,9 +17,9 @@ def main(config):
     global socketio
     socketio = SocketIO(app)
 
-    from .plots.routes import blueprint as plots_blueprint
-    from .server import blueprint as server_blueprint
-    from .api import blueprint as api_blueprint
+    from cea.interfaces.dashboard.plots.routes import blueprint as plots_blueprint
+    from cea.interfaces.dashboard.server import blueprint as server_blueprint
+    from cea.interfaces.dashboard.api import blueprint as api_blueprint
 
     app.register_blueprint(plots_blueprint)
     app.register_blueprint(api_blueprint)


### PR DESCRIPTION
This PR resolves #2910 by generating a simplified preview image for scenarios with large number of buildings to prevent it from blocking other requests for too long which makes the GUI unresponsive.