### PR TITLE
zone_helper.clean_geometries fails for Point

### DIFF
--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -315,6 +315,7 @@ def clean_geometries(gdf):
         if geometry.type == 'Polygon':  # ignore Polygons
             return geometry
         elif geometry.type == 'Point':
+            print('Discarding geometry of type: Point')
             return None # discard geometry if it is a Point
         else:
             joined = unary_union(list(geometry))

--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -314,6 +314,8 @@ def clean_geometries(gdf):
         from shapely.ops import unary_union
         if geometry.type == 'Polygon':  # ignore Polygons
             return geometry
+        elif geometry.type == 'Point':
+            return None # discard geometry if it is a Point
         else:
             joined = unary_union(list(geometry))
             if joined.type == 'MultiPolygon':  # some Multipolygons could not be combined

--- a/cea/tests/datamanagement/test_zone_helper.py
+++ b/cea/tests/datamanagement/test_zone_helper.py
@@ -1,0 +1,32 @@
+import unittest
+
+import geopandas as gpd
+from geopandas.testing import assert_geodataframe_equal
+from shapely.geometry import Point, Polygon
+
+from cea.datamanagement import zone_helper
+
+class TestCleanGeometries(unittest.TestCase):
+
+    def assertGeoDataFrameEqual(self, a, b, msg, *kwargs):
+        try:
+            assert_geodataframe_equal(a, b, *kwargs)
+        except AssertionError as e:
+            raise self.failureException(msg) from e
+    
+    def setUp(self):
+        self.addTypeEqualityFunc(gpd.GeoDataFrame, self.assertGeoDataFrameEqual)
+
+    def test_clean_geometries(self):
+        raw_geometries = gpd.GeoDataFrame(
+            {
+                "geometry": [Point(0,0), Polygon([(0,0), (0,1), (1,0)])]
+            }
+        )
+        expected_output = gpd.GeoDataFrame(
+            {
+                "geometry": [Polygon([(0,0), (0,1), (1,0)])]
+            }
+        )
+        output = zone_helper.clean_geometries(raw_geometries).reset_index(drop=True)
+        self.assertEqual(output, expected_output)


### PR DESCRIPTION
# Behaviour

When `osmnx.footprints.footprints_from_polygon` returns buildings with `Point` geometries `joined = unary_union(list(geometry))` in `zone_helper.clean_geometries.flatten_geometries` fails as `Point` geometries are not iterable.

# Expected Behaviour

`zone_helper.clean_geometries.flatten_geometries` can handle `Point` geometries

# To reproduce:

- Setup a local `CityEnergyAnalyst` development environment via `docker`:
   - `git clone https://github.com/architecture-building-systems/CityEnergyAnalyst`
   - `cd CityEnergyAnalyst`
   -  `docker run --rm -it --entrypoint /bin/bash --workdir /CityEnergyAnalyst -v $(pwd):/CityEnergyAnalyst darenthomas/cityenergyanalyst`
   - `source activate /venv/bin/activate` 
   - `pip install -e .`
  
- Run:
```python
import geopandas as gpd
from shapely.geometry import Point, Polygon
from cea.datamanagement.zone_helper import clean_geometries

raw_geometries = gpd.GeoDataFrame(
    {
        "geometry": [Point(0,0), Polygon([(0,0), (0,1), (1,0)])]
    }
)
clean_geometries(raw_geometries)
```

- Produces:
```python-traceback
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-d15aa4329f60> in <module>
      7     }
      8 )
----> 9 clean_geometries(raw_geometries)

/venv/lib/python3.8/site-packages/cea/datamanagement/zone_helper.py in clean_geometries(gdf)
    325                 return joined
    326 
--> 327     gdf.geometry = gdf.geometry.map(flatten_geometries)
    328     gdf = gdf[gdf.geometry.notnull()]  # remove None geometries
    329 

/venv/lib/python3.8/site-packages/pandas/core/series.py in map(self, arg, na_action)
   3968         dtype: object
   3969         """
-> 3970         new_values = super()._map_values(arg, na_action=na_action)
   3971         return self._constructor(new_values, index=self.index).__finalize__(
   3972             self, method="map"

/venv/lib/python3.8/site-packages/pandas/core/base.py in _map_values(self, mapper, na_action)
   1158 
   1159         # mapper is a function
-> 1160         new_values = map_f(values, mapper)
   1161 
   1162         return new_values

pandas/_libs/lib.pyx in pandas._libs.lib.map_infer()

/venv/lib/python3.8/site-packages/cea/datamanagement/zone_helper.py in flatten_geometries(geometry)
    316             return geometry
    317         else:
--> 318             joined = unary_union(list(geometry))
    319             if joined.type == 'MultiPolygon':  # some Multipolygons could not be combined
    320                 return joined[0]  # just return first polygon

TypeError: 'Point' object is not iterable
```

---

# Bug Fix 

I've added an `elif` statement to discard `Point` geometries & a unit test to `cea.tests.datamanagement.test_zone_helper` (mirroring the folder structure of `cea`) checking that the above test case holds.