### PR TITLE
Fix memory error when writing radiance surfaces

### DIFF
--- a/cea/resources/radiation_daysim/radiance.py
+++ b/cea/resources/radiation_daysim/radiance.py
@@ -501,19 +501,17 @@ def surrounding_building_to_radiance(building_geometry):
 
 def create_rad_geometry(file_path, geometry_terrain, building_surface_properties, zone_building_names,
                         surroundings_building_names, geometry_pickle_dir):
-    out = []
-    for terrain_surface in terrain_to_radiance(geometry_terrain):
-        out.append(terrain_surface.rad())
-
-    for building_name in zone_building_names:
-        building_geometry = BuildingGeometry.load(os.path.join(geometry_pickle_dir, 'zone', building_name))
-        for building_surface in zone_building_to_radiance(building_geometry, building_surface_properties):
-            out.append(building_surface.rad())
-
-    for building_name in surroundings_building_names:
-        building_geometry = BuildingGeometry.load(os.path.join(geometry_pickle_dir, 'surroundings', building_name))
-        for building_surface in surrounding_building_to_radiance(building_geometry):
-            out.append(building_surface.rad())
-
     with open(file_path, "w") as rad_file:
-        rad_file.write(''.join(out))
+        for terrain_surface in terrain_to_radiance(geometry_terrain):
+            rad_file.write(terrain_surface.rad())
+
+        for building_name in zone_building_names:
+            building_geometry = BuildingGeometry.load(os.path.join(geometry_pickle_dir, 'zone', building_name))
+            for building_surface in zone_building_to_radiance(building_geometry, building_surface_properties):
+                rad_file.write(building_surface.rad())
+
+        for building_name in surroundings_building_names:
+            building_geometry = BuildingGeometry.load(
+                os.path.join(geometry_pickle_dir, 'surroundings', building_name))
+            for building_surface in surrounding_building_to_radiance(building_geometry):
+                rad_file.write(building_surface.rad())


### PR DESCRIPTION
To prevent memory errors when writing to the rad file, the strings are written to file after each iteration, instead of storing it in an array (which would increase in size as the number of buildings increases). This results in a small (could be negligible) speed penalty, since there is more I/O operations, but at least it would prevent it from crashing.