### PR TITLE
Allow exclude current scenario in choices

### DIFF
--- a/cea/config.py
+++ b/cea/config.py
@@ -878,7 +878,7 @@ class ScenarioNameParameter(ChoiceParameter):
     """A parameter that can be set to a scenario-name"""
 
     def initialize(self, parser):
-        pass
+        self.exclude_current = parser.get(self.section.name, f"{self.name}.exclude_current", fallback=False)
 
     def encode(self, value):
         """Make sure the scenario folder exists"""
@@ -894,8 +894,11 @@ class ScenarioNameParameter(ChoiceParameter):
 
     @property
     def _choices(self):
-        return get_scenarios_list(self.config.project)
+        choices = get_scenarios_list(self.config.project)
+        if self.exclude_current and self.config.scenario_name:
+            choices.remove(self.config.scenario_name)
 
+        return choices
 
 class ScenarioParameter(Parameter):
     """This parameter type is special in that it is derived from two other parameters (project, scenario-name)"""
@@ -1151,7 +1154,7 @@ def get_scenarios_list(project_path: str) -> List[str]:
                     folder_name != "__pycache__",
                     folder_name != "__MACOSX"])
 
-    return [folder_name for folder_name in os.listdir(project_path) if is_valid_scenario(folder_name)]
+    return sorted([folder_name for folder_name in os.listdir(project_path) if is_valid_scenario(folder_name)])
 
 
 def get_systems_list(scenario_path):

--- a/cea/config.py
+++ b/cea/config.py
@@ -895,7 +895,7 @@ class ScenarioNameParameter(ChoiceParameter):
     @property
     def _choices(self):
         choices = get_scenarios_list(self.config.project)
-        if self.exclude_current and self.config.scenario_name:
+        if self.exclude_current and self.config.scenario_name and self.config.scenario_name in choices:
             choices.remove(self.config.scenario_name)
 
         return choices

--- a/cea/default.config
+++ b/cea/default.config
@@ -496,6 +496,7 @@ include-trees.category = Detailed settings
 reference-scenario-name =
 reference-scenario-name.type = ScenarioNameParameter
 reference-scenario-name.help = Select the original Scenario executed with export-to-Rhino-Grasshopper. CEA can copy its database, terrain file, and/or weather file from the current Scenario.
+reference-scenario-name.exclude_current = True
 
 copy-database = True
 copy-database.type = BooleanParameter


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a parameter to conditionally exclude the current scenario name from selection options.
	- Added a new configuration option to exclude the current scenario when exporting to Rhino-Grasshopper.
  
- **Improvements**
	- Enhanced the sorting of scenario lists for better organization and presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->