### PR TITLE
Handling zero interest rates

### DIFF
--- a/cea/analysis/costs/equations.py
+++ b/cea/analysis/costs/equations.py
@@ -26,7 +26,7 @@ def calc_opex_annualized(OpC_USDyr, Inv_IR_perc, Inv_LT_yr):
     :param Inv_LT_yr: Lifetime in years
     :return: Annuitized Operating Expenditure in USD per year
     """
-    if Inv_LT_yr == 0:
+    if Inv_IR_perc == 0:
         return OpC_USDyr
 
     Inv_IR = Inv_IR_perc / 100
@@ -47,7 +47,7 @@ def calc_capex_annualized(InvC_USD, Inv_IR_perc, Inv_LT_yr):
     :param Inv_LT_yr: Lifetime in years
     :return: Annuitized Capital Expenditure in USD
     """
-    if Inv_LT_yr == 0:
+    if Inv_IR_perc == 0:
         return InvC_USD / Inv_LT_yr
 
     Inv_IR = Inv_IR_perc / 100

--- a/cea/analysis/costs/equations.py
+++ b/cea/analysis/costs/equations.py
@@ -17,6 +17,18 @@ __status__ = "Production"
 
 # Calculates the EQUIVALENT ANNUAL COSTS (1. Step PRESENT VALUE OF COSTS (PVC), 2. Step EQUIVALENT ANNUAL COSTS)
 def calc_opex_annualized(OpC_USDyr, Inv_IR_perc, Inv_LT_yr):
+    """
+    Calculate Annuitized Operating Expenditure (OPEX) -
+    Calculations based on http://fahmi.ba.free.fr/docs/Courses/2012%20HEC/FBA_FE_Chap1_time_value_derivation.pdf
+
+    :param OpC_USDyr: Operating Expenditure in USD per year
+    :param Inv_IR_perc: Interest Rate in percentage
+    :param Inv_LT_yr: Lifetime in years
+    :return: Annuitized Operating Expenditure in USD per year
+    """
+    if Inv_LT_yr == 0:
+        return OpC_USDyr
+
     Inv_IR = Inv_IR_perc / 100
     opex_list = [0.0]
     opex_list.extend(Inv_LT_yr * [OpC_USDyr])
@@ -26,5 +38,17 @@ def calc_opex_annualized(OpC_USDyr, Inv_IR_perc, Inv_LT_yr):
 
 
 def calc_capex_annualized(InvC_USD, Inv_IR_perc, Inv_LT_yr):
+    """
+    Calculate Annuitized Capital Expenditure (CAPEX) -
+    Calculations based on http://fahmi.ba.free.fr/docs/Courses/2012%20HEC/FBA_FE_Chap1_time_value_derivation.pdf
+
+    :param InvC_USD: Capital Expenditure in USD
+    :param Inv_IR_perc: Interest Rate in percentage
+    :param Inv_LT_yr: Lifetime in years
+    :return: Annuitized Capital Expenditure in USD
+    """
+    if Inv_LT_yr == 0:
+        return InvC_USD / Inv_LT_yr
+
     Inv_IR = Inv_IR_perc / 100
     return -((-InvC_USD * Inv_IR) / (1 - (1 + Inv_IR) ** (-Inv_LT_yr)))


### PR DESCRIPTION
This introduces a simple fix to calculating annualised capex and opex with an interest rate of 0. This is necessary since the basic annuity formula is undefined for an interest rate of zero.

In addition, the documentation of these methods was updated and a source explaining how the annuity factor is derived has been added.