### PR TITLE
Fixing interaction between energy potentials and supply system operation

### DIFF
--- a/cea/optimization_new/component.py
+++ b/cea/optimization_new/component.py
@@ -523,8 +523,8 @@ class CogenPlant(ActiveComponent):
 
         # initialize energy flows
         fuel_in = EnergyFlow('source', self.placement, self.input_energy_carriers[0].code)
-        electricity_out = EnergyFlow(self.placement, 'primary', self.input_energy_carriers[0].code)
-        waste_heat_out = EnergyFlow(self.placement, 'environment', self.output_energy_carriers[0].code)
+        electricity_out = EnergyFlow(self.placement, 'primary', self.output_energy_carriers[0].code)
+        waste_heat_out = EnergyFlow(self.placement, 'environment', self.output_energy_carriers[1].code)
 
         # run operational/efficiency code
         if Component._model_complexity == 'constant':

--- a/cea/optimization_new/supplySystem.py
+++ b/cea/optimization_new/supplySystem.py
@@ -99,10 +99,14 @@ class SupplySystem(object):
         self.installed_components = self._build_supply_system()
         # operate primary components
         primary_demand_dict = {self.structure.main_final_energy_carrier.code: self.demand_energy_flow}
-        self._perform_water_filling_principle('primary', primary_demand_dict)
+        remaining_primary_demand_dict = self._draw_from_potentials(primary_demand_dict, reset=True)
+        remaining_primary_demand_dict = self._draw_from_infinite_sources(remaining_primary_demand_dict)
+        self._perform_water_filling_principle('primary', remaining_primary_demand_dict)
         # operate secondary components
         secondary_demand_dict = self._group_component_flows_by_ec('primary', 'in')
-        self._perform_water_filling_principle('secondary', secondary_demand_dict)
+        remaining_secondary_demand_dict = self._draw_from_potentials(secondary_demand_dict)
+        remaining_secondary_demand_dict = self._draw_from_infinite_sources(remaining_secondary_demand_dict)
+        self._perform_water_filling_principle('secondary', remaining_secondary_demand_dict)
         # operate tertiary components
         component_energy_release_dict = self._group_component_flows_by_ec(['primary', 'secondary'], 'out')
         tertiary_demand_dict = self._release_to_grids_or_env(component_energy_release_dict)
@@ -232,11 +236,9 @@ class SupplySystem(object):
         :param demand_dict: dictionary of demand energy flows that need to be met, keys are energy carrier codes
         :type demand_dict: dict of <cea.optimization_new.energyFlow>-EnergyFlow class objects
         """
-        remaining_demand_dict = self._draw_from_potentials(demand_dict, reset=True)
-        remaining_demand_dict = self._draw_from_infinite_sources(remaining_demand_dict)
 
-        for ec_code in remaining_demand_dict.keys():
-            demand = remaining_demand_dict[ec_code]
+        for ec_code in demand_dict.keys():
+            demand = demand_dict[ec_code]
 
             for component_model in self.structure.activation_order[placement]:
                 if not ((component_model in self.structure.component_selection_by_ec[placement][ec_code]) and


### PR DESCRIPTION
When performing the 'cascading' activation of the components installed in the supply system, the previous code would erroneously look at the availability of the demand from renewable energy potentials and grids independently of the component category.

This has now been fixed. With the new code:

- Main cooling/heating components (i.e. primary components) would check if their demand could be met by potentials or the grid prior to activation. 
- Supply components (i.e. secondary components) would check if their demand can be satisfied by the remaining renewable energy potentials and/or the grid.
- Lastly, heat rejection components (i.e. tertiary components) would check if the heat they need to reject can be directly expulsed to the environment prior to their activation.

Additionally, a mistake was fixed for cogeneration plants, where the wrong energy carriers were attributed to their outputs.