### PR TITLE
Fix race condition when creating building geometries

### DIFF
--- a/cea/resources/radiation_daysim/geometry_generator.py
+++ b/cea/resources/radiation_daysim/geometry_generator.py
@@ -262,8 +262,7 @@ class BuildingGeometry(object):
 
     def save(self, pickle_location):
         dir_name = os.path.dirname(pickle_location)
-        if not os.path.exists(dir_name):
-            os.makedirs(dir_name)
+        os.makedirs(dir_name, exist_ok=True)
 
         with open(pickle_location, 'wb') as f:
             pickle.dump(self.__getstate__(), f)


### PR DESCRIPTION
This PR solves #3068. 

The issue is caused by a race condition when trying to create the temporary folder during building geometry creation, using multiprocessing. 

```python
if not os.path.exists(dir_name): <--- 
    os.makedirs(dir_name)
```

Surprisingly, this did not occur very often, even when using machines with higher number of processors.