### PR TITLE
Use micromamba instead of miniforge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,28 +17,10 @@ jobs:
           sudo apt-get clean && sudo apt-get update
           sudo apt-get install -y libgl1
 
-      - name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Install Conda environment with Micromamba
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          python-version: 3.8
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          use-mamba: true
-          activate-environment: cea
-
-      - name: Cache conda env
-        uses: actions/cache@v3
-        env:
-          # Increase this value to reset cache if etc/example-environment.yml has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ${{ env.CONDA }}/envs
-          key: conda-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('environment.yml') }}-${{ env.CACHE_NUMBER }}
-        id: cache
-
-      - name: Update environment
-        run: mamba env update -n cea -f environment.yml
-        if: steps.cache.outputs.cache-hit != 'true'
+          cache-env: true
 
       - name: Install CEA
         shell: bash -l {0}

--- a/.github/workflows/pull.request.yml
+++ b/.github/workflows/pull.request.yml
@@ -17,28 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Install Conda environment with Micromamba
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          python-version: 3.8
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          use-mamba: true
-          activate-environment: cea
-
-      - name: Cache conda env
-        uses: actions/cache@v3
-        env:
-          # Increase this value to reset cache if etc/example-environment.yml has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ${{ env.CONDA }}/envs
-          key: conda-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('environment.yml') }}-${{ env.CACHE_NUMBER }}
-        id: cache
-
-      - name: Update environment
-        run: mamba env update -n cea -f environment.yml
-        if: steps.cache.outputs.cache-hit != 'true'
+          cache-env: true
 
       - name: Install CEA
         shell: bash -l {0}


### PR DESCRIPTION
This could help improve the speed of GitHub actions test, by reducing the time needed to prepare the environment.