### PR TITLE
Consider adjacent walls by default

### DIFF
--- a/cea/datamanagement/databases_verification.py
+++ b/cea/datamanagement/databases_verification.py
@@ -47,7 +47,7 @@ def assert_input_geometry_acceptable_values_floor_height(zone_df: pd.DataFrame):
     # Rule 2. Where floor height is less than 1m on average above ground.
     rule2 = (zone_df['height_ag'] < zone_df['floors_ag']).any()
     if rule2:
-        raise Exception('one of more buildings have less report less than 1m height per floor. This is not possible'
+        raise Exception('one of more buildings report less than 1m height per floor. This is not possible'
                         'to simulate in CEA at the moment. Please verify your Zone or Surroundings shapefile file')
 
     # Rule 3. floors below ground cannot be negative

--- a/cea/default.config
+++ b/cea/default.config
@@ -166,10 +166,10 @@ consider-floors.type = BooleanParameter
 consider-floors.help = True if floors are considered in the geometry.
 consider-floors.category = Level of Detail
 
-consider-adjacent-buildings = false
-consider-adjacent-buildings.type = BooleanParameter
-consider-adjacent-buildings.help = True if walls between adjacent buildings should be considered. If set to False, there might be insolation on attached walls and no adiabatic surfaces between adjacent buildings will be considered, but the simulation time might increases by up to 5 times.
-consider-adjacent-buildings.category = Level of Detail
+neglect-adjacent-buildings = false
+neglect-adjacent-buildings.type = BooleanParameter
+neglect-adjacent-buildings.help = True if adjacent walls with neighboring buildings should be neglected. If set to True, the results might be less accurate (there might be insolation on attached walls and no adiabatic surfaces between adjacent buildings will be considered), but the simulation time will decrease somewhat.
+neglect-adjacent-buildings.category = Level of Detail
 
 rad-ab = 4
 rad-ab.type = IntegerParameter

--- a/cea/default.config
+++ b/cea/default.config
@@ -166,10 +166,10 @@ consider-floors.type = BooleanParameter
 consider-floors.help = True if floors are considered in the geometry.
 consider-floors.category = Level of Detail
 
-consider-intersections = false
-consider-intersections.type = BooleanParameter
-consider-intersections.help = True if intersecting walls between buildings are considered (this increases simulation time in x5), but can give more precise estimates.
-consider-intersections.category = Level of Detail
+consider-adjacent-buildings = false
+consider-adjacent-buildings.type = BooleanParameter
+consider-adjacent-buildings.help = True if intersecting walls between buildings should be considered. If set to False, there might be insolation on attached walls and no adiabatic surfaces between adjacent buildings will be considered, but the simulation time might increases by up to 5 times.
+consider-adjacent-buildings.category = Level of Detail
 
 rad-ab = 4
 rad-ab.type = IntegerParameter

--- a/cea/default.config
+++ b/cea/default.config
@@ -168,7 +168,7 @@ consider-floors.category = Level of Detail
 
 consider-adjacent-buildings = false
 consider-adjacent-buildings.type = BooleanParameter
-consider-adjacent-buildings.help = True if intersecting walls between buildings should be considered. If set to False, there might be insolation on attached walls and no adiabatic surfaces between adjacent buildings will be considered, but the simulation time might increases by up to 5 times.
+consider-adjacent-buildings.help = True if walls between adjacent buildings should be considered. If set to False, there might be insolation on attached walls and no adiabatic surfaces between adjacent buildings will be considered, but the simulation time might increases by up to 5 times.
 consider-adjacent-buildings.category = Level of Detail
 
 rad-ab = 4

--- a/cea/demand/building_properties.py
+++ b/cea/demand/building_properties.py
@@ -241,7 +241,6 @@ class BuildingProperties(object):
         Htr_w        1.403374e+03   (thermal transmission coefficient for windows and glazing in [W/K])
         =========    ============   ================================================================================================
 
-        FIXME: rename Awall_all to something more sane...
         """
 
         # calculate building geometry

--- a/cea/demand/rc_model_SIA.py
+++ b/cea/demand/rc_model_SIA.py
@@ -83,8 +83,6 @@ def calc_h_op_m(Htr_op):
     # (9) in SIA 2044 / Korrigenda C1 zum Merkblatt SIA 2044:2011 / Korrigenda C2 zum Mekblatt SIA 2044:2011
     # h_op_m = a_j_m * u_j  # summation
     # This formula in the future should take specific properties of the location of the building into account.
-    # Adiabatic surfaces are currently only considered if `consider_adjacent_buildings` was set to True when the radiation
-    # script was run.
 
     return h_op_m
 
@@ -105,8 +103,6 @@ def calc_h_j_em():
     #h_j_em = (h_em * a_j_m * u_j) / h_op_m
 
     # This formula in the future should take specific properties of the location of the building into account.
-    # Adiabatic surfaces are currently only considered if `consider_adjacent_buildings` was set to True when the radiation
-    # script was run.
 
     return None
 
@@ -116,8 +112,6 @@ def calc_h_ec(Htr_w):
     # (12) in SIA 2044 / Korrigenda C1 zum Merkblatt SIA 2044:2011 / Korrigenda C2 zum Mekblatt SIA 2044:2011
     # h_ec = a_j_l * u_j
     # This formula in the future should take specific properties of the location of the building into account.
-    # Adiabatic surfaces are currently only considered if `consider_adjacent_buildings` was set to True when the radiation
-    # script was run.
     # TODO: can incorporate point or linear thermal bridges
 
     h_ec = Htr_w  # h_ec is Htr_w of ISO13790 RC model
@@ -350,8 +344,6 @@ def calc_theta_ec(T_ext):
     # theta_ec = a_j_l * u_j * theta_e_j / h_ec
 
     # This formula in the future should take specific properties of the location of the building into account.
-    # Adiabatic surfaces are currently only considered if `consider_adjacent_buildings` was set to True when the radiation
-    # script was run.
 
     # TODO: theta_e_j is dependent on adjacent space to surface (outdoor, adiabatic, ground, etc.)
 
@@ -368,8 +360,6 @@ def calc_theta_em(T_ext):
     # theta_em = h_j_em * theta_e_j / h_em
 
     # This formula in the future should take specific properties of the location of the building into account.
-    # Adiabatic surfaces are currently only considered if `consider_adjacent_buildings` was set to True when the radiation
-    # script was run.
 
     # TODO: theta_e_j is dependent on adjacent space to surface (outdoor, adiabatic, ground, etc.)
 

--- a/cea/demand/rc_model_SIA.py
+++ b/cea/demand/rc_model_SIA.py
@@ -83,7 +83,7 @@ def calc_h_op_m(Htr_op):
     # (9) in SIA 2044 / Korrigenda C1 zum Merkblatt SIA 2044:2011 / Korrigenda C2 zum Mekblatt SIA 2044:2011
     # h_op_m = a_j_m * u_j  # summation
     # This formula in the future should take specific properties of the location of the building into account.
-    # Adiabatic surfaces are currently only considered if `consider_intersections` was set to True when the radiation
+    # Adiabatic surfaces are currently only considered if `consider_adjacent_buildings` was set to True when the radiation
     # script was run.
 
     return h_op_m
@@ -105,7 +105,7 @@ def calc_h_j_em():
     #h_j_em = (h_em * a_j_m * u_j) / h_op_m
 
     # This formula in the future should take specific properties of the location of the building into account.
-    # Adiabatic surfaces are currently only considered if `consider_intersections` was set to True when the radiation
+    # Adiabatic surfaces are currently only considered if `consider_adjacent_buildings` was set to True when the radiation
     # script was run.
 
     return None
@@ -116,7 +116,7 @@ def calc_h_ec(Htr_w):
     # (12) in SIA 2044 / Korrigenda C1 zum Merkblatt SIA 2044:2011 / Korrigenda C2 zum Mekblatt SIA 2044:2011
     # h_ec = a_j_l * u_j
     # This formula in the future should take specific properties of the location of the building into account.
-    # Adiabatic surfaces are currently only considered if `consider_intersections` was set to True when the radiation
+    # Adiabatic surfaces are currently only considered if `consider_adjacent_buildings` was set to True when the radiation
     # script was run.
     # TODO: can incorporate point or linear thermal bridges
 
@@ -350,7 +350,7 @@ def calc_theta_ec(T_ext):
     # theta_ec = a_j_l * u_j * theta_e_j / h_ec
 
     # This formula in the future should take specific properties of the location of the building into account.
-    # Adiabatic surfaces are currently only considered if `consider_intersections` was set to True when the radiation
+    # Adiabatic surfaces are currently only considered if `consider_adjacent_buildings` was set to True when the radiation
     # script was run.
 
     # TODO: theta_e_j is dependent on adjacent space to surface (outdoor, adiabatic, ground, etc.)
@@ -368,7 +368,7 @@ def calc_theta_em(T_ext):
     # theta_em = h_j_em * theta_e_j / h_em
 
     # This formula in the future should take specific properties of the location of the building into account.
-    # Adiabatic surfaces are currently only considered if `consider_intersections` was set to True when the radiation
+    # Adiabatic surfaces are currently only considered if `consider_adjacent_buildings` was set to True when the radiation
     # script was run.
 
     # TODO: theta_e_j is dependent on adjacent space to surface (outdoor, adiabatic, ground, etc.)

--- a/cea/demand/rc_model_SIA.py
+++ b/cea/demand/rc_model_SIA.py
@@ -82,8 +82,9 @@ def calc_h_op_m(Htr_op):
 
     # (9) in SIA 2044 / Korrigenda C1 zum Merkblatt SIA 2044:2011 / Korrigenda C2 zum Mekblatt SIA 2044:2011
     # h_op_m = a_j_m * u_j  # summation
-    # TODO: this formula in the future should take specific properties of the location of the building into account
-    # e.g. adiabatic building elements with U = 0
+    # This formula in the future should take specific properties of the location of the building into account.
+    # Adiabatic surfaces are currently only considered if `consider_intersections` was set to True when the radiation
+    # script was run.
 
     return h_op_m
 
@@ -103,8 +104,9 @@ def calc_h_j_em():
     # (11) in SIA 2044 / Korrigenda C1 zum Merkblatt SIA 2044:2011 / Korrigenda C2 zum Mekblatt SIA 2044:2011
     #h_j_em = (h_em * a_j_m * u_j) / h_op_m
 
-    # TODO: this formula in the future should take specific properties of the location of the building into account
-    # e.g. adiabatic building elements with U = 0
+    # This formula in the future should take specific properties of the location of the building into account.
+    # Adiabatic surfaces are currently only considered if `consider_intersections` was set to True when the radiation
+    # script was run.
 
     return None
 
@@ -113,8 +115,9 @@ def calc_h_ec(Htr_w):
 
     # (12) in SIA 2044 / Korrigenda C1 zum Merkblatt SIA 2044:2011 / Korrigenda C2 zum Mekblatt SIA 2044:2011
     # h_ec = a_j_l * u_j
-    # TODO: this formula in the future should take specific properties of the location of the building into account
-    # e.g. adiabatic building elements with U = 0
+    # This formula in the future should take specific properties of the location of the building into account.
+    # Adiabatic surfaces are currently only considered if `consider_intersections` was set to True when the radiation
+    # script was run.
     # TODO: can incorporate point or linear thermal bridges
 
     h_ec = Htr_w  # h_ec is Htr_w of ISO13790 RC model
@@ -346,10 +349,11 @@ def calc_theta_ec(T_ext):
 
     # theta_ec = a_j_l * u_j * theta_e_j / h_ec
 
-    # TODO: this formula in the future should take specific properties of the location of the building into account
-    # e.g. adiabatic building elements with U = 0
+    # This formula in the future should take specific properties of the location of the building into account.
+    # Adiabatic surfaces are currently only considered if `consider_intersections` was set to True when the radiation
+    # script was run.
 
-    # TODO: theta_e_j is depending on adjacent space to surface (outdoor, adiabatic, ground, etc.)
+    # TODO: theta_e_j is dependent on adjacent space to surface (outdoor, adiabatic, ground, etc.)
 
     return theta_ec
 
@@ -363,10 +367,11 @@ def calc_theta_em(T_ext):
 
     # theta_em = h_j_em * theta_e_j / h_em
 
-    # TODO: this formula in the future should take specific properties of the location of the building into account
-    # e.g. adiabatic building elements with U = 0
+    # This formula in the future should take specific properties of the location of the building into account.
+    # Adiabatic surfaces are currently only considered if `consider_intersections` was set to True when the radiation
+    # script was run.
 
-    # TODO: theta_e_j is depending on adjacent space to surface (outdoor, adiabatic, ground, etc.)
+    # TODO: theta_e_j is dependent on adjacent space to surface (outdoor, adiabatic, ground, etc.)
 
     return theta_em
 

--- a/cea/resources/radiation/geometry_generator.py
+++ b/cea/resources/radiation/geometry_generator.py
@@ -169,7 +169,7 @@ def building_2d_to_3d(zone_df, surroundings_df, architecture_wwr_df, elevation_m
     num_processes = config.get_number_of_processes()
     zone_simplification = config.radiation.zone_geometry
     surroundings_simplification = config.radiation.surrounding_geometry
-    consider_intersections = config.radiation.consider_intersections
+    consider_adjacent_buildings = config.radiation.consider_adjacent_buildings
 
     print('Calculating terrain intersection of building geometries')
     zone_buildings_df = zone_df.set_index('Name')
@@ -194,7 +194,7 @@ def building_2d_to_3d(zone_df, surroundings_df, architecture_wwr_df, elevation_m
                                                                           num_processes,
                                                                           on_complete=print_progress)
 
-    if consider_intersections:
+    if consider_adjacent_buildings:
         all_building_solid_list = np.append(zone_building_solid_list, surroundings_building_solid_list)
     else:
         all_building_solid_list = []
@@ -203,7 +203,7 @@ def building_2d_to_3d(zone_df, surroundings_df, architecture_wwr_df, elevation_m
                                                           repeat(all_building_solid_list, n),
                                                           repeat(architecture_wwr_df, n),
                                                           repeat(geometry_pickle_dir, n),
-                                                          repeat(consider_intersections, n))
+                                                          repeat(consider_adjacent_buildings, n))
     return geometry_3D_zone, geometry_3D_surroundings
 
 
@@ -260,7 +260,7 @@ class BuildingGeometry(object):
 
 
 def calc_building_geometry_zone(name, building_solid, all_building_solid_list, architecture_wwr_df,
-                                geometry_pickle_dir, consider_intersections):
+                                geometry_pickle_dir, consider_adjacent_buildings):
     # now get all surfaces and create windows only if the buildings are in the area of study
     window_list = []
     wall_list = []
@@ -272,7 +272,7 @@ def calc_building_geometry_zone(name, building_solid, all_building_solid_list, a
 
     # check if buildings are close together and it merits to check the intersection
     potentially_intersecting_solids = []
-    if consider_intersections:
+    if consider_adjacent_buildings:
         box = calculate.get_bounding_box(building_solid)
         x, y = box[0], box[1]
         for solid in all_building_solid_list:

--- a/cea/resources/radiation/geometry_generator.py
+++ b/cea/resources/radiation/geometry_generator.py
@@ -169,7 +169,7 @@ def building_2d_to_3d(zone_df, surroundings_df, architecture_wwr_df, elevation_m
     num_processes = config.get_number_of_processes()
     zone_simplification = config.radiation.zone_geometry
     surroundings_simplification = config.radiation.surrounding_geometry
-    consider_adjacent_buildings = config.radiation.consider_adjacent_buildings
+    neglect_adjacent_buildings = config.radiation.neglect_adjacent_buildings
 
     print('Calculating terrain intersection of building geometries')
     zone_buildings_df = zone_df.set_index('Name')
@@ -194,7 +194,7 @@ def building_2d_to_3d(zone_df, surroundings_df, architecture_wwr_df, elevation_m
                                                                           num_processes,
                                                                           on_complete=print_progress)
 
-    if consider_adjacent_buildings:
+    if not neglect_adjacent_buildings:
         all_building_solid_list = np.append(zone_building_solid_list, surroundings_building_solid_list)
     else:
         all_building_solid_list = []
@@ -203,7 +203,7 @@ def building_2d_to_3d(zone_df, surroundings_df, architecture_wwr_df, elevation_m
                                                           repeat(all_building_solid_list, n),
                                                           repeat(architecture_wwr_df, n),
                                                           repeat(geometry_pickle_dir, n),
-                                                          repeat(consider_adjacent_buildings, n))
+                                                          repeat(neglect_adjacent_buildings, n))
     return geometry_3D_zone, geometry_3D_surroundings
 
 
@@ -260,7 +260,7 @@ class BuildingGeometry(object):
 
 
 def calc_building_geometry_zone(name, building_solid, all_building_solid_list, architecture_wwr_df,
-                                geometry_pickle_dir, consider_adjacent_buildings):
+                                geometry_pickle_dir, neglect_adjacent_buildings):
     # now get all surfaces and create windows only if the buildings are in the area of study
     window_list = []
     wall_list = []
@@ -272,7 +272,7 @@ def calc_building_geometry_zone(name, building_solid, all_building_solid_list, a
 
     # check if buildings are close together and it merits to check the intersection
     potentially_intersecting_solids = []
-    if consider_adjacent_buildings:
+    if not neglect_adjacent_buildings:
         box = calculate.get_bounding_box(building_solid)
         x, y = box[0], box[1]
         for solid in all_building_solid_list:

--- a/cea/tests/workflow_medium.yml
+++ b/cea/tests/workflow_medium.yml
@@ -24,7 +24,7 @@
       buildings: []
 - script: radiation
   parameters:
-    consider-intersections: false
+    consider-adjacent-buildings: false
 - script: schedule-maker
 - script: demand
 - script: emissions
@@ -87,7 +87,7 @@
     weather: Singapore-Changi_1990_2010_TMY
 - script: radiation
   parameters:
-    consider-intersections: false
+    consider-adjacent-buildings: false
 - script: schedule-maker
 - script: demand
 - script: emissions

--- a/cea/tests/workflow_medium.yml
+++ b/cea/tests/workflow_medium.yml
@@ -24,7 +24,7 @@
       buildings: []
 - script: radiation
   parameters:
-    consider-adjacent-buildings: false
+    neglect-adjacent-buildings: false
 - script: schedule-maker
 - script: demand
 - script: emissions
@@ -87,7 +87,7 @@
     weather: Singapore-Changi_1990_2010_TMY
 - script: radiation
   parameters:
-    consider-adjacent-buildings: false
+    neglect-adjacent-buildings: false
 - script: schedule-maker
 - script: demand
 - script: emissions

--- a/cea/tests/workflow_slow.yml
+++ b/cea/tests/workflow_slow.yml
@@ -20,7 +20,7 @@
     weather: Zug-inducity_1990_2010_TMY
 - script: radiation
   parameters:
-    consider-adjacent-buildings: false
+    neglect-adjacent-buildings: false
 - script: schedule-maker
 - script: demand
 - script: emissions
@@ -81,7 +81,7 @@
     weather: Singapore-Changi_1990_2010_TMY
 - script: radiation
   parameters:
-    consider-adjacent-buildings: false
+    neglect-adjacent-buildings: false
 - script: schedule-maker
 - script: demand
 - script: emissions

--- a/cea/tests/workflow_slow.yml
+++ b/cea/tests/workflow_slow.yml
@@ -20,7 +20,7 @@
     weather: Zug-inducity_1990_2010_TMY
 - script: radiation
   parameters:
-    consider-intersections: false
+    consider-adjacent-buildings: false
 - script: schedule-maker
 - script: demand
 - script: emissions
@@ -81,7 +81,7 @@
     weather: Singapore-Changi_1990_2010_TMY
 - script: radiation
   parameters:
-    consider-intersections: false
+    consider-adjacent-buildings: false
 - script: schedule-maker
 - script: demand
 - script: emissions

--- a/cea/workflows/coverage.yml
+++ b/cea/workflows/coverage.yml
@@ -30,7 +30,7 @@
       buildings: []
 - script: radiation
   parameters:
-    consider-intersections: false
+    consider-adjacent-buildings: false
 - script: schedule-maker
 - script: demand
 - script: emissions
@@ -108,7 +108,7 @@
       buildings: []
 - script: radiation
   parameters:
-    consider-intersections: false
+    consider-adjacent-buildings: false
 - script: schedule-maker
 - script: demand
 - script: emissions

--- a/cea/workflows/coverage.yml
+++ b/cea/workflows/coverage.yml
@@ -30,7 +30,7 @@
       buildings: []
 - script: radiation
   parameters:
-    consider-adjacent-buildings: false
+    neglect-adjacent-buildings: false
 - script: schedule-maker
 - script: demand
 - script: emissions
@@ -108,7 +108,7 @@
       buildings: []
 - script: radiation
   parameters:
-    consider-adjacent-buildings: false
+    neglect-adjacent-buildings: false
 - script: schedule-maker
 - script: demand
 - script: emissions


### PR DESCRIPTION
As discussed in issue #3555, adjacent walls were not considered by CEA by default. This means that there was artificial insolation on attached walls and adiabatic surfaces were neglected (i.e., walls were assumed to be in contact with exterior air). This is not consistent with the SIA and ISO standards on which the calculation is based, but it does have the advantage of somewhat lower simulation times.

Therefore, the parameter has been redefined: rather than users whether they would like to `consider-intersections`, they are now asked whether they would like to `neglect-adjacent-buildings`. The default value is `False`, as that is the more correct simulation method, but users may set this parameter to `True` if they are okay with less accurate simulations in exchange for somewhat faster simulation times.