### PR TITLE
Requested by IDP students, adding in Total_demand_hourly.csv

### DIFF
--- a/cea/demand/demand_main.py
+++ b/cea/demand/demand_main.py
@@ -119,7 +119,8 @@ def demand_calculation(locator, config):
 
     # WRITE TOTAL YEARLY VALUES
     writer_totals = demand_writers.YearlyDemandWriter(loads_output, massflows_output, temperatures_output)
-    writer_totals.write_to_csv(building_names, locator)
+    writer_totals.write_aggregate_buildingly(locator, building_names)
+    writer_totals.write_aggregate_hourly(locator, building_names)
     time_elapsed = time.perf_counter() - t0
     print('done - time elapsed: %d.2 seconds' % time_elapsed)
 

--- a/cea/demand/demand_main.py
+++ b/cea/demand/demand_main.py
@@ -118,9 +118,8 @@ def demand_calculation(locator, config):
         repeat(debug, n))
 
     # WRITE TOTAL YEARLY VALUES
-    writer_totals = demand_writers.YearlyDemandWriter(loads_output, massflows_output, temperatures_output)
-    writer_totals.write_aggregate_buildingly(locator, building_names)
-    writer_totals.write_aggregate_hourly(locator, building_names)
+    demand_writers.YearlyDemandWriter.write_aggregate_buildings(locator, building_names)
+    demand_writers.YearlyDemandWriter.write_aggregate_hourly(locator, building_names)
     time_elapsed = time.perf_counter() - t0
     print('done - time elapsed: %d.2 seconds' % time_elapsed)
 

--- a/cea/demand/demand_writers.py
+++ b/cea/demand/demand_writers.py
@@ -4,10 +4,6 @@ that sums the values up monthly. See the `cea.analysis.sensitivity.sensitivity_d
 the `MonthlyDemandWriter`.
 """
 
-
-
-
-
 import numpy as np
 import pandas as pd
 
@@ -23,7 +19,6 @@ class DemandWriter(object):
     """
 
     def __init__(self, loads, massflows, temperatures):
-
         from cea.demand.thermal_loads import TSD_KEYS_ENERGY_BALANCE_DASHBOARD, TSD_KEYS_SOLAR
 
         self.load_vars = loads
@@ -61,7 +56,7 @@ class DemandWriter(object):
         # if printing total values is necessary
         # treating timeseries data from W to MWh
         data = dict((x + '_MWhyr', np.nan_to_num(tsd[x]).sum() / 1000000) for x in self.load_vars)
-        data.update(dict((x + '0_kW', np.nan_to_num(tsd[x]) .max() / 1000) for x in self.load_vars))
+        data.update(dict((x + '0_kW', np.nan_to_num(tsd[x]).max() / 1000) for x in self.load_vars))
         # get order of columns
         keys = data.keys()
         columns = self.OTHER_VARS
@@ -152,7 +147,6 @@ class MonthlyDemandWriter(DemandWriter):
         return monthly_data_new
 
 
-
 def aggregate_results(locator, building_names):
     aggregated_hourly_results_df = pd.DataFrame()
 
@@ -166,14 +160,12 @@ def aggregate_results(locator, building_names):
     return aggregated_hourly_results_df
 
 
-class YearlyDemandWriter(DemandWriter):
+class YearlyDemandWriter:
     """Write out the yearly demand results"""
 
-    def __init__(self, loads, massflows, temperatures):
-        super(YearlyDemandWriter, self).__init__(loads, massflows, temperatures)
-
-    def write_aggregate_buildingly(self, locator, building_names):
-        """read in the temporary results files and append them to the Total_demand_buildingly.csv file."""
+    @staticmethod
+    def write_aggregate_buildings(locator, building_names):
+        """read in the temporary results files and append them to the Total_demand_building.csv file."""
         df = None
         for building in building_names:
             temporary_file = locator.get_temporary_file('%(building)sT.csv' % locals())
@@ -183,7 +175,8 @@ class YearlyDemandWriter(DemandWriter):
                 df = pd.concat([df, pd.read_csv(temporary_file)], ignore_index=True)
         df.to_csv(locator.get_total_demand('csv'), index=False, float_format='%.3f', na_rep='nan')
 
-    def write_aggregate_hourly(config, locator, building_names):
+    @staticmethod
+    def write_aggregate_hourly(locator, building_names):
         """read in the building files and append them to the Total_demand_hourly.csv file."""
         aggregated_hourly_results_df = pd.DataFrame()
 
@@ -200,7 +193,8 @@ class YearlyDemandWriter(DemandWriter):
         aggregated_hourly_results_df.to_csv(locator.get_total_demand_hourly('csv'),
                                             index=True, float_format='%.3f', na_rep='nan')
 
-    def write_to_hdf5(self, list_buildings, locator):
+    @staticmethod
+    def write_to_hdf5(locator, list_buildings):
         """read in the temporary results files and append them to the Totals.csv file."""
         df = None
         for name in list_buildings:

--- a/cea/demand/demand_writers.py
+++ b/cea/demand/demand_writers.py
@@ -10,7 +10,6 @@ the `MonthlyDemandWriter`.
 
 import numpy as np
 import pandas as pd
-from multiprocessing.dummy import Pool
 
 FLOAT_FORMAT = '%.3f'
 

--- a/cea/demand/demand_writers.py
+++ b/cea/demand/demand_writers.py
@@ -174,7 +174,7 @@ class YearlyDemandWriter(DemandWriter):
         super(YearlyDemandWriter, self).__init__(loads, massflows, temperatures)
 
     def write_aggregate_buildingly(self, locator, building_names):
-        """read in the temporary results files and append them to the Totals.csv file."""
+        """read in the temporary results files and append them to the Total_demand_buildingly.csv file."""
         df = None
         for building in building_names:
             temporary_file = locator.get_temporary_file('%(building)sT.csv' % locals())
@@ -185,6 +185,7 @@ class YearlyDemandWriter(DemandWriter):
         df.to_csv(locator.get_total_demand('csv'), index=False, float_format='%.3f', na_rep='nan')
 
     def write_aggregate_hourly(config, locator, building_names):
+        """read in the building files and append them to the Total_demand_hourly.csv file."""
         aggregated_hourly_results_df = pd.DataFrame()
 
         for i, building in enumerate(building_names):
@@ -199,9 +200,6 @@ class YearlyDemandWriter(DemandWriter):
         # save hourly results
         aggregated_hourly_results_df.to_csv(locator.get_total_demand_hourly('csv'),
                                             index=True, float_format='%.3f', na_rep='nan')
-
-
-
 
     def write_to_hdf5(self, list_buildings, locator):
         """read in the temporary results files and append them to the Totals.csv file."""

--- a/cea/inputlocator.py
+++ b/cea/inputlocator.py
@@ -1125,6 +1125,10 @@ class InputLocator(object):
         """scenario/outputs/data/demand/Total_demand.csv"""
         return os.path.join(self.get_demand_results_folder(), 'Total_demand.%(format)s' % locals())
 
+    def get_total_demand_hourly(self, format='csv'):
+        """scenario/outputs/data/demand/Total_demand_hourly.csv"""
+        return os.path.join(self.get_demand_results_folder(), 'Total_demand_hourly.%(format)s' % locals())
+
     def get_demand_results_file(self, building, format='csv'):
         """scenario/outputs/data/demand/{building}.csv"""
         return os.path.join(self.get_demand_results_folder(), '%(building)s.%(format)s' % locals())


### PR DESCRIPTION
Requested by IDP students, adding in Total_demand_hourly.csv on top of the Total_demand(_buildingly).csv.

How to test?
Run demand 
Check >outputs>data>demand>Total_demand_hourly.csv

Does it exist? Is the number correct?

Unfortunately, the naming of the .csv files are not aligned with the equivalents for the PV aggregated results.