### PR TITLE
Fixed deap-creator error

### DIFF
--- a/cea/optimization/master/evaluation.py
+++ b/cea/optimization/master/evaluation.py
@@ -8,6 +8,7 @@ from cea.optimization.master import objective_function_calculator
 from cea.optimization.master import master_to_slave as master
 from cea.optimization.master.generation import individual_to_barcode
 from cea.optimization.master.performance_aggregation import summarize_results_individual
+from cea.optimization.master.optimisation_individual import FitnessMin
 from cea.optimization.slave import cooling_main
 from cea.optimization.slave import electricity_main
 from cea.optimization.slave import heating_main
@@ -88,6 +89,9 @@ def evaluation_main(individual,
     :return: Resulting values of the objective function. costs, CO2, prim
     :rtype: tuple
     """
+    # IN CASE OF MULTIPROCESSING RE-INITIALISE THE NUMBER OPTIMISATION-OBJECTIVES AS PART OF THE FITNESS-OBJECT
+    if config.multiprocessing:
+        FitnessMin.set_objective_function_selection(config)
 
     # CREATE THE INDIVIDUAL BARCODE AND INDIVIDUAL WITH HER COLUMN NAME AS A DICT
     DHN_barcode, DCN_barcode,\

--- a/cea/optimization/master/optimisation_individual.py
+++ b/cea/optimization/master/optimisation_individual.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""
+The class in this script offers a container structure for energy system configurations that are tested in the
+genetic optimisation algorithm using the deap-library.
+"""
+
+__author__ = "Mathias Niffeler"
+__copyright__ = "Copyright 2023, Architecture and Buildings Systems - ETH Zurich"
+__credits__ = ["Mathias Niffeler"]
+__license__ = "MIT"
+__version__ = "0.1"
+__maintainer__ = "NA"
+__email__ = "mathias.niffeler@sec.ethz.ch"
+__status__ = "Production"
+
+
+from deap.base import Fitness
+
+from cea.optimization.constants import DH_ACRONYM, DC_ACRONYM
+
+
+class Individual(list):
+
+    def __init__(self, system_encoding):
+
+        super().__init__(system_encoding)
+        self.typecode = 'd'
+        self.fitness = FitnessMin()
+
+
+class FitnessMin(Fitness):
+
+    objective_function_selection = []
+    nbr_of_objectives = 0
+
+    def __init__(self):
+
+        self.weights = (-1.0, ) * FitnessMin.nbr_of_objectives
+        super().__init__()
+
+
+    @staticmethod
+    def set_objective_function_selection(cea_config):
+        objective_function_selection = []
+        if cea_config.optimization.network_type == DC_ACRONYM:
+            objective_function_selection = cea_config.optimization.objective_functions_DC
+        elif cea_config.optimization.network_type == DH_ACRONYM:
+            objective_function_selection = ['cost', 'GHG_emissions']
+
+        FitnessMin.objective_function_selection = objective_function_selection
+        FitnessMin.nbr_of_objectives = len(objective_function_selection)
+
+        return objective_function_selection

--- a/cea/optimization/optimization_main.py
+++ b/cea/optimization/optimization_main.py
@@ -16,7 +16,6 @@ from cea.optimization.preprocessing.preprocessing_main import preproccessing
 from cea.optimization.constants import DH_ACRONYM, DC_ACRONYM
 
 warnings.filterwarnings("ignore")
-master_main.create_individual_class(cea.config.Configuration())
 
 __author__ = "Jimeno A. Fonseca"
 __copyright__ = "Copyright 2016, Architecture and Building Systems - ETH Zurich"


### PR DESCRIPTION
When running in multiprocessing the the 'Individual'-class created using the deap-creator module could not be accessed since it was not set as a global value. This fix omits creating unnecessary global values by introducing an new 'explicit' Individual-class.