### PR TITLE
3102 decentralized buildings cooling

### DIFF
--- a/cea/optimization/preprocessing/decentralized_buildings_cooling.py
+++ b/cea/optimization/preprocessing/decentralized_buildings_cooling.py
@@ -542,7 +542,7 @@ def rank_results(TAC_USD, TotalCO2, TotalPrim, number_of_configurations):
         optsearch[int(CO2S[rank][0])] -= 1
         if np.count_nonzero(optsearch) != number_of_configurations:
             Bestfound = True
-            indexBest = np.where(optsearch == 0)[0][0]
+            indexBest = np.where(optsearch == 0)[0][0] #FIXME: it is possible to have more than one configuration that reaches zero here
         rank += 1
     # get the best option according to the ranking.
     Best[indexBest][0] = 1

--- a/cea/optimization/preprocessing/decentralized_buildings_cooling.py
+++ b/cea/optimization/preprocessing/decentralized_buildings_cooling.py
@@ -545,7 +545,10 @@ def rank_results(TAC_USD, TotalCO2, TotalPrim, number_of_configurations):
             indexBest = np.where(optsearch == 0)[0][0] #FIXME: it is possible to have more than one configuration that reaches zero here
         rank += 1
     # get the best option according to the ranking.
-    Best[indexBest][0] = 1
+    if indexBest is not None:
+        Best[indexBest][0] = 1
+    else:
+        raise('indexBest not found, please check the ranking process or report this issue on GitHub.')
     return Best, indexBest
 
 

--- a/cea/optimization/preprocessing/decentralized_buildings_cooling.py
+++ b/cea/optimization/preprocessing/decentralized_buildings_cooling.py
@@ -525,20 +525,22 @@ def compile_TAC_CO2_Prim(Capex_a_USD, Opex_a_fixed_USD, number_of_configurations
 
 
 def rank_results(TAC_USD, TotalCO2, TotalPrim, number_of_configurations):
-    Best = np.zeros((number_of_configurations, 1))
-    # rank results
+    # sort TAC_USD and TotalCO2
     CostsS = TAC_USD[np.argsort(TAC_USD[:, 1])]
     CO2S = TotalCO2[np.argsort(TotalCO2[:, 1])]
-    el = len(CostsS)
+    # initialize optsearch array
+    optsearch = np.empty(number_of_configurations)
+    number_of_objectives = 2 # TAC_USD and TotalCO2
+    optsearch.fill(number_of_objectives)
+    # rank results
     rank = 0
     Bestfound = False
-    optsearch = np.empty(el)
-    optsearch.fill(3)
-    indexBest = 0
-    while not Bestfound and rank < el:
+    indexBest = None
+    Best = np.zeros((number_of_configurations, 1))
+    while not Bestfound and rank < number_of_configurations:
         optsearch[int(CostsS[rank][0])] -= 1
         optsearch[int(CO2S[rank][0])] -= 1
-        if np.count_nonzero(optsearch) != el:
+        if np.count_nonzero(optsearch) != number_of_configurations:
             Bestfound = True
             indexBest = np.where(optsearch == 0)[0][0]
         rank += 1

--- a/cea/optimization/preprocessing/decentralized_buildings_cooling.py
+++ b/cea/optimization/preprocessing/decentralized_buildings_cooling.py
@@ -7,6 +7,7 @@ Operation for decentralized buildings
 
 import time
 from math import ceil
+import random
 
 import numpy as np
 import pandas as pd
@@ -525,30 +526,67 @@ def compile_TAC_CO2_Prim(Capex_a_USD, Opex_a_fixed_USD, number_of_configurations
 
 
 def rank_results(TAC_USD, TotalCO2, TotalPrim, number_of_configurations):
+    """
+    This function chooses the best configuration according to the configurations' ranking in terms of cost and
+    emissions.
+    If different configurations have the same rank, just across different objective functions:
+    e.g. config 1: 1st in emissions, 2nd in cost
+         config 2: 2nd in emissions, 1st in cost
+    the function chooses the config that has the lowest value in each of the objective functions, relative to
+    the mean of the all configs:
+    e.g. If config 1: 41000 kgCO2 per year and the mean across all configs is 50000 kgCO2 per year the relative
+         emissions value of config 1 would be 82%.
+         If config 2: 44000 kgCO2 per year its relative emissions value would be 88%.
+         Let's assume the relative cost values of config 1 and 2 are 78% and 75% respectively.
+         The compounded relative objective value (cROV) of config 1 would therefore be 160%,
+         the compounded relative objective value of config 2 would be 163%.
+         -> config 1 would be chosen as the best
+    In the rare case where multiple configurations have the exact same compounded relative objective value
+    one of them is selected at random.
+    """
+
     # sort TAC_USD and TotalCO2
     CostsS = TAC_USD[np.argsort(TAC_USD[:, 1])]
     CO2S = TotalCO2[np.argsort(TotalCO2[:, 1])]
-    # initialize optsearch array
-    optsearch = np.empty(number_of_configurations)
-    number_of_objectives = 2 # TAC_USD and TotalCO2
-    optsearch.fill(number_of_objectives)
+    # initialize optSearch array
+    optSearch = np.empty(number_of_configurations)
+    number_of_objectives = 2  # TAC_USD and TotalCO2
+    optSearch.fill(number_of_objectives)
     # rank results
     rank = 0
-    Bestfound = False
+    BestFound = False
     indexBest = None
     Best = np.zeros((number_of_configurations, 1))
-    while not Bestfound and rank < number_of_configurations:
-        optsearch[int(CostsS[rank][0])] -= 1
-        optsearch[int(CO2S[rank][0])] -= 1
-        if np.count_nonzero(optsearch) != number_of_configurations:
-            Bestfound = True
-            indexBest = np.where(optsearch == 0)[0][0] #FIXME: it is possible to have more than one configuration that reaches zero here
+    while not BestFound and rank < number_of_configurations:
+        optSearch[int(CostsS[rank][0])] -= 1
+        optSearch[int(CO2S[rank][0])] -= 1
+
+        if np.count_nonzero(optSearch) != number_of_configurations:
+            BestFound = True
+            # in case only one best ranked configuration exists choose that one
+            if np.count_nonzero(optSearch) == number_of_configurations - 1:
+                indexBest = np.where(optSearch == 0)[0][0]
+            # in case different configurations have the same rank, evaluate their compounded relative objective values
+            else:
+                indexesSharedBest = np.where(optSearch == 0)[0]
+                relTAC_USD = TAC_USD[:, 1] / np.mean(TAC_USD[:, 1])
+                relTotalCO2 = TotalCO2[:, 1] / np.mean(TotalCO2[:, 1])
+                relTAC_USDSharedBest = relTAC_USD[indexesSharedBest]
+                relTotalCO2SharedBest = relTotalCO2[indexesSharedBest]
+                cROVsSharedBest = relTAC_USDSharedBest + relTotalCO2SharedBest
+                locBestCROV = np.where(cROVsSharedBest == np.min(cROVsSharedBest))[0]
+                if len(locBestCROV) == 1:
+                    indexBest = indexesSharedBest[locBestCROV[0]]
+                else:
+                    freeChoice = random.randint(0, len(locBestCROV) - 1)
+                    indexBest = indexesSharedBest[locBestCROV[freeChoice]]
+
         rank += 1
     # get the best option according to the ranking.
     if indexBest is not None:
         Best[indexBest][0] = 1
     else:
-        raise('indexBest not found, please check the ranking process or report this issue on GitHub.')
+        raise ('indexBest not found, please check the ranking process or report this issue on GitHub.')
     return Best, indexBest
 
 

--- a/cea/optimization/preprocessing/decentralized_buildings_heating.py
+++ b/cea/optimization/preprocessing/decentralized_buildings_heating.py
@@ -258,10 +258,8 @@ def disconnected_heating_for_building(building_name, supply_systems, T_ground_K,
         Capex_a_USD[3 + i][0] += Capex_a_GHP_USD
         Opex_a_fixed_USD[3 + i][0] += Opex_a_fixed_GHP_USD
         Capex_opex_a_fixed_only_USD[3 + i][0] += Capex_a_GHP_USD + Opex_a_fixed_GHP_USD  # TODO:variable price?
-    # Best configuration
+    # Compile Objectives
     number_of_configurations = len(GHG_tonCO2) # 13
-    Best = np.zeros((number_of_configurations, 1))
-    indexBest = None
     TAC_USD = np.zeros((number_of_configurations, 2))
     TotalCO2 = np.zeros((number_of_configurations, 2))
     for i in range(number_of_configurations):
@@ -269,16 +267,17 @@ def disconnected_heating_for_building(building_name, supply_systems, T_ground_K,
         Opex_a_USD[i][1] = Opex_a_fixed_USD[i][0] + Opex_a_var_USD[i][4]
         TAC_USD[i][1] = Capex_opex_a_fixed_only_USD[i][0] + Opex_a_var_USD[i][4]
         TotalCO2[i][1] = GHG_tonCO2[i][5]
+    # Rank results and find the best configuration
     # sort TAC_USD and TotalCO2
     CostsS = TAC_USD[np.argsort(TAC_USD[:, 1])]
     CO2S = TotalCO2[np.argsort(TotalCO2[:, 1])]
-    # rank results
-    rank = 0
-    Bestfound = False
+    # initialize optsearch array
+    number_of_objectives = 2  # TAC_USD and TotalCO2
     optsearch = np.empty(number_of_configurations)
-    optsearch.fill(3)
-    geothermal_potential = geothermal_potential_data.set_index('Name')
+    optsearch.fill(number_of_objectives)
+    Best = np.zeros((number_of_configurations, 1))
     # Check the GHP area constraint for configuration 4-13
+    geothermal_potential = geothermal_potential_data.set_index('Name')
     for i in range(10):
         QGHP = (1 - i / 10.0) * Qnom_W
         areaAvail = geothermal_potential.loc[building_name, 'Area_geo']
@@ -287,17 +286,22 @@ def disconnected_heating_for_building(building_name, supply_systems, T_ground_K,
             # disqualify the configuration if constraint not met
             optsearch[i + 3] += 1
             Best[i + 3][0] = - 1
+    # rank results
+    rank = 0
+    Bestfound = False
+    indexBest = None
     while not Bestfound and rank < number_of_configurations:
         optsearch[int(CostsS[rank][0])] -= 1
         optsearch[int(CO2S[rank][0])] -= 1
-        print(rank, optsearch)
         if np.count_nonzero(optsearch) != number_of_configurations:
             Bestfound = True
             indexBest = np.where(optsearch == 0)[0][0] #FIXME: it is possible to have more than one configuration that reaches zero here
-            print(indexBest)
         rank += 1
     # get the best option according to the ranking.
-    Best[indexBest][0] = 1
+    if indexBest is not None:
+        Best[indexBest][0] = 1
+    else:
+        raise('indexBest not found, please check the ranking process or report this issue on GitHub.')
     # Save results in csv file
     performance_results = {
         "Nominal heating load": Qnom_W,

--- a/cea/optimization/preprocessing/decentralized_buildings_heating.py
+++ b/cea/optimization/preprocessing/decentralized_buildings_heating.py
@@ -7,7 +7,7 @@ Operation for decentralized buildings
 
 
 import time
-
+import random
 import numpy as np
 import pandas as pd
 from geopandas import GeoDataFrame as Gdf
@@ -263,7 +263,7 @@ def disconnected_heating_for_building(building_name, supply_systems, T_ground_K,
     TAC_USD = np.zeros((number_of_configurations, 2))
     TotalCO2 = np.zeros((number_of_configurations, 2))
     for i in range(number_of_configurations):
-        TAC_USD[i][0] = TotalCO2[i][0]  = i
+        TAC_USD[i][0] = TotalCO2[i][0] = i
         Opex_a_USD[i][1] = Opex_a_fixed_USD[i][0] + Opex_a_var_USD[i][4]
         TAC_USD[i][1] = Capex_opex_a_fixed_only_USD[i][0] + Opex_a_var_USD[i][4]
         TotalCO2[i][1] = GHG_tonCO2[i][5]
@@ -271,10 +271,10 @@ def disconnected_heating_for_building(building_name, supply_systems, T_ground_K,
     # sort TAC_USD and TotalCO2
     CostsS = TAC_USD[np.argsort(TAC_USD[:, 1])]
     CO2S = TotalCO2[np.argsort(TotalCO2[:, 1])]
-    # initialize optsearch array
+    # initialize optSearch array
     number_of_objectives = 2  # TAC_USD and TotalCO2
-    optsearch = np.empty(number_of_configurations)
-    optsearch.fill(number_of_objectives)
+    optSearch = np.empty(number_of_configurations)
+    optSearch.fill(number_of_objectives)
     Best = np.zeros((number_of_configurations, 1))
     # Check the GHP area constraint for configuration 4-13
     geothermal_potential = geothermal_potential_data.set_index('Name')
@@ -284,18 +284,34 @@ def disconnected_heating_for_building(building_name, supply_systems, T_ground_K,
         Qallowed = np.ceil(areaAvail / GHP_A) * GHP_HMAX_SIZE  # [W_th]
         if Qallowed < QGHP:
             # disqualify the configuration if constraint not met
-            optsearch[i + 3] += 1
+            optSearch[i + 3] += 1
             Best[i + 3][0] = - 1
     # rank results
     rank = 0
-    Bestfound = False
+    BestFound = False
     indexBest = None
-    while not Bestfound and rank < number_of_configurations:
-        optsearch[int(CostsS[rank][0])] -= 1
-        optsearch[int(CO2S[rank][0])] -= 1
-        if np.count_nonzero(optsearch) != number_of_configurations:
-            Bestfound = True
-            indexBest = np.where(optsearch == 0)[0][0] #FIXME: it is possible to have more than one configuration that reaches zero here
+    while not BestFound and rank < number_of_configurations:
+        optSearch[int(CostsS[rank][0])] -= 1
+        optSearch[int(CO2S[rank][0])] -= 1
+        if np.count_nonzero(optSearch) != number_of_configurations:
+            BestFound = True
+            # in case only one best ranked configuration exists choose that one
+            if np.count_nonzero(optSearch) == number_of_configurations - 1:
+                indexBest = np.where(optSearch == 0)[0][0]
+            # in case different configurations have the same rank, evaluate their compounded relative objective values
+            else:
+                indexesSharedBest = np.where(optSearch == 0)[0]
+                relTAC_USD = TAC_USD[:, 1] / np.mean(TAC_USD[:, 1])
+                relTotalCO2 = TotalCO2[:, 1] / np.mean(TotalCO2[:, 1])
+                relTAC_USDSharedBest = relTAC_USD[indexesSharedBest]
+                relTotalCO2SharedBest = relTotalCO2[indexesSharedBest]
+                cROVsSharedBest = relTAC_USDSharedBest + relTotalCO2SharedBest
+                locBestCROV = np.where(cROVsSharedBest == np.min(cROVsSharedBest))[0]
+                if len(locBestCROV) == 1:
+                    indexBest = indexesSharedBest[locBestCROV[0]]
+                else:
+                    freeChoice = random.randint(0, len(locBestCROV) - 1)
+                    indexBest = indexesSharedBest[locBestCROV[freeChoice]]
         rank += 1
     # get the best option according to the ranking.
     if indexBest is not None:


### PR DESCRIPTION
This PR resolves #3102 .
The error came from: 
(1) the incorrect/hard-coded value for the number of objectives (`optsearch.fill(3)`).
(2) the initialization of `indexBest=0` is changed to `None`, it was the reason why the first configuration always got picked

To fix the error, the number of objectives is updated to 2 (cost and emission), but it is still hard-coded at the moment.
Some refactoring is also done to avoid hard-coded values for number_of_configurations.

To test:
- Run the same scenario provided in #3102, and check whether the best index is found.