### PR TITLE
Add mamba to CEA installer build

### DIFF
--- a/cea/dev/build.py
+++ b/cea/dev/build.py
@@ -88,8 +88,13 @@ def get_env(config, conda_env):
 
 
 def conda_env_create(config, env_name, environment_yml):
+    print("INSTALL mamba")
+    command = [conda(), "conda", "install", "mamba", "-c", "conda-forge", "-y"]
+    print("RUN: {command}".format(command=" ".join(command)))
+    subprocess.run(command, capture_output=False, check=True, env=get_env(config, "base"), shell=True)
+
     print("CREATE conda environment: {env_name}".format(env_name=env_name))
-    command = [conda(), "conda", "env", "create", "--name", env_name, "--file", environment_yml]
+    command = [conda(), "mamba", "env", "create", "--name", env_name, "--file", environment_yml]
     print("RUN: {command}".format(command=" ".join(command)))
     subprocess.run(command, capture_output=False, check=True, env=get_env(config, "base"), shell=True)
     print("DONE")


### PR DESCRIPTION
Propose to use mamba when building the CEA windows installer instead of conda to try to speed up `cea-dev build`. mamba will be able to solve the conda environment much faster than conda. 

However, it should be noted that this only helps a bit, since the bulk of the time spent during `cea-dev build` is compiling the installer itself.