### PR TITLE
rewrite ensure_cpg_file function to prevent frequent file writing

### DIFF
--- a/cea/utilities/standardize_coordinates.py
+++ b/cea/utilities/standardize_coordinates.py
@@ -32,10 +32,15 @@ def shapefile_to_WSG_and_UTM(shapefile_path):
 
 def ensure_cpg_file(shapefile_path):
     cpg_file_path = shapefile_path.split('.shp', 1)[0] + '.CPG'
-    cpg_file = open(cpg_file_path, "w")
-    cpg_file.write("ISO-8859-1")
-    cpg_file.close()
-
+    with open(cpg_file_path, "r") as cpg_file:
+        content = cpg_file.read().strip()
+        if content == "ISO-8859-1":
+            # already set to ISO-8859-1, nothing to do
+            return
+        
+    with open(cpg_file_path, "w") as cpg_file:
+        cpg_file.write("ISO-8859-1")
+        cpg_file.close()
 
 def raster_to_WSG_and_UTM(raster_path, lat, lon):
 

--- a/cea/utilities/standardize_coordinates.py
+++ b/cea/utilities/standardize_coordinates.py
@@ -33,7 +33,7 @@ def shapefile_to_WSG_and_UTM(shapefile_path):
 def ensure_cpg_file(shapefile_path):
     cpg_file_path = shapefile_path.split('.shp', 1)[0] + '.CPG'
     with open(cpg_file_path, "r") as cpg_file:
-        content = cpg_file.read().strip()
+        content = cpg_file.read()
         if content == "ISO-8859-1":
             # already set to ISO-8859-1, nothing to do
             return


### PR DESCRIPTION
**Describe the PR**
The original `ensure_cpg_file` function was called very frequently whenever `get_zone_geometry` is used. Particularly, when using the energy potential - photovoltaic-thermal panels functionality. In each separate PVT calculation, this function was called around 12 times. 

The original implementation of `ensure_cpg_file` is to just write `zone.cpg` file to desired content: "ISO-8859-1". When using a cloud drive, for example, OneDrive, to sync the scenarios, such frequent writing will cause OneDrive to sync this .cpg file constantly. Sometimes this cloud drive sync will block CEA to write it, causing PermissionError when trying to write this file again, forcing CEA to exit the current batch simulation. For example, my batch of PVT simulation stops at 1728/1752, and it's hard to find out which one has not been simulated yet...

A straightforward solution will be first open the file with read access, check if the content is already there. If so, there's no need to change anything and just end the function; if not, then the file is re-opened using `with`, and this time the correct content is written into the file.

**To Test**
I have tested it on my own computer and make sure that this function worked correctly with both correct and wrong content in `zone.cpg` after several runs. However, there's not yet a systematic testing on all cases. 

Steps to test this PR:
1. open `zone.cpg` in `/inputs/geometry` folder;
2. delete contents inside the .cpg file, save and close;
3. do a demand analysis for a building, or any other functionality that calls `get_zone_geometry`;
4. After the calculation, open the `zone.cpg` file again, confirm that the content is `ISO-8859-1`.
5. This test confirms that the goal of this function, which is still to ensure the encoding, is still working.

**Expected behaviour**
Behaviour should not be affected.

**Extra Data Needed**
None.
