### PR TITLE
Read and write sensor data using feather instead of json

### DIFF
--- a/cea/inputlocator.py
+++ b/cea/inputlocator.py
@@ -887,12 +887,12 @@ class InputLocator(object):
         return self._ensure_folder(self.scenario, 'outputs', 'data', 'solar-radiation')
 
     def get_radiation_building(self, building):
-        """scenario/outputs/data/solar-radiation/${building}_insolation.json"""
+        """scenario/outputs/data/solar-radiation/${building}_radiation.csv"""
         return os.path.join(self.get_solar_radiation_folder(), '%s_radiation.csv' % building)
 
     def get_radiation_building_sensors(self, building):
-        """scenario/outputs/data/solar-radiation/${building}_insolation_Whm2.json"""
-        return os.path.join(self.get_solar_radiation_folder(), '%s_insolation_Whm2.json' % building)
+        """scenario/outputs/data/solar-radiation/${building}_insolation_Whm2.feather"""
+        return os.path.join(self.get_solar_radiation_folder(), '%s_insolation_Whm2.feather' % building)
 
     def get_radiation_metadata(self, building):
         """scenario/outputs/data/solar-radiation/{building}_geometrgy.csv"""

--- a/cea/resources/radiation/daysim.py
+++ b/cea/resources/radiation/daysim.py
@@ -18,6 +18,8 @@ __maintainer__ = "Daren Thomas"
 __email__ = "cea@arch.ethz.ch"
 __status__ = "Production"
 
+from pyarrow import feather
+
 from cea.constants import HOURS_IN_YEAR
 from cea.resources.radiation.geometry_generator import BuildingGeometry
 
@@ -325,8 +327,7 @@ def isolation_daysim(chunk_n, cea_daysim, building_names, locator, radiance_para
 
 
 def write_sensor_results(sensor_data_path, sensor_values):
-    with open(sensor_data_path, 'w') as outfile:
-        json.dump(sensor_values.T.to_dict(orient="list"), outfile)
+    feather.write_feather(sensor_values, sensor_data_path, compression="zstd")
 
 
 def write_aggregated_results(building_name, sensor_values, locator, date):

--- a/cea/technologies/solar/photovoltaic_thermal.py
+++ b/cea/technologies/solar/photovoltaic_thermal.py
@@ -68,7 +68,7 @@ def calc_PVT(locator, config, latitude, longitude, weather_data, date_local, bui
     """
     t0 = time.perf_counter()
 
-    radiation_json_path = locator.get_radiation_building_sensors(building_name)
+    radiation_path = locator.get_radiation_building_sensors(building_name)
     metadata_csv_path = locator.get_radiation_metadata(building_name)
 
     # solar properties
@@ -82,7 +82,7 @@ def calc_PVT(locator, config, latitude, longitude, weather_data, date_local, bui
 
     # select sensor point with sufficient solar radiation
     max_annual_radiation, annual_radiation_threshold, sensors_rad_clean, sensors_metadata_clean = \
-        solar_equations.filter_low_potential(radiation_json_path, metadata_csv_path, config)
+        solar_equations.filter_low_potential(radiation_path, metadata_csv_path, config)
 
     print('filtering low potential sensor points done for building %s' % building_name)
 

--- a/cea/technologies/solar/solar_collector.py
+++ b/cea/technologies/solar/solar_collector.py
@@ -62,7 +62,7 @@ def calc_SC(locator, config, latitude, longitude, weather_data, date_local, buil
 
     type_panel = config.solar.type_SCpanel
 
-    radiation_csv = locator.get_radiation_building_sensors(building=building_name)
+    radiation_path = locator.get_radiation_building_sensors(building=building_name)
     metadata_csv = locator.get_radiation_metadata(building=building_name)
 
     # solar properties
@@ -75,7 +75,7 @@ def calc_SC(locator, config, latitude, longitude, weather_data, date_local, buil
 
     # select sensor point with sufficient solar radiation
     max_annual_radiation, annual_radiation_threshold, sensors_rad_clean, sensors_metadata_clean = \
-        solar_equations.filter_low_potential(radiation_csv, metadata_csv, config)
+        solar_equations.filter_low_potential(radiation_path, metadata_csv, config)
 
     print('filtering low potential sensor points done for building %s' % building_name)
 

--- a/cea/utilities/solar_equations.py
+++ b/cea/utilities/solar_equations.py
@@ -11,6 +11,8 @@ import ephem
 import datetime
 import collections
 from math import *
+
+from pyarrow import feather
 from timezonefinder import TimezoneFinder
 import pytz
 from cea.constants import HOURS_IN_YEAR
@@ -205,7 +207,7 @@ def get_equation_of_time(day_date):
 
 # filter sensor points with low solar potential
 
-def filter_low_potential(radiation_json_path, metadata_csv_path, config):
+def filter_low_potential(radiation_sensor_path, metadata_csv_path, config):
     """
     To filter the sensor points/hours with low radiation potential.
 
@@ -213,10 +215,10 @@ def filter_low_potential(radiation_json_path, metadata_csv_path, config):
     #. eliminate points when hourly production < 50 W/m2
     #. augment the solar radiation due to differences between panel reflectance and original reflectances used in daysim
 
-    :param radiation_csv: solar insulation data on all surfaces of each building
-    :type radiation_csv: .csv
+    :param radiation_sensor_path: solar insulation data on all surfaces of each building
+    :type radiation_csv: str
     :param metadata_csv: solar insulation sensor data of each building
-    :type metadata_csv: .csv
+    :type metadata_csv: str
     :return max_annual_radiation: yearly horizontal radiation [Wh/m2/year]
     :rtype max_annual_radiation: float
     :return annual_radiation_threshold: minimum yearly radiation threshold for sensor selection [Wh/m2/year]
@@ -241,7 +243,7 @@ def filter_low_potential(radiation_json_path, metadata_csv_path, config):
             return x
 
     # read radiation file
-    sensors_rad = pd.read_json(radiation_json_path)
+    sensors_rad = feather.read_feather(radiation_sensor_path)
     sensors_metadata = pd.read_csv(metadata_csv_path)
 
     # join total radiation to sensor_metadata

--- a/environment.yml
+++ b/environment.yml
@@ -43,6 +43,7 @@ dependencies:
 - pyyaml
 - timezonefinder
 - python-cufflinks
+- pyarrow
 - pip:
   - xlrd
   - xlwt


### PR DESCRIPTION
Closes #3304

You would have to install `pyarrow` using `pip install pyarrow` in the CEA console for this to work.

As mentioned in the issue, using feather instead of JSON actually saves both time and disk space. This would greatly help scenarios with large amount of buildings.

> It's actually faster to read/write feather compared to json. The time taken for feather is quite consistent and is sub 0s even for large buildings.
> 
> For a single building with 2917 sensors
> 
> ```
> write json       20.513s
> read json         4.054s
> 
> write feather     0.582s
> read feather      0.182s
> 
> size json        305.4MB
> size feather      40.3MB
> ```
> 
> For a single building with 217 sensors
> 
> ```
> write json       1.4673s
> read json         0.265s
> 
> write feather     0.507s
> read feather      0.126s
> 
> size json         22.7MB
> size feather       6.6MB
> ```
