### PR TITLE
2977 data migrator

### DIFF
--- a/cea/datamanagement/data_migrator.py
+++ b/cea/datamanagement/data_migrator.py
@@ -172,7 +172,7 @@ def internal_loads_is_3_22(scenario):
 
 
 def output_occupancy_is_3_22(scenario):
-    if os.path.isdir(os.path.join(scenario, 'outputs', 'data', 'occupancy')) and max(
+    if os.path.isdir(os.path.join(scenario, 'outputs', 'data', 'occupancy')) and any(
             ['people_pax' in pd.read_csv(os.path.join(scenario, 'outputs', 'data', 'occupancy', i)).columns for i in
              os.listdir(os.path.join(scenario, 'outputs', 'data', 'occupancy'))]):
         return True

--- a/cea/datamanagement/data_migrator.py
+++ b/cea/datamanagement/data_migrator.py
@@ -173,7 +173,8 @@ def internal_loads_is_3_22(scenario):
 
 def output_occupancy_is_3_22(scenario):
     if os.path.isdir(os.path.join(scenario, 'outputs', 'data', 'occupancy')) and any(
-            ['people_pax' in pd.read_csv(os.path.join(scenario, 'outputs', 'data', 'occupancy', i)).columns for i in
+            ['people_pax' in pd.read_csv(os.path.join(scenario, 'outputs', 'data', 'occupancy', i)).columns
+             and '_original' not in i for i in
              os.listdir(os.path.join(scenario, 'outputs', 'data', 'occupancy'))]):
         return True
     else:

--- a/cea/datamanagement/data_migrator.py
+++ b/cea/datamanagement/data_migrator.py
@@ -30,7 +30,7 @@ __status__ = "Production"
 def find_migrators(scenario):
     """
     Add new migrations here as they become necessary
-    the database-migrator will run these in sequence starting from the first migrator found
+    the data-migrator will run these in sequence starting from the first migrator found
     (NOTE: I've added a dummy migration - 2.31 - 2.31.1 - to show how the principle works)
     """
     migrations = collections.OrderedDict()
@@ -149,12 +149,35 @@ def is_3_22(scenario):
     '''
     Checks if "pax" is being used the indoor comfort dbf file.
     '''
+    if indoor_comfort_is_3_22(scenario) or internal_loads_is_3_22(scenario) or output_occupancy_is_3_22(scenario):
+        return True
+    else:
+        return False
 
+
+def indoor_comfort_is_3_22(scenario):
     indoor_comfort = dbf_to_dataframe(os.path.join(scenario, "inputs", "building-properties", "indoor_comfort.dbf"))
 
     if not 'Ve_lpspax' in indoor_comfort.columns:
         return False
     return True
+
+
+def internal_loads_is_3_22(scenario):
+    internal_loads = dbf_to_dataframe(os.path.join(scenario, "inputs", "building-properties", "internal_loads.dbf"))
+
+    if not 'Occ_m2pax' in internal_loads.columns:
+        return False
+    return True
+
+
+def output_occupancy_is_3_22(scenario):
+    if os.path.isdir(os.path.join(scenario, 'outputs', 'data', 'occupancy')) and max(
+            ['people_pax' in pd.read_csv(os.path.join(scenario, 'outputs', 'data', 'occupancy', i)).columns for i in
+             os.listdir(os.path.join(scenario, 'outputs', 'data', 'occupancy'))]):
+        return True
+    else:
+        return False
 
 
 def migrate_3_22_to_3_22_1(scenario):
@@ -165,37 +188,61 @@ def migrate_3_22_to_3_22_1(scenario):
     INDOOR_COMFORT_COLUMNS = {'Ve_lpspax': 'Ve_lsp'}
     INTERNAL_LOADS_COLUMNS = {'Occ_m2pax': 'Occ_m2p', 'Qs_Wpax': 'Qs_Wp', 'Vw_lpdpax': 'Vw_ldp',
                               'Vww_lpdpax': 'Vww_ldp', 'X_ghpax': 'X_ghp'}
+    OCCUPANCY_COLUMNS = {'people_pax': 'people_p'}
+
+    if indoor_comfort_is_3_22(scenario):
+        # import building properties
+        indoor_comfort = dbf_to_dataframe(os.path.join(scenario, 'inputs', 'building-properties', 'indoor_comfort.dbf'))
+        # make a backup copy of original data for user's own reference
+        os.rename(os.path.join(scenario, 'inputs', 'building-properties', 'indoor_comfort.dbf'),
+                  os.path.join(scenario, 'inputs', 'building-properties', 'indoor_comfort_original.dbf'))
+        # rename columns containing "pax"
+        indoor_comfort.rename(columns=INDOOR_COMFORT_COLUMNS, inplace=True)
+        # export dataframes to dbf files
+        print("- writing indoor_comfort.dbf")
+        dataframe_to_dbf(indoor_comfort, os.path.join(scenario, 'inputs', 'building-properties', 'indoor_comfort.dbf'))
+
+    if internal_loads_is_3_22(scenario):
+        # import building properties
+        internal_loads = dbf_to_dataframe(os.path.join(scenario, 'inputs', 'building-properties', 'internal_loads.dbf'))
+        # make a backup copy of original data for user's own reference
+        os.rename(os.path.join(scenario, 'inputs', 'building-properties', 'internal_loads.dbf'),
+                  os.path.join(scenario, 'inputs', 'building-properties', 'internal_loads_original.dbf'))
+        # rename columns containing "pax"
+        internal_loads.rename(columns=INTERNAL_LOADS_COLUMNS, inplace=True)
+        # export dataframes to dbf files
+        print("- writing internal_loads.dbf")
+        dataframe_to_dbf(internal_loads, os.path.join(scenario, 'inputs', 'building-properties', 'internal_loads.dbf'))
 
     # import building properties
-    indoor_comfort = dbf_to_dataframe(os.path.join(scenario, 'inputs', 'building-properties', 'indoor_comfort.dbf'))
-    internal_loads = dbf_to_dataframe(os.path.join(scenario, 'inputs', 'building-properties', 'internal_loads.dbf'))
     use_type_properties = pd.read_excel(os.path.join(scenario, 'inputs', 'technology', 'archetypes', 'use_types',
                                                      'USE_TYPE_PROPERTIES.xlsx'), sheet_name=None)
-    # make a backup copy of original data for user's own reference
-    os.rename(os.path.join(scenario, 'inputs', 'building-properties', 'indoor_comfort.dbf'),
-              os.path.join(scenario, 'inputs', 'building-properties', 'indoor_comfort_original.dbf'))
-    os.rename(os.path.join(scenario, 'inputs', 'building-properties', 'internal_loads.dbf'),
-              os.path.join(scenario, 'inputs', 'building-properties', 'internal_loads_original.dbf'))
-    os.rename(os.path.join(scenario, 'inputs', 'technology', 'archetypes', 'use_types', 'USE_TYPE_PROPERTIES.xlsx'),
-              os.path.join(scenario, 'inputs', 'technology', 'archetypes', 'use_types',
-                           'USE_TYPE_PROPERTIES_original.xlsx'))
-
-    # rename columns containing "pax"
-    indoor_comfort.rename(columns=INDOOR_COMFORT_COLUMNS, inplace=True)
-    internal_loads.rename(columns=INTERNAL_LOADS_COLUMNS, inplace=True)
-    use_type_properties['INDOOR_COMFORT'].rename(columns=INDOOR_COMFORT_COLUMNS, inplace=True)
-    use_type_properties['INTERNAL_LOADS'].rename(columns=INTERNAL_LOADS_COLUMNS, inplace=True)
-
-    # export dataframes to dbf files
-    print("- writing indoor_comfort.dbf")
-    dataframe_to_dbf(indoor_comfort, os.path.join(scenario, 'inputs', 'building-properties', 'indoor_comfort.dbf'))
-    print("- writing internal_loads.dbf")
-    dataframe_to_dbf(internal_loads, os.path.join(scenario, 'inputs', 'building-properties', 'internal_loads.dbf'))
-    print("-writing USE_TYPE_PROPERTIES.xlsx")
-    with pd.ExcelWriter(os.path.join(scenario, 'inputs', 'technology', 'archetypes', 'use_types',
-                                     'USE_TYPE_PROPERTIES.xlsx')) as writer1:
-        for sheet_name in use_type_properties.keys():
-            use_type_properties[sheet_name].to_excel(writer1, sheet_name=sheet_name, index=False)
+    if max([i in use_type_properties['INTERNAL_LOADS'].columns for i in INTERNAL_LOADS_COLUMNS.keys()]) or max(
+            [i in use_type_properties['INDOOR_COMFORT'].columns for i in INDOOR_COMFORT_COLUMNS.keys()]):
+        os.rename(os.path.join(scenario, 'inputs', 'technology', 'archetypes', 'use_types', 'USE_TYPE_PROPERTIES.xlsx'),
+                  os.path.join(scenario, 'inputs', 'technology', 'archetypes', 'use_types',
+                               'USE_TYPE_PROPERTIES_original.xlsx'))
+        # rename columns containing "pax"
+        use_type_properties['INDOOR_COMFORT'].rename(columns=INDOOR_COMFORT_COLUMNS, inplace=True)
+        use_type_properties['INTERNAL_LOADS'].rename(columns=INTERNAL_LOADS_COLUMNS, inplace=True)
+        # export dataframes to dbf files
+        print("-writing USE_TYPE_PROPERTIES.xlsx")
+        with pd.ExcelWriter(os.path.join(scenario, 'inputs', 'technology', 'archetypes', 'use_types',
+                                         'USE_TYPE_PROPERTIES.xlsx')) as writer1:
+            for sheet_name in use_type_properties.keys():
+                use_type_properties[sheet_name].to_excel(writer1, sheet_name=sheet_name, index=False)
+    if output_occupancy_is_3_22(scenario):
+        # if occupancy schedule files are found in the outputs, these are also renamed
+        print("-writing schedules in ./outputs/data/occupancy")
+        for file_name in os.listdir(os.path.join(scenario, 'outputs', 'data', 'occupancy')):
+            schedule_df = pd.read_csv(os.path.join(scenario, 'outputs', 'data', 'occupancy', file_name))
+            if 'people_pax' in schedule_df.columns:
+                os.rename(os.path.join(scenario, 'outputs', 'data', 'occupancy', file_name),
+                          os.path.join(scenario, 'outputs', 'data', 'occupancy', file_name.split('.')[0] +
+                                       '_original.' + file_name.split('.')[1]))
+                schedule_df.rename(columns=OCCUPANCY_COLUMNS, inplace=True)
+                # export dataframes to dbf files
+                schedule_df.to_csv(os.path.join(scenario, 'outputs', 'data', 'occupancy', file_name))
 
     print("- done")
 

--- a/cea/demand/demand_main.py
+++ b/cea/demand/demand_main.py
@@ -17,7 +17,7 @@ from cea.demand.building_properties import BuildingProperties
 from cea.utilities import epwreader
 from cea.utilities.date import get_date_range_hours_from_year
 from cea.demand import demand_writers
-from cea.datamanagement.database_migrator import is_3_22
+from cea.datamanagement.data_migrator import is_3_22
 
 warnings.filterwarnings("ignore")
 
@@ -67,7 +67,7 @@ def demand_calculation(locator, config):
     # CHECK DATABASE
     if is_3_22(config.scenario):
         raise ValueError("""The data format of indoor comfort has been changed after v3.22. 
-        Please run Database migrator in Utilities.""")
+        Please run Data migrator in Utilities.""")
 
     # INITIALIZE TIMER
     t0 = time.perf_counter()

--- a/cea/demand/schedule_maker/schedule_maker.py
+++ b/cea/demand/schedule_maker/schedule_maker.py
@@ -13,7 +13,7 @@ import cea.inputlocator
 import cea.utilities.parallel
 from cea.constants import HOURS_IN_YEAR, MONTHS_IN_YEAR
 from cea.datamanagement.schedule_helper import read_cea_schedule
-from cea.datamanagement.database_migrator import is_3_22
+from cea.datamanagement.data_migrator import is_3_22
 from cea.demand.building_properties import calc_useful_areas
 from cea.demand.constants import VARIABLE_CEA_SCHEDULE_RELATION
 from cea.utilities import epwreader
@@ -48,7 +48,7 @@ def schedule_maker_main(locator, config, building=None):
     # CHECK DATABASE
     if is_3_22(config.scenario):
         raise ValueError("""The data format of indoor comfort has been changed after v3.22. 
-        Please run Database migrator in Utilities.""")
+        Please run Data migrator in Utilities.""")
 
     # get variables of indoor comfort and internal loads
     internal_loads = dbf_to_dataframe(locator.get_building_internal()).set_index('Name')

--- a/cea/demand/schedule_maker/schedule_maker.py
+++ b/cea/demand/schedule_maker/schedule_maker.py
@@ -287,8 +287,6 @@ def convert_schedule_string_to_temperature(schedule_string, schedule_type, Ths_s
     :type schedule_string: list of strings
     :param schedule_type: type of the schedule, either 'Ths_set' or 'Tcs_set'
     :type schedule_type: str
-    :param bpr: BuildingPropertiesRow object, from here the setpoint and setback temperatures are extracted
-    :type bpr: BuildingPropoertiesRow
     :return: an array of temperatures containing np.nan when the system is OFF
     :rtype: numpy.array
     """

--- a/cea/schemas.yml
+++ b/cea/schemas.yml
@@ -1996,7 +1996,7 @@ get_building_supply:
   - system_costs
 get_building_typology:
   created_by:
-  - database_migrator
+  - data_migrator
   file_path: inputs/building-properties/typology.dbf
   file_type: dbf
   schema:

--- a/cea/scripts.yml
+++ b/cea/scripts.yml
@@ -276,13 +276,13 @@ Optimization:
       - [PV_totals]
 
 Utilities:
-  - name: database-migrator
-    label: Database migrator
+  - name: data-migrator
+    label: Data migrator
     description: "Migrate older scenario inputs to the latest version.
                   Please consider running this for scenario inputs created before v3.22.
                   NOTE: This cannot be undone - save a copy of the scenario first."
     interfaces: [cli, dashboard]
-    module: cea.datamanagement.database_migrator
+    module: cea.datamanagement.data_migrator
     parameters: ['general:scenario']
     input-files:
       - [get_database_construction_standards]

--- a/cea/scripts.yml
+++ b/cea/scripts.yml
@@ -279,7 +279,7 @@ Utilities:
   - name: data-migrator
     label: Data migrator
     description: "Migrate older scenario inputs to the latest version.
-                  Please consider running this for scenario inputs created before v3.22.
+                  Please consider running this for scenario created before v3.22.
                   NOTE: This cannot be undone - save a copy of the scenario first."
     interfaces: [cli, dashboard]
     module: cea.datamanagement.data_migrator

--- a/docs/graphviz/database_migrator.gv
+++ b/docs/graphviz/database_migrator.gv
@@ -1,4 +1,4 @@
-digraph database_migrator {
+digraph data_migrator {
     rankdir="LR";
     graph [overlap=false, fontname=arial];
     node [shape=box, style=filled, color=white, fontsize=15, fontname=arial, fixedsize=true, width=5];
@@ -13,7 +13,7 @@ digraph database_migrator {
         "inputs"->"process"[style=invis]
         "process"->"outputs"[style=invis]
     }
-    "database_migrator"[style=filled, color=white, fillcolor="#3FC0C2", shape=note, fontsize=20, fontname=arial];
+    "data_migrator"[style=filled, color=white, fillcolor="#3FC0C2", shape=note, fontsize=20, fontname=arial];
     subgraph cluster_0_out {
         style = filled;
         color = "#aadcdd";
@@ -22,5 +22,5 @@ digraph database_migrator {
         label="inputs/building-properties";
         get_building_typology[label="typology.dbf"];
     }
-    "database_migrator" -> get_building_typology[label="(get_building_typology)"];
+    "data_migrator" -> get_building_typology[label="(get_building_typology)"];
     }

--- a/docs/modules/cea.datamanagement.rst
+++ b/docs/modules/cea.datamanagement.rst
@@ -36,7 +36,7 @@ cea.datamanagement.data\_initializer module
 cea.datamanagement.database\_migrator module
 --------------------------------------------
 
-.. automodule:: cea.datamanagement.database_migrator
+.. automodule:: cea.datamanagement.data_migrator
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/script-data-flow.rst
+++ b/docs/script-data-flow.rst
@@ -1289,11 +1289,11 @@ weather_helper
     "weather_helper" -> get_weather_file[label="(get_weather_file)"];
     }
 
-database_migrator
+data_migrator
 -----------------
 .. graphviz::
 
-    digraph database_migrator {
+    digraph data_migrator {
     rankdir="LR";
     graph [overlap=false, fontname=arial];
     node [shape=box, style=filled, color=white, fontsize=15, fontname=arial, fixedsize=true, width=5];
@@ -1308,7 +1308,7 @@ database_migrator
         "inputs"->"process"[style=invis]
         "process"->"outputs"[style=invis]
     }
-    "database_migrator"[style=filled, color=white, fillcolor="#3FC0C2", shape=note, fontsize=20, fontname=arial];
+    "data_migrator"[style=filled, color=white, fillcolor="#3FC0C2", shape=note, fontsize=20, fontname=arial];
     subgraph cluster_0_out {
         style = filled;
         color = "#aadcdd";
@@ -1317,7 +1317,7 @@ database_migrator
         label="inputs/building-properties";
         get_building_typology[label="typology.dbf"];
     }
-    "database_migrator" -> get_building_typology[label="(get_building_typology)"];
+    "data_migrator" -> get_building_typology[label="(get_building_typology)"];
     }
 
 optimization


### PR DESCRIPTION
This PR solves issue #2977 and does the following things:
1. add functions to separately check if the internal loads and indoor comfort inputs and/or the output occupancy schedules need to be updated before doing migration
2. add code to rename column `people_pax` in files in `./outputs/data/occupancy`
3. rename `database_migrator` to `data_migrator` to be consistent with the current functionality
