### PR TITLE
Remove `MULTIUSER_PAGE_INSTALLMODE`

### DIFF
--- a/setup/cityenergyanalyst.nsi
+++ b/setup/cityenergyanalyst.nsi
@@ -40,7 +40,7 @@ CRCCheck On
 ;Pages
 
 !insertmacro MUI_PAGE_LICENSE "..\LICENSE"
-!insertmacro MULTIUSER_PAGE_INSTALLMODE
+# !insertmacro MULTIUSER_PAGE_INSTALLMODE
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_COMPONENTS
 !insertmacro MUI_PAGE_INSTFILES


### PR DESCRIPTION
Closes #3558

Installer was still showing the install mode options. Removing the macro directly should remove it.