### PR TITLE
Allow user to define heating/cooling plant location

### DIFF
--- a/cea/default.config
+++ b/cea/default.config
@@ -989,7 +989,7 @@ connected-buildings.help = List of buildings/customers to connect (blank if all 
 
 plant-buildings =
 plant-buildings.type = ListParameter
-plant-buildings.help = List of buildings where a plant is located (blank for plant to be created automatically).
+plant-buildings.help = List of buildings where a plant is located (blank for plant to be created automatically at the anchor load).
 possible-plant-sites.category = Advanced
 
 pipe-diameter = 150

--- a/cea/default.config
+++ b/cea/default.config
@@ -987,6 +987,11 @@ connected-buildings =
 connected-buildings.type = BuildingsParameter
 connected-buildings.help = List of buildings/customers to connect (blank if all buildings connected).
 
+plant-buildings =
+plant-buildings.type = ListParameter
+plant-buildings.help = List of buildings where a plant is located (blank for plant to be created automatically).
+possible-plant-sites.category = Advanced
+
 pipe-diameter = 150
 pipe-diameter.type = IntegerParameter
 pipe-diameter.help = Nominal diameter of pipe in mm.

--- a/cea/technologies/network_layout/main.py
+++ b/cea/technologies/network_layout/main.py
@@ -43,6 +43,7 @@ def layout_network(network_layout, locator, plant_building_names=None, output_na
     building_centroids_df = calc_building_centroids(path_zone_shp,
                                                     temp_path_building_centroids_shp,
                                                     list_district_scale_buildings,
+                                                    plant_building_names,
                                                     consider_only_buildings_with_demand,
                                                     type_network,
                                                     total_demand_location)
@@ -101,7 +102,9 @@ def main(config):
     assert os.path.exists(config.scenario), 'Scenario not found: %s' % config.scenario
     locator = cea.inputlocator.InputLocator(scenario=config.scenario)
     network_layout = NetworkLayout(network_layout=config.network_layout)
-    layout_network(network_layout, locator)
+    plant_building_names = config.network_layout.plant_buildings
+
+    layout_network(network_layout, locator, plant_building_names=plant_building_names)
 
 
 if __name__ == '__main__':

--- a/cea/technologies/network_layout/steiner_spanning_tree.py
+++ b/cea/technologies/network_layout/steiner_spanning_tree.py
@@ -146,7 +146,10 @@ def calc_steiner_spanning_tree(crs_projected,
             mst_nodes, mst_edges = add_plant_close_to_anchor(building_anchor, mst_nodes, mst_edges,
                                                              type_mat_default, pipe_diameter_default)
     elif os.path.exists(total_demand_location):
-        building_anchor = calc_coord_anchor(total_demand_location, mst_nodes, type_network)
+        if len(plant_building_names) > 0:
+            building_anchor = mst_nodes[mst_nodes['Building'].isin(plant_building_names)]
+        else:
+            building_anchor = calc_coord_anchor(total_demand_location, mst_nodes, type_network)
         mst_nodes, mst_edges = add_plant_close_to_anchor(building_anchor, mst_nodes, mst_edges,
                                                          type_mat_default, pipe_diameter_default)
 

--- a/cea/technologies/network_layout/steiner_spanning_tree.py
+++ b/cea/technologies/network_layout/steiner_spanning_tree.py
@@ -157,7 +157,8 @@ def calc_steiner_spanning_tree(crs_projected,
     mst_edges.crs = crs_projected
     mst_nodes.crs = crs_projected
     mst_edges['length_m'] = mst_edges['weight']
-    mst_edges[['geometry','length_m', 'Type_mat', 'Name', 'Pipe_DN']].to_file(path_output_edges_shp, driver='ESRI Shapefile')
+    mst_edges[['geometry', 'length_m', 'Type_mat', 'Name', 'Pipe_DN']].to_file(path_output_edges_shp,
+                                                                               driver='ESRI Shapefile')
     mst_nodes[['geometry', 'Building', 'Name', 'Type']].to_file(path_output_nodes_shp, driver='ESRI Shapefile')
 
 

--- a/cea/technologies/network_layout/substations_location.py
+++ b/cea/technologies/network_layout/substations_location.py
@@ -25,6 +25,7 @@ __status__ = "Production"
 def calc_building_centroids(input_buildings_shp,
                             temp_path_building_centroids_shp,
                             list_district_scale_buildings,
+                            plant_buildings,
                             consider_only_buildings_with_demand=False,
                             type_network="DH",
                             total_demand=False):
@@ -40,10 +41,10 @@ def calc_building_centroids(input_buildings_shp,
             field = "QH_sys_MWhyr"
         elif type_network == "DC":
             field = "QC_sys_MWhyr"
-        buildings_with_load_df = total_demand[total_demand[field] > 0.0]
-        if buildings_with_load_df.shape[0] >= 2:
-            buildings_with_load = buildings_with_load_df['Name'].tolist()
-            zone_df = zone_df.loc[zone_df['Name'].isin(buildings_with_load)]
+        buildings_with_load = total_demand[total_demand[field] > 0.0].Name.tolist()
+        connected_buildings = buildings_with_load + plant_buildings
+        if len(connected_buildings) >= 2:
+            zone_df = zone_df.loc[zone_df['Name'].isin(connected_buildings)]
             zone_df = zone_df.reset_index(drop=True)
         else:
             raise Exception("We could not find two or more buildings with thermal energy demand the network layout "

--- a/cea/technologies/network_layout/substations_location.py
+++ b/cea/technologies/network_layout/substations_location.py
@@ -31,7 +31,7 @@ def calc_building_centroids(input_buildings_shp,
                             total_demand=False):
     # # get coordinate system and project to WSG 84
     zone_df = gdf.from_file(input_buildings_shp)
-    zone_df = zone_df.loc[zone_df['Name'].isin(list_district_scale_buildings)]
+    zone_df = zone_df.loc[zone_df['Name'].isin(list_district_scale_buildings + plant_buildings)]
     zone_df = zone_df.reset_index(drop=True)
 
     # get only buildings with a demand, send out a message if there are less than 2 buildings.
@@ -42,9 +42,9 @@ def calc_building_centroids(input_buildings_shp,
         elif type_network == "DC":
             field = "QC_sys_MWhyr"
         buildings_with_load = total_demand[total_demand[field] > 0.0].Name.tolist()
-        connected_buildings = buildings_with_load + plant_buildings
-        if len(connected_buildings) >= 2:
-            zone_df = zone_df.loc[zone_df['Name'].isin(connected_buildings)]
+        selected_buildings = list(set(buildings_with_load).union(set(plant_buildings)))
+        if len(selected_buildings) >= 2:
+            zone_df = zone_df.loc[zone_df['Name'].isin(selected_buildings)]
             zone_df = zone_df.reset_index(drop=True)
         else:
             raise Exception("We could not find two or more buildings with thermal energy demand the network layout "


### PR DESCRIPTION
Up until now, the network layout tool was also tasked with placing the centralized heating/cooling plant at the building with the highest load. However, users might want to be able to specify plant locations themselves.

Allowing users to do so is actually quite easy! The function `layout_network` does include `plant_building_names` as an input parameter, but it seems to only be used during optimization.

This PR creates an additional parameter in the config file (`config.network_layout.plant_buildings`) such that users can select the building where the plant is located before running the network layout script. This parameter can take no values (i.e., the plant is located in the building with the highest demand), 1 value (the plant location specified by the user), or multiple values.

Some additional modifications were also necessary to allow users to specify buildings with no demands as the plant location, since this is actually the case in the case study I'm working with (i.e., there is a dedicated building for the area's cooling plant which would otherwise never be connected to the network in CEA).

I have tested these changes by running the following cases on a modified `reference-case-open` where only two buildings have demands:
1. _Running the network layout script in the master branch_
![image](https://user-images.githubusercontent.com/18548065/129020431-49bb8637-2015-4124-90f5-975b51f7f574.png)
2. _Running the script with no specified buildings_: the same layout as the master branch is created
![image](https://user-images.githubusercontent.com/18548065/129020565-95674a7b-2d35-4c08-a79b-0188966e9c46.png)
3. _Running the script with one specified plant building_: the buildings are supplied by a building with no loads
![image](https://user-images.githubusercontent.com/18548065/129020706-4a9fffae-19ad-4e6b-b097-fbb6d706c7cb.png)
4. _Running the script with two specified plant buildings_: the buildings are supplied by two buildings with no loads (case 3 shown in red for comparison)
![image](https://user-images.githubusercontent.com/18548065/129020783-4dfa1378-0ccc-44b2-a5e7-275bdb4f24b6.png)

I've checked all uses of the functions I have changed, which appear to only be used by the optimization workflow. The changes made don't seem to affect the functionality of the optimization, but since I am not very familiar with these scripts I'm requesting @shanshanhsieh reviews this PR.