### PR TITLE
Eliminating zero-capacity components

### DIFF
--- a/cea/optimization_new/supplySystem.py
+++ b/cea/optimization_new/supplySystem.py
@@ -160,8 +160,9 @@ class SupplySystem(object):
             capacity_kw = capacity_indicator.value * max_capacity_component.capacity
 
             try:
-                self.installed_components[placement][component_model] = \
-                    component_class(component_model, placement, capacity_kw)
+                if capacity_kw > 0:
+                    self.installed_components[placement][component_model] = \
+                        component_class(component_model, placement, capacity_kw)
             except ValueError:
                 capacity_indicator.value = 0
 


### PR DESCRIPTION
Eliminating components with a capacity of zero from the final supply system structure.

To test, simply run the optimisation script on a district cooling system and look at the resulting optimal supply system structures. All zero-capacity components that were previously printed to the file should now be gone.