### PR TITLE
Fix Flask dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,9 @@ channels:
 dependencies:
 - deap
 - ephem
-- flask=1.1.2
+- flask=1.1.4
+- jinja2=2.11.3
+- itsdangerous=1.1.0
 - flask-cors
 - flask-restplus
 - flask-socketio=4.3.2
@@ -23,7 +25,6 @@ dependencies:
 - fiona
 - gdal
 - geopandas
-- jinja2
 - matplotlib
 - networkx
 - numba


### PR DESCRIPTION
This closes #3138 by setting the version for the flask dependencies. 

This is a fast fix, but I think we have to upgrade Flask eventually.