### PR TITLE
`zone_helper` cannot import LineString geometry types

### DIFF
--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -296,7 +296,7 @@ def clean_geometries(gdf):
         if geometry.type == 'Polygon':  # ignore Polygons
             return geometry
         elif geometry.type in ['Point', 'LineString']:
-            print('Discarding geometry of type: {}'.format(geometry.type))
+            print(f'Discarding geometry of type: {geometry.type}')
             return None # discard geometry if it is a Point or LineString
         else:
             joined = unary_union(list(geometry))

--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -296,14 +296,14 @@ def clean_geometries(gdf):
         if geometry.type == 'Polygon':  # ignore Polygons
             return geometry
         elif geometry.type in ['Point', 'LineString']:
-            print('Discarding geometry of type: {}'.format(geometry.type))
+            print(f'Discarding geometry of type: {geometry.type}')
             return None # discard geometry if it is a Point or LineString
         else:
             joined = unary_union(list(geometry))
             if joined.type == 'MultiPolygon':  # some Multipolygons could not be combined
                 return joined[0]  # just return first polygon
             elif joined.type != 'Polygon':  # discard geometry if it is still not a Polygon
-                print('Discarding geometry of type: {geometry_type}'.format(geometry_type=joined.type))
+                print(f'Discarding geometry of type: {joined.type}')
                 return None
             else:
                 return joined

--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -296,7 +296,7 @@ def clean_geometries(gdf):
         if geometry.type == 'Polygon':  # ignore Polygons
             return geometry
         elif geometry.type in ['Point', 'LineString']:
-            print(f'Discarding geometry of type: {geometry.type}')
+            print('Discarding geometry of type: {}'.format(geometry.type))
             return None # discard geometry if it is a Point or LineString
         else:
             joined = unary_union(list(geometry))

--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -298,6 +298,8 @@ def clean_geometries(gdf):
         elif geometry.type == 'Point':
             print('Discarding geometry of type: Point')
             return None # discard geometry if it is a Point
+        elif geometry.type == 'LineString':
+            return geometry.convex_hull
         else:
             joined = unary_union(list(geometry))
             if joined.type == 'MultiPolygon':  # some Multipolygons could not be combined


### PR DESCRIPTION
While testing a case study, I found a couple of instances of `LineString` geometry type, which the `zone_helper` was unable to deal with.

After checking, in my specific case study, these were categorized in OSM as "garden" and "way", i.e., neither was an actual building. So the easiest solution is to ignore this geometry type, much like `Point` geometry types are already ignored by CEA.