### PR TITLE
Convert geometries to projected coordinate system

### DIFF
--- a/cea/analysis/lca/embodied.py
+++ b/cea/analysis/lca/embodied.py
@@ -26,6 +26,8 @@ __maintainer__ = "Daren Thomas"
 __email__ = "cea@arch.ethz.ch"
 __status__ = "Production"
 
+from cea.utilities.standardize_coordinates import get_lat_lon_projected_shapefile, get_projected_coordinate_system
+
 
 def lca_embodied(year_to_calculate, locator):
     """
@@ -102,6 +104,11 @@ def lca_embodied(year_to_calculate, locator):
     age_df = dbf_to_dataframe(locator.get_building_typology())
     architecture_df = dbf_to_dataframe(locator.get_building_architecture())
     geometry_df = Gdf.from_file(locator.get_zone_geometry())
+
+    # reproject to projected coordinate system (in meters) to calculate area
+    lat, lon = get_lat_lon_projected_shapefile(geometry_df)
+    geometry_df = geometry_df.to_crs(get_projected_coordinate_system(float(lat), float(lon)))
+
     geometry_df['footprint'] = geometry_df.area
     geometry_df['perimeter'] = geometry_df.length
     geometry_df = geometry_df.drop('geometry', axis=1)

--- a/cea/demand/building_properties.py
+++ b/cea/demand/building_properties.py
@@ -23,6 +23,8 @@ __maintainer__ = "Daren Thomas"
 __email__ = "cea@arch.ethz.ch"
 __status__ = "Production"
 
+from cea.utilities.standardize_coordinates import get_lat_lon_projected_shapefile, get_projected_coordinate_system
+
 # import constants
 H_MS = constants.H_MS
 H_IS = constants.H_IS
@@ -57,6 +59,11 @@ class BuildingProperties(object):
         self.building_names = building_names
         print("read input files")
         prop_geometry = Gdf.from_file(locator.get_zone_geometry())
+
+        # reproject to projected coordinate system (in meters) to calculate area
+        lat, lon = get_lat_lon_projected_shapefile(prop_geometry)
+        prop_geometry = prop_geometry.to_crs(get_projected_coordinate_system(float(lat), float(lon)))
+
         prop_geometry['footprint'] = prop_geometry.area
         prop_geometry['perimeter'] = prop_geometry.length
         prop_geometry['Blength'], prop_geometry['Bwidth'] = self.calc_bounding_box_geom(locator.get_zone_geometry())

--- a/cea/demand/schedule_maker/schedule_maker.py
+++ b/cea/demand/schedule_maker/schedule_maker.py
@@ -28,6 +28,8 @@ __maintainer__ = "Daren Thomas"
 __email__ = "cea@arch.ethz.ch"
 __status__ = "Production"
 
+from cea.utilities.standardize_coordinates import get_projected_coordinate_system, get_lat_lon_projected_shapefile
+
 
 def schedule_maker_main(locator, config, building=None):
     # local variables
@@ -51,6 +53,11 @@ def schedule_maker_main(locator, config, building=None):
 
     # get building properties
     prop_geometry = Gdf.from_file(locator.get_zone_geometry())
+
+    # reproject to projected coordinate system (in meters) to calculate area
+    lat, lon = get_lat_lon_projected_shapefile(prop_geometry)
+    prop_geometry = prop_geometry.to_crs(get_projected_coordinate_system(float(lat), float(lon)))
+
     prop_geometry['footprint'] = prop_geometry.area
     prop_geometry['GFA_m2'] = prop_geometry['footprint'] * (prop_geometry['floors_ag'] + prop_geometry['floors_bg'])
     prop_geometry['GFA_ag_m2'] = prop_geometry['footprint'] * prop_geometry['floors_ag']

--- a/cea/optimization/preprocessing/decentralized_buildings_heating.py
+++ b/cea/optimization/preprocessing/decentralized_buildings_heating.py
@@ -24,6 +24,7 @@ from cea.resources.geothermal import calc_ground_temperature
 from cea.utilities import dbf
 from cea.utilities import epwreader
 from cea.technologies.supply_systems_database import SupplySystemsDatabase
+from cea.utilities.standardize_coordinates import get_lat_lon_projected_shapefile, get_projected_coordinate_system
 
 
 def disconnected_buildings_heating_main(locator, total_demand, building_names, config, prices, lca):
@@ -41,6 +42,11 @@ def disconnected_buildings_heating_main(locator, total_demand, building_names, c
     """
     t0 = time.perf_counter()
     prop_geometry = Gdf.from_file(locator.get_zone_geometry())
+
+    # reproject to projected coordinate system (in meters) to calculate area
+    lat, lon = get_lat_lon_projected_shapefile(prop_geometry)
+    prop_geometry = prop_geometry.to_crs(get_projected_coordinate_system(float(lat), float(lon)))
+
     geometry = pd.DataFrame({'Name': prop_geometry.Name, 'Area': prop_geometry.area})
     geothermal_potential_data = dbf.dbf_to_dataframe(locator.get_building_supply())
     geothermal_potential_data = pd.merge(geothermal_potential_data, geometry, on='Name')

--- a/cea/resources/geothermal.py
+++ b/cea/resources/geothermal.py
@@ -23,6 +23,8 @@ __maintainer__ = "Daren Thomas"
 __email__ = "cea@arch.ethz.ch"
 __status__ = "Production"
 
+from cea.utilities.standardize_coordinates import get_lat_lon_projected_shapefile, get_projected_coordinate_system
+
 
 def calc_geothermal_potential(locator, config):
     "A very simplified calculation based on the area available"
@@ -62,6 +64,11 @@ def calc_geothermal_potential(locator, config):
 def calc_area_buildings(locator, buildings_list):
     # initialize value
     prop_geometry = Gdf.from_file(locator.get_zone_geometry())
+
+    # reproject to projected coordinate system (in meters) to calculate area
+    lat, lon = get_lat_lon_projected_shapefile(prop_geometry)
+    prop_geometry = prop_geometry.to_crs(get_projected_coordinate_system(float(lat), float(lon)))
+
     prop_geometry['footprint'] = prop_geometry.area
 
     footprint = prop_geometry[prop_geometry["Name"].isin(buildings_list)]['footprint']


### PR DESCRIPTION
Not using a projected system might cause GFA when it is in WGS 84 (lat, lon). This would have unintended effects such as zero occupancy and extremely high or negative demand values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced area calculations for building geometry by incorporating coordinate standardization.
	- Added functionality for accurate area calculations in the `calc_area_buildings` and geothermal potential calculations.
  
- **Bug Fixes**
	- Improved accuracy of area calculations by ensuring geometries are reprojected to the correct coordinate system.

- **Documentation**
	- Updated comments to reflect the new coordinate standardization steps in various functions. 

These changes significantly improve the handling of geographic data, ensuring that area calculations are more precise and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->