### PR TITLE
Add dev parameter to CEA backend to allow for reloading on file change

### DIFF
--- a/cea/config.py
+++ b/cea/config.py
@@ -174,16 +174,18 @@ class Configuration:
 
         for section, parameter in self.matching_parameters(option_list):
             if parameter.name in command_line_args:
+                command_line_arg = command_line_args.pop(parameter.name)
                 try:
-                    parameter.set(
-                        parameter.decode(
-                            parameter.replace_references(
-                                command_line_args[parameter.name])))
+                    raw_value = parameter.replace_references(command_line_arg)
+
+                    # Allow boolean parameters to be set to empty string to be interpreted as True
+                    if (raw_value == "" and isinstance(parameter, BooleanParameter)):
+                        parameter.set(True)
+                    else:
+                        parameter.set(parameter.decode(raw_value))
                 except Exception as e:
                     raise ValueError(
-                        f"ERROR setting {section.name}:{parameter.name} to {command_line_args[parameter.name]}") from e
-
-                del command_line_args[parameter.name]
+                        f"ERROR setting {section.name}:{parameter.name} to {command_line_arg}") from e
 
         if len(command_line_args) != 0:
             raise ValueError(f"Unexpected parameters: {command_line_args}")

--- a/cea/default.config
+++ b/cea/default.config
@@ -1684,6 +1684,10 @@ browser = false
 browser.type = BooleanParameter
 browser.help = Launch GUI in the browser
 
+dev = false
+dev.type = BooleanParameter
+dev.help = Launch server in development mode (reloads on file changes)
+
 [schemas]
 locator-method = get_zone_geometry
 locator-method.type = StringParameter

--- a/cea/interfaces/dashboard/dashboard.py
+++ b/cea/interfaces/dashboard/dashboard.py
@@ -40,6 +40,7 @@ def main(config):
                     f.flush()
 
             uvicorn.run("cea.interfaces.dashboard.app:app",
+                        reload=config.server.dev,
                         env_file=env_file,
                         host=settings.host, port=settings.port)
     except KeyboardInterrupt:


### PR DESCRIPTION
This helps improve developer's experience when testing the backend in different branches, so that they do not have to manually restart the server.