### PR TITLE
create .csv demand file with debugging on

### DIFF
--- a/cea/demand/demand_writers.py
+++ b/cea/demand/demand_writers.py
@@ -46,11 +46,10 @@ class DemandWriter(object):
             locator.get_temporary_file('%(building_name)sT.hdf' % locals()),
             key='dataset')
 
-    def results_to_csv(self, tsd, bpr, locator, date, building_name, debug):
-        if not debug:
-            # save hourly data
-            columns, hourly_data = self.calc_hourly_dataframe(building_name, date, tsd)
-            self.write_to_csv(building_name, columns, hourly_data, locator)
+    def results_to_csv(self, tsd, bpr, locator, date, building_name):
+        # save hourly data
+        columns, hourly_data = self.calc_hourly_dataframe(building_name, date, tsd)
+        self.write_to_csv(building_name, columns, hourly_data, locator)
 
         # save annual values to a temp file for YearlyDemandWriter
         columns, data = self.calc_yearly_dataframe(bpr, building_name, tsd)

--- a/cea/demand/thermal_loads.py
+++ b/cea/demand/thermal_loads.py
@@ -187,9 +187,8 @@ def write_results(bpr, building_name, date, loads_output, locator, massflows_out
         print('Writing detailed demand results of {} to .xls file.'.format(building_name))
         reporting.quick_visualization_tsd(tsd, locator.get_demand_results_folder(), building_name)
         reporting.full_report_to_xls(tsd, locator.get_demand_results_folder(), building_name)
-        writer.results_to_csv(tsd, bpr, locator, date, building_name, debug=True)
-    else:
-        writer.results_to_csv(tsd, bpr, locator, date, building_name, debug=False)
+
+    writer.results_to_csv(tsd, bpr, locator, date, building_name)
 
 
 def calc_Qcs_sys(bpr, tsd):


### PR DESCRIPTION
Changed the 'demand_writers' and 'thermal_loads' files so that the regular building demand files ('BXXXX.csv') is output regardless of whether debugging is on or off.

Test this functionality by:
1. setting `debug=true` in cea.config
2. creating a new scenario in any of your current test projects
3. running all scripts up until and including 'Building Energy demand'
4. checking the outputs>data>demand folder: are there 'BXXXX.csv' files for each of the buildings in your scenario?
5. running all scripts up until and including 'Thermal Network Part II (simulation)'

If this last script is running successfully, that means all the necessary inputs - including building demand files - are available.