### PR TITLE
Allow more than three use types

### DIFF
--- a/cea/datamanagement/archetypes_mapper.py
+++ b/cea/datamanagement/archetypes_mapper.py
@@ -18,7 +18,7 @@ from typing import List, Tuple
 import cea.config
 import cea.inputlocator
 from cea import InvalidOccupancyNameException
-from cea.datamanagement.schedule_helper import calc_mixed_schedule
+from cea.datamanagement.schedule_helper import calc_mixed_schedule, get_list_of_uses_in_case_study, get_lists_of_var_names_and_var_values
 from cea.utilities.dbf import dbf_to_dataframe, dataframe_to_dbf
 
 
@@ -204,29 +204,6 @@ def architecture_mapper(locator, typology_df):
     dataframe_to_dbf(prop_architecture_df[fields], locator.get_building_architecture())
 
 
-def get_list_of_uses_in_case_study(building_typology_df):
-    """
-    validates lists of uses in case study.
-    refactored from archetypes_mapper function
-
-    :param building_typology_df: dataframe of occupancy.dbf input (can be read in archetypes-mapper or in building-properties)
-    :type building_typology_df: pandas.DataFrame
-    :return: list of uses in case study
-    :rtype: pandas.DataFrame.Index
-    """
-    list_var_names = ["1ST_USE", '2ND_USE', '3RD_USE']
-    list_var_values = ["1ST_USE_R", '2ND_USE_R', '3RD_USE_R']
-    # validate list of uses
-    list_uses = []
-    n_records = building_typology_df.shape[0]
-    for row in range(n_records):
-        for var_name, var_value in zip(list_var_names,list_var_values):
-            if building_typology_df.loc[row, var_value] > 0.0:
-                list_uses.append(building_typology_df.loc[row, var_name])  # append valid uses
-    unique_uses = list(set(list_uses))
-    return unique_uses
-
-
 def calc_code(code1, code2, code3, code4):
     return str(code1) + str(code2) + str(code3) + str(code4)
 
@@ -378,10 +355,7 @@ def calculate_average_multiuse(fields, properties_df, occupant_densities, list_u
         buildings
     """
 
-    if list_var_names is None:
-        list_var_names = ["1ST_USE", '2ND_USE', '3RD_USE']
-    if list_var_values is None:
-        list_var_values = ["1ST_USE_R", '2ND_USE_R', '3RD_USE_R']
+    list_var_names, list_var_values = get_lists_of_var_names_and_var_values(list_var_names, list_var_values, properties_df)
 
     properties_DB = properties_DB.set_index('code')
     for column in fields:

--- a/cea/datamanagement/schedule_helper.py
+++ b/cea/datamanagement/schedule_helper.py
@@ -11,6 +11,7 @@ import cea
 import cea.config
 import cea.inputlocator
 from cea.demand.constants import VARIABLE_CEA_SCHEDULE_RELATION
+from cea.utilities.dbf import dbf_to_dataframe
 from cea.utilities.schedule_reader import read_cea_schedule, save_cea_schedule
 
 __author__ = "Jimeno Fonseca"
@@ -51,14 +52,12 @@ def calc_mixed_schedule(locator, building_typology_df, buildings, list_var_names
     :return:
     """
 
-    if list_var_names is None:
-        list_var_names = ["1ST_USE", '2ND_USE', '3RD_USE']
-    if list_var_values is None:
-        list_var_values = ["1ST_USE_R", '2ND_USE_R', '3RD_USE_R']
-
     metadata = 'mixed-schedule'
     schedule_data_all_uses = ScheduleData(locator)
     building_typology_df = building_typology_df.loc[building_typology_df['Name'].isin(buildings)]
+    list_var_names, list_var_values = get_lists_of_var_names_and_var_values(list_var_names,
+                                                                            list_var_values,
+                                                                            building_typology_df)
 
     # get list of uses only with a valid value in building_occupancy_df
     list_uses = get_list_of_uses_in_case_study(building_typology_df)
@@ -209,8 +208,9 @@ def get_list_of_uses_in_case_study(building_typology_df):
     :return: list of uses in case study
     :rtype: pandas.DataFrame.Index
     """
-    list_var_names = ["1ST_USE", '2ND_USE', '3RD_USE']
-    list_var_values = ["1ST_USE_R", '2ND_USE_R', '3RD_USE_R']
+    list_var_names, list_var_values = get_lists_of_var_names_and_var_values(
+        list_var_names=["1ST_USE", '2ND_USE', '3RD_USE'], list_var_values=["1ST_USE_R", '2ND_USE_R', '3RD_USE_R'],
+        building_typology_df=building_typology_df)
 
     # validate list of uses
     list_uses = set()
@@ -222,6 +222,23 @@ def get_list_of_uses_in_case_study(building_typology_df):
 
     unique_uses = list(list_uses)
     return unique_uses
+
+
+def get_lists_of_var_names_and_var_values(list_var_names, list_var_values, building_typology_df):
+    '''
+    This script checks whether there are more var names in the building typology than the default number, and if so,
+    it allows more than the default number of var names to be processed.
+    '''
+
+    if list_var_names is None:
+        list_var_names = ["1ST_USE", '2ND_USE', '3RD_USE']
+    if list_var_values is None:
+        list_var_values = ["1ST_USE_R", '2ND_USE_R', '3RD_USE_R']
+    if len([c for c in building_typology_df.columns if '_USE_R' in c]) > len(list_var_values):
+        list_var_values = [c for c in building_typology_df.columns if '_USE_R' in c]
+        list_var_names = ['_'.join(c.split('_')[0:2]) for c in list_var_values]
+
+    return list_var_names, list_var_values
 
 
 def calc_average(last, current, share_of_use):
@@ -261,8 +278,15 @@ class ScheduleData(object):
 
 def main(config):
     locator = cea.inputlocator.InputLocator(scenario=config.scenario)
-    path_to_building_schedule = locator.get_database_standard_schedules_use('MULTI_RES')
 
+    # get occupancy and age files
+    building_typology_df = dbf_to_dataframe(locator.get_building_typology())
+
+    # validate list of uses in case study
+    get_list_of_uses_in_case_study(building_typology_df)
+
+    # calculate mixed schedules
+    calc_mixed_schedule(locator, building_typology_df, buildings=config.archetypes_mapper.buildings)
 
 if __name__ == '__main__':
     main(cea.config.Configuration())


### PR DESCRIPTION
This PR modifies the CEA data management scripts can process `typology.dbf` files with more than 3 use types. This modification allows advanced users (e.g., researchers) to run case studies with any number of use types from the command line while not affecting the user experience of dashboard users.