### PR TITLE
Replace whitespaces with underscore in building name

### DIFF
--- a/cea/resources/radiation/radiance.py
+++ b/cea/resources/radiation/radiance.py
@@ -365,7 +365,8 @@ class RadSurface(object):
     __slots__ = ['name', 'points', 'material']
 
     def __init__(self, name, occ_face, material):
-        self.name = name
+        # Make sure there are no spaces in the name, which could affect Daysim parsing the radiance geometry file
+        self.name = name.replace(" ", "_")
         self.points = points_frm_occface(occ_face)
         self.material = material
 


### PR DESCRIPTION
Closes #3355

Daysim would have problems parsing the radiance geometry file if there spaces with the polygon identifier, which in this case is the building name.

To test, use a scenario where buildings have spaces in their name.
With this PR, radiation would successfully complete. On master, radiation would fail.