### PR TITLE
Update demand_writers to remove nan values.py

### DIFF
--- a/cea/demand/demand_writers.py
+++ b/cea/demand/demand_writers.py
@@ -60,8 +60,8 @@ class DemandWriter(object):
     def calc_yearly_dataframe(self, bpr, building_name, tsd):
         # if printing total values is necessary
         # treating timeseries data from W to MWh
-        data = dict((x + '_MWhyr', tsd[x].sum() / 1000000) for x in self.load_vars)
-        data.update(dict((x + '0_kW', tsd[x].max() / 1000) for x in self.load_vars))
+        data = dict((x + '_MWhyr', np.nan_to_num(tsd[x]).sum() / 1000000) for x in self.load_vars)
+        data.update(dict((x + '0_kW', np.nan_to_num(tsd[x]) .max() / 1000) for x in self.load_vars))
         # get order of columns
         keys = data.keys()
         columns = self.OTHER_VARS


### PR DESCRIPTION
In line with Issue#3341, this PR remove `nan` values on the` total_energy_demand.csv`, hence, the `nan` values on the `Total_LCA_operation.csv` are no longer the resolved.

How to test it?
1. Run `demand simulation`
2. Check ` total_energy_demand.csv` to see if there are `nan` values
3. Run `operational emissions`
4.  Check ` total_energy_demand.csv` to see if there are `nan` values

