### PR TITLE
Fix import input files

### DIFF
--- a/cea/api.py
+++ b/cea/api.py
@@ -24,17 +24,18 @@ def register_scripts():
                 config = cea.config.Configuration()
 
             option_list = cea_script.parameters
-            config.restrict_to(option_list)
-            for section, parameter in config.matching_parameters(option_list):
-                if parameter.py_name in kwargs:
-                    parameter.set(kwargs[parameter.py_name])
-            cea_script.print_script_configuration(config)
-            if list(cea_script.missing_input_files(config)):
-                cea_script.print_missing_input_files(config)
-                raise cea.MissingInputDataException()
-            t0 = datetime.datetime.now()
-            # run the script
-            script_module.main(config)
+
+            with config.temp_restrictions(option_list):
+                for section, parameter in config.matching_parameters(option_list):
+                    if parameter.py_name in kwargs:
+                        parameter.set(kwargs[parameter.py_name])
+                cea_script.print_script_configuration(config)
+                if list(cea_script.missing_input_files(config)):
+                    cea_script.print_missing_input_files(config)
+                    raise cea.MissingInputDataException()
+                t0 = datetime.datetime.now()
+                # run the script
+                script_module.main(config)
 
             # print success message
             msg = "Script completed. Execution time: %.2fs" % (datetime.datetime.now() - t0).total_seconds()

--- a/cea/config.py
+++ b/cea/config.py
@@ -113,6 +113,32 @@ class Configuration(object):
             self.restricted_to.append('general:project')
             self.restricted_to.append('general:scenario-name')
 
+    def temp_restrictions(self, parameters):
+        """
+        Apply temporary restricts to script using context manager
+        """
+
+        class TempRestrictions:
+            def __init__(self, _config, _parameters):
+                self.config = _config
+                self.parameters = _parameters
+                self.old_restrictions = None
+
+            def apply(self):
+                self.old_restrictions = self.config.restricted_to
+                self.config.restrict_to(self.parameters)
+
+            def clear(self):
+                self.config.restricted_to = self.old_restrictions
+
+            def __enter__(self):
+                self.apply()
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                self.clear()
+
+        return TempRestrictions(self, parameters)
+
     def ignore_restrictions(self):
         """Create a ``with`` block where the config file restrictions are not kept. Usage::
 

--- a/cea/interfaces/dashboard/api/project.py
+++ b/cea/interfaces/dashboard/api/project.py
@@ -121,7 +121,7 @@ class Scenarios(Resource):
         with tempfile.TemporaryDirectory() as tmp:
             config = cea.config.Configuration()
             config.project = tmp
-            config.scenario_name = "temp"
+            config.scenario_name = "temp_scenario"
 
             _project = project or config.project
 
@@ -138,7 +138,11 @@ class Scenarios(Resource):
                 files = payload.get('files')
                 if files is not None:
                     try:
+                        output_path, project_name = os.path.split(config.project)
                         cea.api.create_new_scenario(config,
+                                                    output_path=output_path,
+                                                    project=project_name,
+                                                    scenario=config.scenario_name,
                                                     zone=files.get('zone'),
                                                     surroundings=files.get('surroundings'),
                                                     streets=files.get('streets'),


### PR DESCRIPTION
This solves #3149

`config` restrictions were still retained which caused errors when trying to run scripts from `cea.api`