### PR TITLE
Update micromamba version

### DIFF
--- a/.github/workflows/setup_build.yml
+++ b/.github/workflows/setup_build.yml
@@ -36,9 +36,10 @@ jobs:
             setup/dependencies/micromamba.exe
           key: ${{ runner.os }}-${{ hashFiles('conda-lock.yml') }}-env
       
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@v2
         if: steps.cache-env.outputs.cache-hit != 'true'
         with:
+          micromamba-version: '2.0.7-0'
           environment-file: conda-lock.yml
           environment-name: cea
           cache-environment: true
@@ -135,9 +136,9 @@ jobs:
         run: |
           cd gui
           mkdir -p ./dependencies/arm64
-          curl -Ls https://micro.mamba.pm/api/micromamba/osx-arm64/1.5.10 | tar -xvj -C ./dependencies/arm64 --strip-components=1 bin/micromamba
+          curl -Ls https://micro.mamba.pm/api/micromamba/osx-arm64/2.0.7 | tar -xvj -C ./dependencies/arm64 --strip-components=1 bin/micromamba
           mkdir -p ./dependencies/x64
-          curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/1.5.10 | tar -xvj -C ./dependencies/x64 --strip-components=1 bin/micromamba 
+          curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/2.0.7 | tar -xvj -C ./dependencies/x64 --strip-components=1 bin/micromamba 
 
       - name: Save Apple API Key secret to file
         env:

--- a/docs/developer/installing-from-source.rst
+++ b/docs/developer/installing-from-source.rst
@@ -15,9 +15,7 @@ Prerequisites
 * `Conda <https://docs.conda.io/projects/conda/en/stable/>`__
    We recommend using `Micromamba <https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html>`__.
    It supports parallel downloading of package files using multi-threading and it natively supports `conda-lock <https://github.com/conda/conda-lock/>`__ to skip the solving of dependencies *(it saves a lot of time!)*.
-   
-   .. attention:: Currently using Micromamba v2 is not supported due to a `bug in micromamba <https://github.com/mamba-org/mamba/issues/3711>`__. Please use **v1.5.10** instead.
-    
+       
    .. attention:: If you are planning to use CEA in **PyCharm**, we recommend using the other ones listed below, since micromamba environments are not natively supported by **PyCharm**.
 
    However, you can use any other conda package manager that you might already have


### PR DESCRIPTION
libmamba has been updated to 2.0.7 that solves the error with installing from `git+https` pip urls, which was previously causing issues for our installation.

https://github.com/mamba-org/mamba/releases/tag/2.0.7

Updating docs and links.