### PR TITLE
fixing inappropriate coordinate system

### DIFF
--- a/cea/default.config
+++ b/cea/default.config
@@ -13,7 +13,7 @@ scenario.help = Select the scenario you're working on.
 
 multiprocessing = true
 multiprocessing.type = BooleanParameter
-multiprocessing.help = Multiprocessing (if available) for quicker calculation.
+multiprocessing.help = True for quicker calculation.
 
 number-of-cpus-to-keep-free = 1
 number-of-cpus-to-keep-free.type = IntegerParameter
@@ -131,11 +131,11 @@ weather.help = Either a full path to a weather file or the name of one of the we
 [radiation]
 buildings =
 buildings.type = BuildingsParameter
-buildings.help = List of buildings considered for the radiation simulation (to simulate all buildings leave blank).
+buildings.help = List of buildings considered for the radiation simulation. Leave blank when simulating all buildings.
 
 use-latest-daysim-binaries = true
 use-latest-daysim-binaries.type = BooleanParameter
-use-latest-daysim-binaries.help = Set true to use latest Daysim binaries which is faster and able to run larger sites, but it produces non-deterministic results. Set false to use the old binary for reproducibility. (only applicable to Windows, will be ignored otherwise)
+use-latest-daysim-binaries.help = True to use the latest Daysim binaries which is faster and able to run larger sites, yet producing non-deterministic results. False to use old binary for reproducibility. Applicable only to Windows and will be ignored otherwise.
 
 albedo = 0.2
 albedo.type = RealParameter
@@ -254,11 +254,11 @@ write-sensor-data.category = Advanced
 [radiation-simplified]
 sample-buildings =
 sample-buildings.type = BuildingsParameter
-sample-buildings.help = List of buildings to sample for the radiation simulation.
+sample-buildings.help = List of buildings to sample for the radiation simulation. Note that this list of sampled buildings must be a subset of the list of buildings selected above.
 
 buffer = 50
 buffer.type = RealParameter
-buffer.help = Perimeter buffer length around sample buildings (in meters).
+buffer.help = Perimeter buffer (m) around sample buildings .
 
 [schedule-maker]
 buildings =

--- a/cea/utilities/standardize_coordinates.py
+++ b/cea/utilities/standardize_coordinates.py
@@ -54,9 +54,9 @@ def get_geographic_coordinate_system():
 def get_projected_coordinate_system(lat, lon):
     easting, northing, zone_number, zone_letter = utm.from_latlon(lat, lon)
     if zone_letter in "NPQRSTUVWXX":
-        return "+proj=utm +zone=" + str(zone_number) + " +ellps=WGS84 +datum=WGS84 +units=m +no_defs +south"
-    elif zone_letter in "CDEFGHJKLM":
         return "+proj=utm +zone=" + str(zone_number) + " +ellps=WGS84 +datum=WGS84 +units=m +no_defs"
+    elif zone_letter in "CDEFGHJKLM":
+        return "+proj=utm +zone=" + str(zone_number) + " +ellps=WGS84 +datum=WGS84 +units=m +no_defs +south"
     else:
         Exception('The projected coordinate system is unknown, lon{}, lat{}').format(lat, lon)
 


### PR DESCRIPTION
This PR fixes the bug of inappropriate coordinate system.

Before this PR, for example, Zurich is set in the southern hemisphere using EPSG:32732, however, it is supposed to be set in the northern hemisphere using EPSG:32632. This is causing issues in the coordinates for the sensor points output from the radiation script.

To test it, choose a random case in Zurich and run CEA radiation analysis. Then check the generated geometry.csv file, and see if the coordinates are in the range of (450000, 5000000).

Can I request @yiqiaowang-arch to review this PR? Thanks.

