### PR TITLE
Fix optimization KeyError

### DIFF
--- a/cea/optimization_new/containerclasses/energyCarrier.py
+++ b/cea/optimization_new/containerclasses/energyCarrier.py
@@ -302,10 +302,10 @@ class EnergyCarrier(object):
             index_closest_mean_temp = (thermal_ec_mean_quals - temperature).abs().nsmallest(n=1).index[0]
             energy_carrier_code = thermal_ecs_of_subtype['code'].loc[index_closest_mean_temp]
         else:
-            energy_carrier_code = thermal_ecs_of_subtype['code'][0]
+            energy_carrier_code = thermal_ecs_of_subtype['code'].iloc[0]
             print(f'The temperature level of a renewable energy potential was not available. '
                   f'We assume that the following energy carrier is output: '
-                  f'{thermal_ecs_of_subtype["description"][0]}')
+                  f'{thermal_ecs_of_subtype["description"].iloc[0]}')
         return energy_carrier_code
 
     @staticmethod


### PR DESCRIPTION
I am getting this error when running optimization. My guess that the intention is to select the first row instead of index 0

```python
Traceback (most recent call last):
  File "processor.py", line 116, in <module>
    function(sys.argv[1])
  File "processor.py", line 109, in function
    cea_workflow(config)
  File "processor.py", line 61, in cea_workflow
    workflow(cea_config)
  File "/mnt/storage/dev/datastore-1/proc-repositories/e8874b67ddb8eba3d501d3662da854d64bad9f77271d05177b42de18717cd4e0/dcn-cea/processor_sim/CityEnergyAnalyst/cea/workflows/workflow.py", line 83, in main
    do_script_step(config, i, step, trace_input)
  File "/mnt/storage/dev/datastore-1/proc-repositories/e8874b67ddb8eba3d501d3662da854d64bad9f77271d05177b42de18717cd4e0/dcn-cea/processor_sim/CityEnergyAnalyst/cea/workflows/workflow.py", line 178, in do_script_step
    run(config, py_script, **py_parameters)
  File "/mnt/storage/dev/datastore-1/proc-repositories/e8874b67ddb8eba3d501d3662da854d64bad9f77271d05177b42de18717cd4e0/dcn-cea/processor_sim/CityEnergyAnalyst/cea/workflows/workflow.py", line 29, in run
    f(config=config, **kwargs)
  File "/mnt/storage/dev/datastore-1/proc-repositories/e8874b67ddb8eba3d501d3662da854d64bad9f77271d05177b42de18717cd4e0/dcn-cea/processor_sim/CityEnergyAnalyst/cea/api.py", line 60, in __call__
    self._runner.__call__(*args, **kwargs)
  File "/mnt/storage/dev/datastore-1/proc-repositories/e8874b67ddb8eba3d501d3662da854d64bad9f77271d05177b42de18717cd4e0/dcn-cea/processor_sim/CityEnergyAnalyst/cea/api.py", line 38, in script_runner
    script_module.main(config)
  File "/mnt/storage/dev/datastore-1/proc-repositories/e8874b67ddb8eba3d501d3662da854d64bad9f77271d05177b42de18717cd4e0/dcn-cea/processor_sim/CityEnergyAnalyst/cea/optimization_new/domain.py", line 447, in main
    current_domain.load_potentials()
  File "/mnt/storage/dev/datastore-1/proc-repositories/e8874b67ddb8eba3d501d3662da854d64bad9f77271d05177b42de18717cd4e0/dcn-cea/processor_sim/CityEnergyAnalyst/cea/optimization_new/domain.py", line 108, in load_potentials
    pvt_potential = EnergyPotential().load_PVT_potential(self.locator, buildings_in_domain)
  File "/mnt/storage/dev/datastore-1/proc-repositories/e8874b67ddb8eba3d501d3662da854d64bad9f77271d05177b42de18717cd4e0/dcn-cea/processor_sim/CityEnergyAnalyst/cea/optimization_new/containerclasses/energyPotential.py", line 84, in load_PVT_potential
    auxiliary_energy_carrier = EnergyCarrier.temp_to_thermal_ec('water', potentials['average_temp'])
  File "/mnt/storage/dev/datastore-1/proc-repositories/e8874b67ddb8eba3d501d3662da854d64bad9f77271d05177b42de18717cd4e0/dcn-cea/processor_sim/CityEnergyAnalyst/cea/optimization_new/containerclasses/energyCarrier.py", line 305, in temp_to_thermal_ec
    energy_carrier_code = thermal_ecs_of_subtype['code'][0]
  File "/mnt/storage/dev/datastore-1/proc-repositories/e8874b67ddb8eba3d501d3662da854d64bad9f77271d05177b42de18717cd4e0/dcn-cea/processor_sim/micromamba/envs/duct-cea/lib/python3.8/site-packages/pandas/core/series.py", line 981, in __getitem__
    return self._get_value(key)
  File "/mnt/storage/dev/datastore-1/proc-repositories/e8874b67ddb8eba3d501d3662da854d64bad9f77271d05177b42de18717cd4e0/dcn-cea/processor_sim/micromamba/envs/duct-cea/lib/python3.8/site-packages/pandas/core/series.py", line 1089, in _get_value
    loc = self.index.get_loc(label)
  File "/mnt/storage/dev/datastore-1/proc-repositories/e8874b67ddb8eba3d501d3662da854d64bad9f77271d05177b42de18717cd4e0/dcn-cea/processor_sim/micromamba/envs/duct-cea/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3804, in get_loc
    raise KeyError(key) from err
KeyError: 0

```