### PR TITLE
3105 Remove Partially Matched CX

### DIFF
--- a/cea/default.config
+++ b/cea/default.config
@@ -809,9 +809,9 @@ crossover-prob.type = RealParameter
 crossover-prob.help = Cross-over probability for genetic algorithm (NSGA-III)
 crossover-prob.category = Advanced
 
-crossover-method-integer = UniformPartialyMatched
+crossover-method-integer = Uniform
 crossover-method-integer.type = ChoiceParameter
-crossover-method-integer.choices = Uniform, TwoPoint, PartialyMatched, UniformPartialyMatched
+crossover-method-integer.choices = Uniform, TwoPoint
 crossover-method-integer.help = Crossover method for integer variables (network connectivity)
 crossover-method-integer.category = Advanced
 

--- a/cea/optimization/master/crossover.py
+++ b/cea/optimization/master/crossover.py
@@ -3,9 +3,6 @@ Crossover routines
 
 """
 
-
-
-
 from deap import tools
 
 from cea.optimization.master.validation import validation_main
@@ -27,11 +24,7 @@ class CrossOverMethodsInteger(object):
         elif self.method == 'TwoPoint':
             return tools.cxESTwoPoint(individual_1,
                                       individual_2)
-        elif self.method == 'PartialyMatched':
-            return tools.cxPartialyMatched(individual_1,
-                                           individual_2)
-        elif self.method == 'UniformPartialyMatched':
-            return tools.cxUniformPartialyMatched(individual_1, individual_2, probability)
+
 
 class CrossOverMethodsContinuous(object):
     """
@@ -49,6 +42,7 @@ class CrossOverMethodsContinuous(object):
         elif self.method == 'TwoPoint':
             return tools.cxESTwoPoint(individual_1,
                                       individual_2)
+
 
 def crossover_main(ind1, ind2, indpb,
                    column_names,


### PR DESCRIPTION
Remove partially matched crossovers form the crossover options, as they only work on chromosomes with unique indices (travelling salesman-type problems)