### PR TITLE
Fix `zone_helper` issue caused by `str` type min_heights

### DIFF
--- a/cea/datamanagement/zone_helper.py
+++ b/cea/datamanagement/zone_helper.py
@@ -155,10 +155,12 @@ def fix_overlapping_geoms(buildings, zone):
 
     # Correct levels below ground if a minimum floor level or height is indicated
     if 'building:min_level' in list_of_attributes:
+        buildings["building:min_level"] = buildings["building:min_level"].astype(float)
         has_min_floor = buildings["building:min_level"] == buildings["building:min_level"]
         buildings[has_min_floor].floors_bg = [- int(x) for x in buildings[has_min_floor]["building:min_level"]]
         buildings[has_min_floor].height_bg = buildings[has_min_floor].floors_bg * constants.H_F
     if 'min_height' in list_of_attributes:
+        buildings["min_height"] = buildings["min_height"].astype(float)
         has_min_height = buildings["min_height"] == buildings["min_height"]
         buildings[has_min_height].height_bg = [- int(x) for x in buildings[has_min_height]["min_height"]]
 


### PR DESCRIPTION
This PR solves #3229, whereby the zone helper didn't work due to inconsistent `min_height` data types. By converting `building:min_level` and `min_height` to float before defining `has_min_floor` and `has_min height`, the zone helper works again.