### PR TITLE
Update PV functions to use vectorized operations

### DIFF
--- a/cea/technologies/solar/photovoltaic.py
+++ b/cea/technologies/solar/photovoltaic.py
@@ -5,7 +5,7 @@ Photovoltaic
 import os
 import time
 from itertools import repeat
-from math import radians, degrees, asin, sin, acos, cos, exp, tan, ceil, log
+from math import radians, degrees, sin, acos, cos, tan, ceil, log
 from multiprocessing.dummy import Pool
 
 import numpy as np

--- a/cea/technologies/solar/photovoltaic.py
+++ b/cea/technologies/solar/photovoltaic.py
@@ -262,7 +262,7 @@ def calc_cell_temperature(absorbed_radiation_Wperm2, T_external_C, panel_propert
     T_cell_C = T_external_C + absorbed_radiation_Wperm2 * (NOCT - 20) / 800  # assuming linear temperature rise vs radiation according to NOCT condition
     
     # Return scalar if input was scalar
-    if np.isscalar(absorbed_radiation_Wperm2) and np.size(T_cell_C) == 1:
+    if np.size(T_cell_C) == 1:
         return float(T_cell_C)
     return T_cell_C
 
@@ -439,7 +439,7 @@ def calc_absorbed_radiation_PV(I_sol, I_direct, I_diffuse, tilt, Sz, teta, tetae
     absorbed_radiation_Wperm2 = np.maximum(absorbed_radiation_Wperm2, 0.0)
 
     # Return scalar if input was scalar
-    if np.isscalar(I_sol) and np.size(absorbed_radiation_Wperm2) == 1:
+    if np.size(absorbed_radiation_Wperm2) == 1:
         return float(absorbed_radiation_Wperm2)
     return absorbed_radiation_Wperm2
 
@@ -474,7 +474,7 @@ def calc_air_mass(Sz, latitude, longitude):
                 np.exp(-0.0001184 * h) / (np.cos(Sz) + 0.5057 * (96.080 - np.degrees(Sz))**(-1.634)))  # air mass (footnote 3)
     
     # Return scalar if input was scalar
-    if np.isscalar(Sz) and np.size(m) == 1:
+    if np.size(m) == 1:
         return float(m)
     return m
 
@@ -509,7 +509,7 @@ def calc_PV_power(absorbed_radiation_Wperm2, T_cell_C, eff_nom, tot_module_area_
                      (1 - Bref_perC * (T_cell_C - T_standard_C)) * (1 - misc_losses) / 1000
     
     # Return scalar if input was scalar
-    if np.isscalar(absorbed_radiation_Wperm2) and np.size(el_output_PV_kW) == 1:
+    if np.size(el_output_PV_kW) == 1:
         return float(el_output_PV_kW)
     return el_output_PV_kW
 

--- a/cea/technologies/solar/photovoltaic.py
+++ b/cea/technologies/solar/photovoltaic.py
@@ -90,7 +90,7 @@ def calc_PV(locator, config, type_PVpanel, latitude, longitude, weather_data, da
 
     # calculate properties of PV panel
     panel_properties_PV = get_properties_PV_db(locator.get_db4_components_conversion_conversion_technology_csv('PHOTOVOLTAIC_PANELS'), type_PVpanel)
-    print('gathering properties of PV panel')
+    # print('gathering properties of PV panel')
 
     # select sensor point with sufficient solar radiation
     max_annual_radiation, annual_radiation_threshold, sensors_rad_clean, sensors_metadata_clean = \
@@ -116,7 +116,7 @@ def calc_PV(locator, config, type_PVpanel, latitude, longitude, weather_data, da
         # group the sensors with the same tilt, surface azimuth, and total radiation
         sensor_groups = solar_equations.calc_groups(sensors_rad_clean, sensors_metadata_cat)
 
-        print('generating groups of sensor points done')
+        # print('generating groups of sensor points done')
 
         final = calc_pv_generation(sensor_groups, weather_data, datetime_local, solar_properties, latitude, longitude,
                                    panel_properties_PV)

--- a/cea/technologies/solar/photovoltaic_thermal.py
+++ b/cea/technologies/solar/photovoltaic_thermal.py
@@ -237,15 +237,14 @@ def calc_PVT_generation(sensor_groups, weather_data, date_local, solar_propertie
         teta_ed_rad, teta_eg_rad = calc_diffuseground_comp(tilt_rad)
 
         # absorbed radiation and Tcell
-        absorbed_radiation_PV_Wperm2 = np.vectorize(calc_absorbed_radiation_PV)(radiation_Wperm2.I_sol,
-                                                                                radiation_Wperm2.I_direct,
-                                                                                radiation_Wperm2.I_diffuse, tilt_rad,
-                                                                                Sz_rad, teta_rad, teta_ed_rad,
-                                                                                teta_eg_rad, panel_properties_PV,
-                                                                                latitude, longitude)
+        absorbed_radiation_PV_Wperm2 = calc_absorbed_radiation_PV(radiation_Wperm2.I_sol,
+                                                                  radiation_Wperm2.I_direct,
+                                                                  radiation_Wperm2.I_diffuse, tilt_rad,
+                                                                  Sz_rad, teta_rad, teta_ed_rad,
+                                                                  teta_eg_rad, panel_properties_PV,
+                                                                  latitude, longitude)
 
-        T_cell_C = np.vectorize(calc_cell_temperature)(absorbed_radiation_PV_Wperm2, weather_data.drybulb_C,
-                                                       panel_properties_PV)
+        T_cell_C = calc_cell_temperature(absorbed_radiation_PV_Wperm2, weather_data.drybulb_C, panel_properties_PV)
 
         ## SC heat generation
         # calculate incidence angle modifier for beam radiation
@@ -400,8 +399,8 @@ def calc_PVT_module(config, radiation_Wperm2, panel_properties_SC, panel_propert
 
     # calculate absorbed radiation
     tilt_rad = radians(tilt_angle_deg)
-    q_rad_vector = np.vectorize(calc_q_rad)(n0, IAM_b, IAM_d, radiation_Wperm2.I_direct, radiation_Wperm2.I_diffuse,
-                                            tilt_rad)  # absorbed solar radiation in W/m2 is a mean of the group
+    q_rad_vector = calc_q_rad(n0, IAM_b, IAM_d, radiation_Wperm2.I_direct, radiation_Wperm2.I_diffuse,
+                              tilt_rad)  # absorbed solar radiation in W/m2 is a mean of the group
     # counter = 0
     # Flag = False
     # Flag2 = False
@@ -516,9 +515,9 @@ def calc_PVT_module(config, radiation_Wperm2, panel_properties_SC, panel_propert
                                                               mcp_kWperK, supply_out_total_kW[5], temperature_in[5],
                                                               temperature_out[5])
 
-    el_output_PV_kW = np.vectorize(calc_PV_power)(absorbed_radiation_PV_Wperm2, T_module_C, eff_nom,
-                                                  module_area_per_group_m2,
-                                                  Bref, misc_losses)
+    el_output_PV_kW = calc_PV_power(absorbed_radiation_PV_Wperm2, T_module_C, eff_nom,
+                                    module_area_per_group_m2,
+                                    Bref, misc_losses)
 
     # write results into a list
     result = [supply_losses_kW[5], supply_out_total_kW[5], auxiliary_electricity_kW[5], temperature_out[5],

--- a/cea/technologies/solar/solar_collector.py
+++ b/cea/technologies/solar/solar_collector.py
@@ -370,8 +370,8 @@ def calc_SC_module(config, radiation_Wperm2, panel_properties, Tamb_vector_C, IA
 
     # calculate absorbed radiation
     tilt_rad = radians(tilt_angle_deg)
-    q_rad_vector = np.vectorize(calc_q_rad)(n0, IAM_b, IAM_d, radiation_Wperm2.I_direct, radiation_Wperm2.I_diffuse,
-                                            tilt_rad)  # absorbed solar radiation in W/m2 is a mean of the group
+    q_rad_vector = calc_q_rad(n0, IAM_b, IAM_d, radiation_Wperm2.I_direct, radiation_Wperm2.I_diffuse,
+                              tilt_rad)  # absorbed solar radiation in W/m2 is a mean of the group
     for flow in range(6):
         mode_seg = 1  # mode of segmented heat loss calculation. only one mode is implemented.
         TIME0 = 0
@@ -614,7 +614,6 @@ def update_negative_total_supply(aperture_area_m2, auxiliary_electricity_kW, flo
                                                                      pipe_lengths, aperture_area_m2)
 
 
-@jit(nopython=True)
 def calc_q_rad(n0, IAM_b, IAM_d, I_direct_Wperm2, I_diffuse_Wperm2, tilt):
     """
     Calculates the absorbed radiation for solar thermal collectors.
@@ -627,7 +626,7 @@ def calc_q_rad(n0, IAM_b, IAM_d, I_direct_Wperm2, I_diffuse_Wperm2, tilt):
     :return q_rad: absorbed radiation [W/m2]
     """
 
-    q_rad_Wperm2 = n0 * IAM_b * I_direct_Wperm2 + n0 * IAM_d * I_diffuse_Wperm2 * (1 + cos(tilt)) / 2
+    q_rad_Wperm2 = n0 * IAM_b * I_direct_Wperm2 + n0 * IAM_d * I_diffuse_Wperm2 * (1 + np.cos(tilt)) / 2
     return q_rad_Wperm2
 
 


### PR DESCRIPTION
`np.vectorize` does not make the code any faster as it is still using loops under the hood. 

The functions are updated to use numpy math operations that actually does vectorization. This decreases PV calculation for reference case from ~25s per building to <1s per building.

To test, run PV script without this PR and one using this PR, then compare results to make sure it is the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined solar energy and radiation computation routines for improved efficiency and consistency.
  - Enhanced type handling to boost reliability and flexibility in solar simulation models.
  - Simplified processing logic by removing redundant operations for faster, more accurate performance.
  - Updated mathematical operations to utilize direct NumPy calls, improving performance.
  - Removed unnecessary vectorization for several calculations, allowing functions to handle array inputs directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->