### PR TITLE
Gets building height from OSM in zone helper

### DIFF
--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -90,8 +90,9 @@ def clean_attributes(shapefile, buildings_height, buildings_floors, buildings_he
             np.nanmedian(data_floors_sum_with_nan))  # median so we get close to the worse case
         shapefile["floors_ag"] = [int(x) if not np.isnan(x) else data_osm_floors_joined for x in
                                   data_floors_sum_with_nan]
+        print(shapefile.info())
         if 'height' in list_of_columns:
-            shapefile["height_ag"] = shapefile['height'].fillna(shapefile["floors_ag"] * constants.H_F)
+            shapefile["height_ag"] = shapefile["height"].fillna(shapefile["floors_ag"] * constants.H_F).astype(float)
         else:
             shapefile["height_ag"] = shapefile["floors_ag"] * constants.H_F
     else:

--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -100,6 +100,9 @@ def clean_attributes(shapefile, buildings_height, buildings_floors, buildings_he
             #  Replaces 'nan' values with CEA assumption
             shapefile["height_ag"] = shapefile["height"].fillna(shapefile["floors_ag"] * constants.H_F).astype(float)
             #  Replaces values of height = 0 with CEA assumption
+            # TODO: Check whether buildings with height between 0 and 1 meter are actually mostly underground
+            #  The radiation script cannot process buildings with height 0m (underground buildings) those at the moment.
+            #  Once the radiation script can process underground buildings, this step might need to be revised.
             shapefile["height_ag"] = shapefile["height_ag"].where(shapefile["height_ag"] != 0,
                                                                   shapefile["floors_ag"] * constants.H_F).astype(float)
 

--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -91,8 +91,7 @@ def clean_attributes(shapefile, buildings_height, buildings_floors, buildings_he
         shapefile["floors_ag"] = [int(x) if not np.isnan(x) else data_osm_floors_joined for x in
                                   data_floors_sum_with_nan]
         if 'height' in list_of_columns:
-            shapefile["height_ag"] = shapefile['height'].fillna('0')
-            shapefile["height_ag"] = shapefile["height_ag"].where(shapefile["height_ag"]==0,shapefile["floors_ag"] * constants.H_F)
+            shapefile["height_ag"] = shapefile['height'].fillna(shapefile["floors_ag"] * constants.H_F)
         else:
             shapefile["height_ag"] = shapefile["floors_ag"] * constants.H_F
     else:

--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -62,10 +62,15 @@ def clean_attributes(shapefile, buildings_height, buildings_floors, buildings_he
     no_buildings = shapefile.shape[0]
     list_of_columns = shapefile.columns
     if buildings_height is None and buildings_floors is None:
-        print('Warning! you have not indicated a height or number of floors above ground for the buildings, '
+        print('Warning! you have not indicated number of floors above ground for the buildings, '
               'we are reverting to data stored in Open Street Maps (It might not be accurate at all),'
               'if we do not find data in OSM for a particular building, we get the median in the surroundings, '
               'if we do not get any data we assume 4 floors per building')
+
+        print('Warning! you have not indicated height above ground for the buildings, '
+              'we are reverting to data stored in Open Street Maps (It might not be accurate at all),'
+              'if we do not find data in OSM for a particular building, we estimate it based on the number of floors,'
+              'multiplied by a pre-defined floor-to-floor height')
 
         # Check which attributes the OSM has, Sometimes it does not have any and indicate the data source
         if 'building:levels' not in list_of_columns:
@@ -92,7 +97,12 @@ def clean_attributes(shapefile, buildings_height, buildings_floors, buildings_he
                                   data_floors_sum_with_nan]
 
         if 'height' in list_of_columns:
+            #  Replaces 'nan' values with CEA assumption
             shapefile["height_ag"] = shapefile["height"].fillna(shapefile["floors_ag"] * constants.H_F).astype(float)
+            #  Replaces values of height = 0 with CEA assumption
+            shapefile["height_ag"] = shapefile["height_ag"].where(shapefile["height_ag"] != 0,
+                                                                  shapefile["floors_ag"] * constants.H_F).astype(float)
+
         else:
             shapefile["height_ag"] = shapefile["floors_ag"] * constants.H_F
     else:
@@ -107,7 +117,7 @@ def clean_attributes(shapefile, buildings_height, buildings_floors, buildings_he
             shapefile["height_ag"] = [buildings_height] * no_buildings
             shapefile["floors_ag"] = [buildings_floors] * no_buildings
 
-    # add fields for floorsa and height below ground
+    # add fields for floors and height below ground
     shapefile["height_bg"] = [buildings_height_below_ground] * no_buildings
     shapefile["floors_bg"] = [buildings_floors_below_ground] * no_buildings
 

--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -101,7 +101,8 @@ def clean_attributes(shapefile, buildings_height, buildings_floors, buildings_he
             shapefile["height_ag"] = shapefile["height"].fillna(shapefile["floors_ag"] * constants.H_F).astype(float)
             #  Replaces values of height = 0 with CEA assumption
             # TODO: Check whether buildings with height between 0 and 1 meter are actually mostly underground
-            #  The radiation script cannot process buildings with height 0m (underground buildings) those at the moment.
+            #  These might not be errors, but rather partially or fully underground buildings. This should be verified.
+            #  Also, the radiation script cannot process buildings with height 0 m at the moment.
             #  Once the radiation script can process underground buildings, this step might need to be revised.
             shapefile["height_ag"] = shapefile["height_ag"].where(shapefile["height_ag"] != 0,
                                                                   shapefile["floors_ag"] * constants.H_F).astype(float)

--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -88,7 +88,11 @@ def clean_attributes(shapefile, buildings_height, buildings_floors, buildings_he
             np.nanmedian(data_floors_sum_with_nan))  # median so we get close to the worse case
         shapefile["floors_ag"] = [int(x) if not np.isnan(x) else data_osm_floors_joined for x in
                                   data_floors_sum_with_nan]
-        shapefile["height_ag"] = shapefile["floors_ag"] * constants.H_F
+        if 'height' in list_of_columns:
+            shapefile["height_ag"] = shapefile['height'].fillna('0')
+            shapefile["height_ag"] = shapefile["height_ag"].where(shapefile["height_ag"]==0,shapefile["floors_ag"] * constants.H_F)
+        else:
+            shapefile["height_ag"] = shapefile["floors_ag"] * constants.H_F
     else:
         shapefile['REFERENCE'] = "User - assumption"
         if buildings_height is None and buildings_floors is not None:

--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -90,7 +90,7 @@ def clean_attributes(shapefile, buildings_height, buildings_floors, buildings_he
             np.nanmedian(data_floors_sum_with_nan))  # median so we get close to the worse case
         shapefile["floors_ag"] = [int(x) if not np.isnan(x) else data_osm_floors_joined for x in
                                   data_floors_sum_with_nan]
-        print(shapefile.info())
+
         if 'height' in list_of_columns:
             shapefile["height_ag"] = shapefile["height"].fillna(shapefile["floors_ag"] * constants.H_F).astype(float)
         else:


### PR DESCRIPTION
Fixes issue #3218.
This is a quick fix to make CEA get height from OSM when attribute 'height' is existent.

Question: Should the same process be applied in lines 100, 103 and 106? I am a bit confused about this particular part, which seems to be for when the user has defined the geometry.

Comment: The same can be done for surrounding building and I plan to address this in issue #3219 