### PR TITLE
Make `roof:levels` 0 by default

### DIFF
--- a/cea/datamanagement/surroundings_helper.py
+++ b/cea/datamanagement/surroundings_helper.py
@@ -59,7 +59,7 @@ def clean_attributes(shapefile, buildings_height, buildings_floors, key):
             shapefile['REFERENCE'] = ["OSM - median" if x is np.nan else "OSM - as it is" for x in
                                       shapefile['building:levels']]
         if 'roof:levels' not in list_of_columns:
-            shapefile['roof:levels'] = [1] * no_buildings
+            shapefile['roof:levels'] = 0
 
         # get the median from the area:
         data_osm_floors1 = shapefile['building:levels'].fillna(0)

--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -76,7 +76,7 @@ def clean_attributes(shapefile, buildings_height, buildings_floors, buildings_he
             shapefile['REFERENCE'] = ["OSM - median values of all buildings" if x is np.nan else "OSM - as it is" for x
                                       in shapefile['building:levels']]
         if 'roof:levels' not in list_of_columns:
-            shapefile['roof:levels'] = [1] * no_buildings
+            shapefile['roof:levels'] = 0
 
         # get the median from the area:
         data_osm_floors1 = shapefile['building:levels'].fillna(0)


### PR DESCRIPTION
When OSM data does not include any information on the number of roofs (`roof:levels`), this value is set to 1 for every building in the case study:
https://github.com/architecture-building-systems/CityEnergyAnalyst/blob/2ddce1bc8cdd04038fbfcce881deadd35c621ed7/cea/datamanagement/zone_helper.py#L78-L79

According to the [OSM wiki](https://wiki.openstreetmap.org/wiki/Simple_3D_Buildings#Roof), this value seems to refer to, say, a pitched roof:
![Screen Shot 2021-11-17 at 16 43 46](https://user-images.githubusercontent.com/18548065/142166797-4b8caa43-8d0a-4275-b560-5ce8bd992bfd.png)

Later on in the script, this value is added to the data on `building:levels` to get the number of floors above ground in the zone shapefile:
https://github.com/architecture-building-systems/CityEnergyAnalyst/blob/2ddce1bc8cdd04038fbfcce881deadd35c621ed7/cea/datamanagement/zone_helper.py#L82-L85

So if no information is available on the type of roof the buildings in the case study have, a roof level is automatically added to all buildings, whether they have it or not (though funnily enough, if a single building in the entire case study had roof level data, no roof levels would be added to all the other buildings).

Assuming every building in the case study has a roof level _**AND**_ that that level is not already accounted for in the `building:levels` data is a very strong assumption. If OSM says a building has _N_ building levels and has no data on the number of roof levels, I would rather assume the building has _N_ levels rather than assume every building in the data set was tagged the wrong height (plus it includes the aforementioned inconsistency iff buildings with roof levels are indeed present in the dataset) – i.e., I'd rather default to truth and assume that the OSM data is _right_ rather than assume it is _wrong_ to begin with.

This furthermore leads the median height of the case study to be skewed, as buildings with no building level information are set to 1 floor above ground. So instead of assigning the median height of all buildings in the case study (as claimed by CEA), we are assigning the median height of all buildings for which we _do_ have data plus a bunch of buildings with an artificial height of 1 floor:
https://github.com/architecture-building-systems/CityEnergyAnalyst/blob/2ddce1bc8cdd04038fbfcce881deadd35c621ed7/cea/datamanagement/zone_helper.py#L86-L88
That's why we so often get 1 as the median height in CEA case studies.

This PR replaces the assumption that all buildings have 1 roof level with an assumption that they have 0 roof levels in order to solve issues #3061 and #3062. By doing so, it ensures that:
1. the number of floors assigned to a building is always equal to the `building:levels` value from OSM (where available) rather than making it potentially depend on whether neighboring buildings have specified `roof:levels` or not
2. buildings for which the number of floors is not given on OSM are set to the median number of floors for the buildings that _do_ have this data