### PR TITLE
Fix typo that caused `roof_grid` parameter to be ignored

### DIFF
--- a/cea/resources/radiation/daysim.py
+++ b/cea/resources/radiation/daysim.py
@@ -192,7 +192,7 @@ def calc_sensors_building(building_geometry: BuildingGeometry, grid_size: GridSi
             sensor_area, \
             sensor_orientation, \
             sensor_intersection = generate_sensor_surfaces(face,
-                                                           grid_size.roof if srf_type == "roof" else grid_size.walls,
+                                                           grid_size.roof if srf_type == "roofs" else grid_size.walls,
                                                            srf_type,
                                                            orientation,
                                                            normal,


### PR DESCRIPTION
As described in #3352, there was a typo in the radiation script that caused the input parameter `config.radiation.roof_grid` not to be used:
```
s a typo in calc_sensors_building that causes the issue:

            sensor_dir, \
            sensor_cord, \
            sensor_type, \
            sensor_area, \
            sensor_orientation, \
            sensor_intersection = generate_sensor_surfaces(face,
                                                           grid_size.roof if srf_type == "roof" else grid_size.walls,
                                                           srf_type,
                                                           orientation,
                                                           normal,
                                                           intersection)
```
(`srf_type` can only be one of the following: `['walls', 'windows', 'roofs']`)

By fixing this typo, the expected behavior is restored.

How to test:
1. Run the radiation script with the default parameters on any case study
2. Run the radiation script with different values for the roof and walls grids
3. Check number of surfaces generated in each case: per the documentation, the number of surfaces should be higher when the grid size is lower
