### PR TITLE
add create-new-scenario to scripts.yml

### DIFF
--- a/cea/scripts.yml
+++ b/cea/scripts.yml
@@ -346,6 +346,13 @@ Utilities:
     module: cea.datamanagement.data_initializer
     parameters: ['general:scenario', data-initializer]
 
+  - name: create-new-scenario
+    label: Create new scenario
+    description: Creates a new scenario
+    interfaces: [cli, dashboard]
+    module: cea.datamanagement.create_new_scenario
+    parameters: [create-new-scenario]
+
   - name: rename-building
     label: Rename building
     description: Renames a building in the input files

--- a/cea/scripts.yml
+++ b/cea/scripts.yml
@@ -349,7 +349,7 @@ Utilities:
   - name: create-new-scenario
     label: Create new scenario
     description: Creates a new scenario
-    interfaces: [cli, dashboard]
+    interfaces: []
     module: cea.datamanagement.create_new_scenario
     parameters: [create-new-scenario]
 


### PR DESCRIPTION
Release v.3.35.0 broke the scenario creation for the dashboard, becuase the create-new-scenario script was removed from scripts. This causes the dashboard to fail when creating a new scenario from scratch with the option "Import input files".

To reproduce, use latest master branch and try to set up a new scenario with the option "Import input files".

Error Message:
```
Exception: create_new_scenario: module 'cea.api' has no attribute 'create_new_scenario'
```
