### PR TITLE
Use ubuntu instead of debian as base image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git
+.github
 
 *.egg-info
 *.egg
@@ -14,3 +15,11 @@ venv
 
 # PyCharm
 .idea
+
+bin
+docs
+logo
+notebooks
+setup
+
+*.md

--- a/docs/installation/installation-on-euler.rst
+++ b/docs/installation/installation-on-euler.rst
@@ -83,7 +83,7 @@ Please login to Euler and conduct the following steps.
 
 ::
 
-    $ singularity shell -B $HOME -B $SCRATCH cea_latest.sif
+    $ SINGULARITY_HOME=/projects singularity shell -B $SCRATCH cea_latest.sif
     Singularity> source /venv/bin/activate
     (venv) Singularity> cea test
 


### PR DESCRIPTION
This PR fixes #3015.

Compilation of Daysim is failing in docker when using the `debian` base image. Not sure what is wrong but my guess might be something to do with a possible new `cmake` update? Using `ubuntu` as the base image somehow fixes this.