### PR TITLE
Update gdal imports to use osgeo instead

### DIFF
--- a/cea/datamanagement/terrain_helper.py
+++ b/cea/datamanagement/terrain_helper.py
@@ -8,13 +8,11 @@ https://www2.jpl.nasa.gov/srtm/
 
 import os
 
-import gdal
 import numpy as np
 import pandas as pd
 import requests
 from geopandas import GeoDataFrame as Gdf
-from osgeo import ogr
-from osgeo import osr
+from osgeo import gdal, ogr, osr
 from shapely.geometry import Polygon
 
 import cea.config

--- a/cea/resources/radiation_daysim/geometry_generator.py
+++ b/cea/resources/radiation_daysim/geometry_generator.py
@@ -10,9 +10,8 @@ import os
 import pickle
 from itertools import repeat
 
-import gdal
 import geopandas as gpd
-import osr
+from osgeo import gdal, osr
 
 import cea
 

--- a/cea/utilities/standardize_coordinates.py
+++ b/cea/utilities/standardize_coordinates.py
@@ -1,10 +1,7 @@
-
-
-
-import utm
-import gdal
-import osr
 import geopandas
+import utm
+from osgeo import gdal, osr
+
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2017, Architecture and Building Systems - ETH Zurich"


### PR DESCRIPTION
It seems that `gdal` has to be imported from `osgeo` when using it with Mac and sometimes Linux. This could be something to do with the newer version of `gdal` that is being installed using conda since we do not restrict the version of the `gdal` being installed in the CEA environment. Importing this way seems to work on Windows as well (at least on my computer) but further testing on other computers would need to be done to make sure that this works on Windows as that is where majority of our users are using CEA. 