### PR TITLE
Decode FileParameter via regex

### DIFF
--- a/cea/config.py
+++ b/cea/config.py
@@ -448,8 +448,11 @@ class FileParameter(Parameter):
         return str(value)
 
     def decode(self, value):
+        _KEYCRE = re.compile(r"\{([^}]+)\}")
         if not value and not self.nullable:
             raise ValueError("Can't decode value for non-nullable FileParameter %s." % self.name)
+        elif _KEYCRE.match(value):
+            return _KEYCRE.sub(lambda match: self.config.get(match.group(1)), value)
         else:
             return value
 

--- a/cea/tests/test_config.py
+++ b/cea/tests/test_config.py
@@ -55,6 +55,10 @@ class TestConfiguration(unittest.TestCase):
         config = pickle.loads(pickle.dumps(config))
         self.assertEquals(config.scenario, config.general.scenario)
 
+    def test_decode_fileparameter(self):
+        config = cea.config.Configuration()
+        expected_output = "/projects/heating/inputs/building-geometry/zone.shp"
+        self.assertEqual(config.create_new_scenario.zone, expected_output)
 
 if __name__ == "__main__":
     unittest.main()

--- a/cea/tests/test_config.py
+++ b/cea/tests/test_config.py
@@ -57,7 +57,8 @@ class TestConfiguration(unittest.TestCase):
 
     def test_decode_fileparameter(self):
         config = cea.config.Configuration()
-        expected_output = "/projects/heating/inputs/building-geometry/zone.shp"
+        scenario = config.general.scenario
+        expected_output = f"{scenario}/inputs/building-geometry/zone.shp"
         self.assertEqual(config.create_new_scenario.zone, expected_output)
 
 if __name__ == "__main__":

--- a/cea/tests/test_config.py
+++ b/cea/tests/test_config.py
@@ -59,7 +59,7 @@ class TestConfiguration(unittest.TestCase):
         config = cea.config.Configuration()
         scenario = config.general.scenario
         expected_output = f"{scenario}/inputs/building-geometry/zone.shp"
-        self.assertEqual(config.create_new_scenario.zone, expected_output)
+        self.assertEqual(os.path.normcase(config.create_new_scenario.zone), os.path.normcase(expected_output))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Behaviour

When calling `config = cea.config.Configuration()`; `FileParameter.decode` isn't interpolating so `config.create_new_scenario.zone` remains as `{general:scenario}/inputs/building-geometry/zone.shp` which breaks `cea.api.create_new_scenario` as `zone_geometry_path = config.create_new_scenario.zone` is not a real filepath.

# Expected Behaviour

`config.create_new_scenario.zone` returns a real filepath

# To reproduce:

- Get `CityEnergyAnalyst`
   - `git clone https://github.com/architecture-building-systems/CityEnergyAnalyst`
   - `cd <path-to-CityEnergyAnalyst>`

- Setup a local `CityEnergyAnalyst` development environment via `docker`:
   -  `docker run --rm -it --entrypoint /bin/bash -v $(pwd):/CityEnergyAnalyst -p 8888:8888 -p 5050:5050 darenthomas/cityenergyanalyst`

- Install latest `cea`:
   - `source activate /venv/bin/activate` 
   - `pip install -e .`
- Run:
    ```python
    import cea.config
    config = cea.config.Configuration()
    print(config.create_new_scenario.zone)
    ```
---

# Bug Fix 

To resolve this bug I've adapted `configparser.ExtendedInterpolation` to work with `FileParameter.decode` so that the `{section:parameter}` is interpolated when called.

---

I'm currently experimenting with the `CityEnergyAnalyst` Python API through `docker` via a `Jupyter Notebook` after reading https://cityenergyanalyst.com/blog/2019/8/1/gabriel - thanks for all the tutorials & docs!