### PR TITLE
Add docker dev target & build with mamba

### DIFF
--- a/cea/datamanagement/terrain_helper.py
+++ b/cea/datamanagement/terrain_helper.py
@@ -8,7 +8,7 @@ https://www2.jpl.nasa.gov/srtm/
 
 import os
 
-import gdal
+from osgeo import gdal
 import numpy as np
 import pandas as pd
 import requests

--- a/cea/resources/radiation_daysim/geometry_generator.py
+++ b/cea/resources/radiation_daysim/geometry_generator.py
@@ -10,9 +10,9 @@ import os
 import pickle
 from itertools import repeat
 
-import gdal
 import geopandas as gpd
-import osr
+from osgeo import gdal
+from osgeo import osr
 
 import cea
 

--- a/cea/utilities/standardize_coordinates.py
+++ b/cea/utilities/standardize_coordinates.py
@@ -2,8 +2,8 @@
 
 
 import utm
-import gdal
-import osr
+from osgeo import gdal
+from osgeo import osr
 import geopandas
 
 __author__ = "Jimeno A. Fonseca"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,43 @@
-FROM continuumio/miniconda3 as cea-build
+FROM continuumio/miniconda3:4.9.2 as base
+
 COPY ./environment.yml /tmp/environment.yml
 
+# replace conda with C++ reimplementation mamba for faster builds
+RUN conda install mamba -n base -c conda-forge
+
 # create the conda environment and install cea...
-RUN conda env create -q -f /tmp/environment.yml -n cea
+RUN mamba env create -f /tmp/environment.yml -n cea \
+    && conda clean -afy 
 ENV PATH /opt/conda/envs/cea/bin:$PATH
-RUN /bin/bash -c "source activate cea && pip install --no-deps git+https://github.com/architecture-building-systems/CityEnergyAnalyst@master#egg=cityenergyanalyst"
+
+# bugfix for matplotlib, see here: https://stackoverflow.com/questions/37604289/tkinter-tclerror-no-display-name-and-no-display-environment-variable
+RUN mkdir -p /root/.config/matplotlib \
+    && echo "backend: Agg" > /root/.config/matplotlib/matplotlibrc
+
+# The dev-stage image; keeps conda installed so
+# can use conda to add new packages 
+FROM base AS cea-dev
+
+# Remove Python Bytecode files & Static Libraries to save 400MB in space
+RUN find /opt/conda/ -follow -type f -name '*.a' -delete \
+    && find /opt/conda/ -follow -type f -name '*.pyc' -delete
+
+# When image is run, activate the environment
+ENV PATH "/Daysim/bin:$PATH"
+SHELL ["/bin/bash", "-c"]
+ENTRYPOINT conda activate cea
+
+# The build-stage image; package conda env
+# so can use in an image without conda installed
+FROM base as cea-build
 
 # conda-pack the environment (with cea pre-installed)
 RUN conda install -c conda-forge conda-pack
-RUN conda-pack -n cea -o /tmp/env.tar && mkdir /venv && cd /venv && tar xf /tmp/env.tar && rm /tmp/env.tar
+RUN conda-pack -n cea -o /tmp/env.tar \
+    && mkdir /venv \
+    && cd /venv \
+    && tar xf /tmp/env.tar \
+    && rm /tmp/env.tar
 RUN /venv/bin/conda-unpack
 
 # The runtime-stage image; we can use Debian as the
@@ -16,19 +45,29 @@ RUN /venv/bin/conda-unpack
 # for us.
 FROM debian:buster AS cea-runtime
 
+COPY --from=base /root/.config/matplotlib /root/.config/matplotlib
 COPY --from=cea-build /venv /venv
 COPY ./Daysim /Daysim
 COPY ./cea.config /root/cea.config
 
-
-# bugfix for matplotlib, see here: https://stackoverflow.com/questions/37604289/tkinter-tclerror-no-display-name-and-no-display-environment-variable
-RUN mkdir -p /root/.config/matplotlib && echo "backend: Agg" > /root/.config/matplotlib/matplotlibrc
+# Add venv & Daysim to Path
+ENV PATH "/venv/cea/bin:/Daysim/bin:$PATH"
 
 # add a folder for projects
 RUN mkdir /projects
 
+# Use bash in Dockerfile RUN commands and make sure bashrc is sourced when
+# executing commands with /bin/bash -c
+ENV BASH_ENV /root/.bashrc
+SHELL ["/bin/bash", "-c"]
+
+# Install latest CEA from Github
+RUN apt-get update \
+    && apt-get install -y git \
+    && source /venv/bin/activate \
+    && pip install --no-deps git+https://github.com/architecture-building-systems/CityEnergyAnalyst@master#egg=cityenergyanalyst
+
 # When image is run, run the code with the environment
 # activated:
-ENV PATH "/venv/cea/bin:/Daysim/bin:$PATH"
-SHELL ["/bin/bash", "-c"]
-ENTRYPOINT source /venv/bin/activate && cea dashboard
+ENTRYPOINT source /venv/bin/activate \
+    && cea dashboard

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,12 @@ ENTRYPOINT conda activate cea
 # so can use in an image without conda installed
 FROM base as cea-build
 
+# Install latest CEA from Github
+RUN apt-get update \
+    && apt-get install -y git \
+    && source /venv/bin/activate \
+    && pip install --no-deps git+https://github.com/architecture-building-systems/CityEnergyAnalyst@master#egg=cityenergyanalyst
+    
 # conda-pack the environment (with cea pre-installed)
 RUN conda install -c conda-forge conda-pack
 RUN conda-pack -n cea -o /tmp/env.tar \
@@ -60,12 +66,6 @@ RUN mkdir /projects
 # executing commands with /bin/bash -c
 ENV BASH_ENV /root/.bashrc
 SHELL ["/bin/bash", "-c"]
-
-# Install latest CEA from Github
-RUN apt-get update \
-    && apt-get install -y git \
-    && source /venv/bin/activate \
-    && pip install --no-deps git+https://github.com/architecture-building-systems/CityEnergyAnalyst@master#egg=cityenergyanalyst
 
 # When image is run, run the code with the environment
 # activated:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,10 +22,13 @@ FROM base AS cea-dev
 RUN find /opt/conda/ -follow -type f -name '*.a' -delete \
     && find /opt/conda/ -follow -type f -name '*.pyc' -delete
 
-# When image is run, activate the environment
 ENV PATH "/Daysim/bin:$PATH"
+
+# When image is run, activate the environment
+RUN echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate cea" >> ~/.bashrc
 SHELL ["/bin/bash", "-c"]
-ENTRYPOINT conda activate cea
+CMD ["/bin/bash"] 
 
 # The build-stage image; package conda env
 # so can use in an image without conda installed
@@ -34,9 +37,8 @@ FROM base as cea-build
 # Install latest CEA from Github
 RUN apt-get update \
     && apt-get install -y git \
-    && source /venv/bin/activate \
     && pip install --no-deps git+https://github.com/architecture-building-systems/CityEnergyAnalyst@master#egg=cityenergyanalyst
-    
+
 # conda-pack the environment (with cea pre-installed)
 RUN conda install -c conda-forge conda-pack
 RUN conda-pack -n cea -o /tmp/env.tar \
@@ -44,6 +46,7 @@ RUN conda-pack -n cea -o /tmp/env.tar \
     && cd /venv \
     && tar xf /tmp/env.tar \
     && rm /tmp/env.tar
+
 RUN /venv/bin/conda-unpack
 
 # The runtime-stage image; we can use Debian as the
@@ -57,17 +60,13 @@ COPY ./Daysim /Daysim
 COPY ./cea.config /root/cea.config
 
 # Add venv & Daysim to Path
-ENV PATH "/venv/cea/bin:/Daysim/bin:$PATH"
+ENV PATH "/venv/bin:/Daysim/bin:$PATH"
 
 # add a folder for projects
 RUN mkdir /projects
 
-# Use bash in Dockerfile RUN commands and make sure bashrc is sourced when
-# executing commands with /bin/bash -c
-ENV BASH_ENV /root/.bashrc
-SHELL ["/bin/bash", "-c"]
-
 # When image is run, run the code with the environment
 # activated:
+SHELL ["/bin/bash", "-c"]
 ENTRYPOINT source /venv/bin/activate \
     && cea dashboard

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM continuumio/miniconda3:4.9.2 as base
 
-COPY ./environment.yml /tmp/environment.yml
+COPY ./docker/environment.yml /tmp/environment.yml
 
 # replace conda with C++ reimplementation mamba for faster builds
 RUN conda install mamba -n base -c conda-forge
@@ -27,17 +27,11 @@ ENV PATH "/Daysim/bin:$PATH"
 # When image is run, activate the environment
 RUN echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate cea" >> ~/.bashrc
-SHELL ["/bin/bash", "-c"]
 CMD ["/bin/bash"] 
 
 # The build-stage image; package conda env
 # so can use in an image without conda installed
 FROM base as cea-build
-
-# Install latest CEA from Github
-RUN apt-get update \
-    && apt-get install -y git \
-    && pip install --no-deps git+https://github.com/architecture-building-systems/CityEnergyAnalyst@master#egg=cityenergyanalyst
 
 # conda-pack the environment (with cea pre-installed)
 RUN conda install -c conda-forge conda-pack
@@ -46,7 +40,6 @@ RUN conda-pack -n cea -o /tmp/env.tar \
     && cd /venv \
     && tar xf /tmp/env.tar \
     && rm /tmp/env.tar
-
 RUN /venv/bin/conda-unpack
 
 # The runtime-stage image; we can use Debian as the
@@ -56,17 +49,23 @@ FROM debian:buster AS cea-runtime
 
 COPY --from=base /root/.config/matplotlib /root/.config/matplotlib
 COPY --from=cea-build /venv /venv
-COPY ./Daysim /Daysim
-COPY ./cea.config /root/cea.config
+COPY ./docker/Daysim /Daysim
+COPY ./docker/cea.config /root/cea.config
 
 # Add venv & Daysim to Path
 ENV PATH "/venv/bin:/Daysim/bin:$PATH"
 
-# add a folder for projects
-RUN mkdir /projects
+# Activate cea venv during when launch bash shell
+RUN echo "source /venv/bin/activate" >> ~/.bashrc
+
+# Install latest CEA from cloned repo
+COPY cea/ /CityEnergyAnalyst/cea/
+COPY setup.py README.rst /CityEnergyAnalyst/
+WORKDIR /CityEnergyAnalyst/
+SHELL ["/bin/bash", "-c"]
+RUN pip install -e .
 
 # When image is run, run the code with the environment
 # activated:
 SHELL ["/bin/bash", "-c"]
-ENTRYPOINT source /venv/bin/activate \
-    && cea dashboard
+ENTRYPOINT cea dashboard


### PR DESCRIPTION
1. I adapted the existing Dockerfile to add a
cea-dev build step so that cea developers can
quickly build their own developement environment
via docker and experiment with new dependencies
such as pytest by installing them with conda
in this development environment.  I moved the
pip install git+cea... step into the cea-runtime
step as the source code changes frequently while
the dependencies perhaps not as frequently.
Rebuilding the docker image is much faster if
cea is included in the final step as it doesn't
have to start from scratch and can use cached versions
of the earlier stages.  Developers can volume mount
the cea source code when running the docker image by

- building the cea-dev image with
`docker build --target=cea-dev -t cea-dev .`
- mounting the source code in with
`cd to cea` and
`docker run -v $(pwd):/CityEnergyAnalyst cea-dev` and
`pip install -e .`

2. I also replaced conda with mamba
so now the Dockerfile uses C++ instead of Python
to resolve the conda environment as specified in
environment.yml.  It now installs and resolves all
dependencies in a few minutes