### PR TITLE
included partitions

### DIFF
--- a/cea/schemas.yml
+++ b/cea/schemas.yml
@@ -1737,6 +1737,17 @@ get_building_architecture:
             path: get_database_envelope_systems
             sheet: WALL
             column: code
+      type_part:
+        description: Internal partitions construction assembly (relates to "code" in ENVELOPE
+          assemblies)
+        type: string
+        unit: '[-]'
+        values: alphanumeric
+        choice:
+          lookup:
+            path: get_database_envelope_systems
+            sheet: WALL
+            column: code
       type_floor:
         description: Internal floor construction assembly (relates to "code" in ENVELOPE
           assemblies)


### PR DESCRIPTION
This solves #2962 

Partitions are included in schemas.yml to show up in the interface.

To test: open a scenario, run archetypes mapper if necessary and look for  type_part in the architecture tab