### PR TITLE
Fix CRS change

### DIFF
--- a/cea/datamanagement/streets_helper.py
+++ b/cea/datamanagement/streets_helper.py
@@ -10,7 +10,7 @@ from geopandas import GeoDataFrame as Gdf
 
 import cea.config
 import cea.inputlocator
-from cea.datamanagement.surroundings_helper import get_zone_and_surr_in_geographic_crs
+from cea.datamanagement.surroundings_helper import get_zone_and_surr_in_projected_crs
 from cea.utilities.standardize_coordinates import get_projected_coordinate_system, get_geographic_coordinate_system
 
 __author__ = "Jimeno Fonseca"
@@ -25,7 +25,7 @@ __status__ = "Production"
 
 def calc_bounding_box(locator):
     # connect both files and avoid repetition
-    data_zone, data_dis = get_zone_and_surr_in_geographic_crs(locator)
+    data_zone, data_dis = get_zone_and_surr_in_projected_crs(locator)
     data_dis = data_dis.loc[~data_dis["Name"].isin(data_zone["Name"])]
     data = data_zone.append(data_dis, ignore_index=True, sort=True)
     data = data.to_crs(get_geographic_coordinate_system())

--- a/cea/datamanagement/surroundings_helper.py
+++ b/cea/datamanagement/surroundings_helper.py
@@ -39,15 +39,19 @@ def calc_surrounding_area(zone_gdf, buffer_m):
     return surrounding_area
 
 
-def get_zone_and_surr_in_geographic_crs(locator):
+def get_zone_and_surr_in_projected_crs(locator):
     # generate GeoDataFrames from files
     zone_gdf = gdf.from_file(locator.get_zone_geometry())
     surroundings_gdf = gdf.from_file(locator.get_surroundings_geometry())
+    # get longitude and latitude of zone centroid
+    zone_gdf_in_geographic_crs = zone_gdf.to_crs(get_geographic_coordinate_system())
+    lon = zone_gdf_in_geographic_crs.geometry[0].centroid.coords.xy[0][0]
+    lat = zone_gdf_in_geographic_crs.geometry[0].centroid.coords.xy[1][0]
     # check if the coordinate reference systems (crs) of the zone and its surroundings match
-    if zone_gdf.crs != surroundings_gdf.crs or zone_gdf.crs != get_geographic_coordinate_system():
+    if zone_gdf.crs != surroundings_gdf.crs or zone_gdf.crs != get_projected_coordinate_system(lat=lat, lon=lon):
         # if they don't match project the zone and its surroundings to the global crs...
-        zone_gdf = zone_gdf.to_crs(get_geographic_coordinate_system())
-        surroundings_gdf = surroundings_gdf.to_crs(get_geographic_coordinate_system())
+        zone_gdf = zone_gdf.to_crs(get_projected_coordinate_system(lat=lat, lon=lon))
+        surroundings_gdf = surroundings_gdf.to_crs(get_projected_coordinate_system(lat=lat, lon=lon))
         # and save the projected GDFs to their corresponding shapefiles
         zone_gdf.to_file(locator.get_zone_geometry())
         surroundings_gdf.to_file(locator.get_surroundings_geometry())

--- a/cea/datamanagement/terrain_helper.py
+++ b/cea/datamanagement/terrain_helper.py
@@ -17,7 +17,7 @@ from shapely.geometry import Polygon
 
 import cea.config
 import cea.inputlocator
-from cea.datamanagement.surroundings_helper import get_zone_and_surr_in_geographic_crs
+from cea.datamanagement.surroundings_helper import get_zone_and_surr_in_projected_crs
 from cea.utilities.standardize_coordinates import get_projected_coordinate_system, get_geographic_coordinate_system
 
 __author__ = "Jimeno Fonseca"
@@ -43,7 +43,7 @@ def request_elevation(lon, lat):
 def calc_bounding_box_projected_coordinates(locator):
 
     # connect both files and avoid repetition
-    data_zone, data_dis = get_zone_and_surr_in_geographic_crs(locator)
+    data_zone, data_dis = get_zone_and_surr_in_projected_crs(locator)
     data_dis = data_dis.loc[~data_dis["Name"].isin(data_zone["Name"])]
     data = data_zone.append(data_dis, ignore_index = True, sort=True)
     data = data.to_crs(get_geographic_coordinate_system())


### PR DESCRIPTION
The previous change to these scripts saved the zone and surroundings files in the geographic coordinate systems. This change caused issues in some surface calculations in later scripts.
This change now saves them to the projected coordinated system (with the projection point set to the centroid of the zone), which should rectify the errors in the surface calculations.