### PR TITLE
Fix aggregation for solar potential scripts

### DIFF
--- a/cea/technologies/solar/photovoltaic_thermal.py
+++ b/cea/technologies/solar/photovoltaic_thermal.py
@@ -714,7 +714,7 @@ def main(config):
     # aggregate results from all buildings
     aggregated_annual_results = {}
     for i, building in enumerate(building_names):
-        hourly_results_per_building = pd.read_csv(locator.PVT_results(building))
+        hourly_results_per_building = pd.read_csv(locator.PVT_results(building)).set_index("Date")
         if i == 0:
             aggregated_hourly_results_df = hourly_results_per_building
             temperature_sup = []
@@ -736,7 +736,6 @@ def main(config):
     aggregated_hourly_results_df['T_PVT_re_C'] = pd.DataFrame(temperature_re).mean(axis=0)
     aggregated_hourly_results_df = aggregated_hourly_results_df[aggregated_hourly_results_df.columns.drop(
         aggregated_hourly_results_df.filter(like='Tout', axis=1).columns)]  # drop columns with Tout
-    aggregated_hourly_results_df = aggregated_hourly_results_df.set_index('Date')
     aggregated_hourly_results_df.to_csv(locator.PVT_totals(), index=True, float_format='%.2f', na_rep='nan')
     # save annual results
     aggregated_annual_results_df = pd.DataFrame(aggregated_annual_results).T

--- a/cea/technologies/solar/solar_collector.py
+++ b/cea/technologies/solar/solar_collector.py
@@ -1009,7 +1009,7 @@ def main(config):
     # aggregate results from all buildings
     aggregated_annual_results = {}
     for i, building in enumerate(building_names):
-        hourly_results_per_building = pd.read_csv(locator.SC_results(building, panel_type))
+        hourly_results_per_building = pd.read_csv(locator.SC_results(building, panel_type)).set_index('Date')
         if i == 0:
             aggregated_hourly_results_df = hourly_results_per_building
             temperature_sup = hourly_results_per_building['T_SC_sup_C'].mean()
@@ -1022,7 +1022,6 @@ def main(config):
         aggregated_annual_results[building] = building_annual_results
 
     # save hourly results
-    aggregated_hourly_results_df = aggregated_hourly_results_df.set_index('Date')
     aggregated_hourly_results_df = aggregated_hourly_results_df[aggregated_hourly_results_df.columns.drop(
         aggregated_hourly_results_df.filter(like='Tout', axis=1).columns)]  # drop columns with Tout
     # recalculate average temperature supply and return of all panels


### PR DESCRIPTION
During aggregation of the solar potential data, the csv is being read by pandas without parsing the `Date` column as `datetime` type (default behavior), but reading it as it is causing the `Date` column values to be parsed as string.

When "summing" 2 dataframes together, pandas will "sum"/concatenate the `Date` column as strings, resulting in a long string of dates.
https://github.com/architecture-building-systems/CityEnergyAnalyst/blob/1dc92c5fea5a03085032fc2483b17d686fbf4b22/cea/technologies/solar/photovoltaic_thermal.py#L725
https://github.com/architecture-building-systems/CityEnergyAnalyst/blob/1dc92c5fea5a03085032fc2483b17d686fbf4b22/cea/technologies/solar/solar_collector.py#L1017

```
# example of concatenated Date column value
2009-01-01 01:00:00+01:002009-01-01 01:00:00+01:002009-01-01 01:00:00+01:00
```

Setting date as index when reading csv will prevent this as pandas will not "sum" indexes.