### PR TITLE
Fix Windows setup bugs

### DIFF
--- a/.github/workflows/setup_build.yml
+++ b/.github/workflows/setup_build.yml
@@ -26,8 +26,16 @@ jobs:
           python -m pip install build
           python -m build
           mv dist/cityenergyanalyst-$CEA_VERSION.tar.gz setup/cityenergyanalyst.tar.gz
+
+      - name: Cache CEA env
+        id: cache-env
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/setup/dependencies/cea-env.7z
+          key: ${{ runner.os }}-${{ hashFiles('conda-lock.yml') }}-env
       
       - uses: mamba-org/setup-micromamba@v1
+        if: steps.cache-env.outputs.cache-hit != 'true'
         with:
           environment-file: conda-lock.yml
           environment-name: cea
@@ -35,10 +43,12 @@ jobs:
           create-args: --no-pyc
 
       - name: Clean conda environment
+        if: steps.cache-env.outputs.cache-hit != 'true'
         shell: bash -el {0}
         run: micromamba clean -afy
 
       - name: Compress conda environment
+        if: steps.cache-env.outputs.cache-hit != 'true'
         shell: bash -el {0}
         run: 7z a setup/dependencies/cea-env.7z $MAMBA_ROOT_PREFIX
 

--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -147,7 +147,7 @@ Section "Create Start menu shortcuts" Create_Start_Menu_Shortcuts_Section
     CreateShortCut '$SMPROGRAMS\${CEA_TITLE}\CEA Console.lnk' "$WINDIR\System32\cmd.exe" "/K $INSTDIR\dependencies\cea-env.bat" \
         "$INSTDIR\cea-icon.ico" 0 SW_SHOWNORMAL "" "Launch the CEA Console"
 
-    CreateShortcut "$SMPROGRAMS\${CEA_TITLE}\CEA Dashboard.lnk" "$INSTDIR\CityEnergyAnalyst-GUI-win32-x64\CityEnergyAnalyst-GUI.exe" "" \
+    CreateShortcut "$SMPROGRAMS\${CEA_TITLE}\CEA Dashboard.lnk" "$INSTDIR\dashboard\CityEnergyAnalyst-GUI.exe" "" \
         "$INSTDIR\cea-icon.ico" 0 SW_SHOWNORMAL "" "Launch the CEA Dashboard"
 
     CreateShortcut "$SMPROGRAMS\${CEA_TITLE}\cea.config.lnk" "$WINDIR\notepad.exe" "$PROFILE\cea.config" \
@@ -174,7 +174,7 @@ Section /o "Create Desktop shortcuts" Create_Desktop_Shortcuts_Section
     CreateShortCut '$DESKTOP\CEA Console.lnk' "$WINDIR\System32\cmd.exe" "/K $INSTDIR\dependencies\cea-env.bat" \
         "$INSTDIR\cea-icon.ico" 0 SW_SHOWNORMAL "" "Launch the CEA Console"
 
-    CreateShortcut "$DESKTOP\CEA Dashboard.lnk" "$INSTDIR\CityEnergyAnalyst-GUI-win32-x64\CityEnergyAnalyst-GUI.exe" "" \
+    CreateShortcut "$DESKTOP\CEA Dashboard.lnk" "$INSTDIR\dashboard\CityEnergyAnalyst-GUI.exe" "" \
         "$INSTDIR\cea-icon.ico" 0 SW_SHOWMAXIMIZED "" "Launch the CEA Dashboard"
 
     CreateShortcut "$DESKTOP\cea.config.lnk" "$WINDIR\notepad.exe" "$PROFILE\cea.config" \

--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -1,25 +1,22 @@
 # NSIS script for creating the City Energy Analyst installer
-; include logic library
-!include 'LogicLib.nsh'
-
-; include the modern UI stuff
-!include "MUI2.nsh"
+!define CEA_TITLE "City Energy Analyst"
+!define VER $%CEA_VERSION%
+!define CEA_REPO_URL "https://github.com/architecture-building-systems/CityEnergyAnalyst.git"
 
 # Request the highest possible execution level for the current user
 !define MULTIUSER_EXECUTIONLEVEL Highest
 !define MULTIUSER_INSTALLMODE_COMMANDLINE
 !define MULTIUSER_INSTALLMODE_DEFAULT_CURRENTUSER
+!define MULTIUSER_INSTALLMODE_INSTDIR "CityEnergyAnalyst"
 !define MULTIUSER_MUI
 
 !include MultiUser.nsh
 
-; include some string functions
-#!include "StrFunc.nsh"
-#${StrRep}
+; include logic library
+!include 'LogicLib.nsh'
 
-!define CEA_TITLE "City Energy Analyst"
-!define VER $%CEA_VERSION%
-!define CEA_REPO_URL "https://github.com/architecture-building-systems/CityEnergyAnalyst.git"
+; include the modern UI stuff
+!include "MUI2.nsh"
 
 Name "${CEA_TITLE} ${VER}"
 OutFile "Output\Setup_CityEnergyAnalyst_${VER}.exe"
@@ -27,18 +24,14 @@ SetCompressor /FINAL lzma
 CRCCheck On
 
 ;--------------------------------
-;Sets the default installation directory
-InstallDir "$DOCUMENTS\CityEnergyAnalyst"
-
 ;Request application privileges for Windows Vista
 #RequestExecutionLevel user
 
 Function .onInit
     !insertmacro MULTIUSER_INIT
-    # set default installation directory to ProgramFiles if user has privileges
-    ${If} "$MultiUser.Privileges" == "Admin"
-    ${AndIf} "$MultiUser.Privileges" == "Power"
-        StrCpy $INSTDIR "$PROGRAMFILES\CityEnergyAnalyst"
+    # set default installation directory to Documents if in CurrentUser mode
+    ${If} "$MultiUser.InstallMode" == "CurrentUser"
+        StrCpy $INSTDIR "$DOCUMENTS\CityEnergyAnalyst"
     ${EndIf}
 FunctionEnd
 

--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -209,6 +209,7 @@ Section "Uninstall"
     Delete /REBOOTOK "$INSTDIR\CEA Dashboard.lnk"
     Delete /REBOOTOK "$INSTDIR\cea.config.lnk"
     Delete /REBOOTOK "$INSTDIR\cea-icon.ico"
+    Delete /REBOOTOK "$INSTDIR\dashboard.bat"
     RMDir /R /REBOOTOK "$INSTDIR\dashboard"
     RMDir /R /REBOOTOK "$INSTDIR\dependencies"
 


### PR DESCRIPTION
Fixes:
- Start menu shortcuts pointing to old directory
- Remove "dashboard.bat" after installation
- Default installation path for "all users" mode to "Program Files"
- Cache CEA python env