### PR TITLE
Send regex info to frontend

### DIFF
--- a/cea/interfaces/dashboard/api/inputs.py
+++ b/cea/interfaces/dashboard/api/inputs.py
@@ -247,6 +247,10 @@ def get_building_properties():
                     columns[column_name]['choices'] = get_choices(column['choice'], path)
                 if 'constraints' in column:
                     columns[column_name]['constraints'] = column['constraints']
+                if 'regex' in column:
+                    columns[column_name]['regex'] = column['regex']
+                    if 'example' in column:
+                        columns[column_name]['example'] = column['example']
                 columns[column_name]['description'] = column["description"]
                 columns[column_name]['unit'] = column["unit"]
             store['columns'][db] = columns

--- a/cea/schemas.yml
+++ b/cea/schemas.yml
@@ -1588,24 +1588,29 @@ get_building_air_conditioning:
       heat_starts:
         description: Start of the heating season - use 00|00 when there is none
         type: string
+        regex: ^(0[1-9]|[12][0-9]|3[01])\|(0[1-9]|1[012])$
+        example: '31|12'
         unit: '[DD|MM]'
         values: '{00|00...31|12}'
       heat_ends:
         description: End of the heating season - use 00|00 when there is none
         type: string
-        regex: ^\d{2}|\d{2}$
+        regex: ^(0[1-9]|[12][0-9]|3[01])\|(0[1-9]|1[012])$
+        example: '31|12'
         unit: '[DD|MM]'
         values: '{00|00...31|12}'
       cool_starts:
         description: Start of the cooling season - use 00|00 when there is none
         type: string
-        regex: ^\d{2}|\d{2}$
+        regex: ^(0[1-9]|[12][0-9]|3[01])\|(0[1-9]|1[012])$
+        example: '31|12'
         unit: '[DD|MM]'
         values: '{00|00...31|12}'
       cool_ends:
         description: End of the cooling season - use 00|00 when there is none
         type: string
-        regex: ^\d{2}|\d{2}$
+        regex: ^(0[1-9]|[12][0-9]|3[01])\|(0[1-9]|1[012])$
+        example: '31|12'
         unit: '[DD|MM]'
         values: '{00|00...31|12}'
   used_by:


### PR DESCRIPTION
This closes #2990. It fixes the issue where regex information is not being sent to the front end, that is why is was not able to validate such inputs correctly.