### PR TITLE
Fix missing settings after uvicorn reloads

### DIFF
--- a/cea/interfaces/dashboard/dashboard.py
+++ b/cea/interfaces/dashboard/dashboard.py
@@ -4,15 +4,14 @@ import tempfile
 
 import uvicorn
 
-from cea.interfaces.dashboard.settings import get_settings
+from cea.config import Configuration
+from cea.interfaces.dashboard.settings import get_settings, Settings
 
 
-def main(config):
-    # Try loading settings from env vars first
-    settings = get_settings()
-    config_dict = dict()
-
-    # Load from config if not found in env vars
+def load_from_config(settings: Settings, config: Configuration):
+    """
+    Load settings from config file if not set in Settings (not found in env vars)
+    """
     if settings.host is None:
         settings.host = config.server.host
 
@@ -21,23 +20,25 @@ def main(config):
 
     if settings.project_root is None:
         settings.project_root = config.server.project_root
-        config_dict["project_root"] = config.server.project_root
 
         # Ensure project root exists before starting the server
         if settings.project_root != "" and not os.path.exists(settings.project_root):
             raise ValueError(f"The path `{settings.project_root}` does not exist. "
                              f"Make sure project_root in config is set correctly.")
 
+    return settings
+
+def main(config):
+    # Load settings from env vars (priority) then config file
+    settings = get_settings()
+    load_from_config(settings, config)
     print(f"Using settings: {settings}")
 
     try:
-        # Write missing settings to temp env file
         with tempfile.TemporaryDirectory() as temp_dir:
             env_file = os.path.join(temp_dir, "cea.env")
-            with open(env_file, "w") as f:
-                for key, value in config_dict.items():
-                    f.write(f"CEA_{key.upper()}={value}\n")
-                    f.flush()
+            # Rewrite settings to env file to be loaded by uvicorn process
+            settings.to_env_file(env_file)
 
             uvicorn.run("cea.interfaces.dashboard.app:app",
                         reload=config.server.dev,

--- a/cea/interfaces/dashboard/dashboard.py
+++ b/cea/interfaces/dashboard/dashboard.py
@@ -8,7 +8,7 @@ from cea.config import Configuration
 from cea.interfaces.dashboard.settings import get_settings, Settings
 
 
-def load_from_config(settings: Settings, config: Configuration):
+def load_from_config(settings: Settings, config: Configuration) -> None:
     """
     Load settings from config file if not set in Settings (not found in env vars)
     """
@@ -26,7 +26,6 @@ def load_from_config(settings: Settings, config: Configuration):
             raise ValueError(f"The path `{settings.project_root}` does not exist. "
                              f"Make sure project_root in config is set correctly.")
 
-    return settings
 
 def main(config):
     # Load settings from env vars (priority) then config file
@@ -50,4 +49,5 @@ def main(config):
 
 if __name__ == "__main__":
     import cea.config
+
     main(cea.config.Configuration())

--- a/cea/interfaces/dashboard/settings.py
+++ b/cea/interfaces/dashboard/settings.py
@@ -20,8 +20,17 @@ class Settings(BaseSettings):
         """
         return self.project_root == ""
 
+    def to_env_file(self, path: str):
+        """
+        Write settings to env file in the format CEA_{KEY}={VALUE}
+        """
+        with open(path, "w") as f:
+            for key, value in self.__dict__.items():
+                if value is not None:
+                    f.write(f"CEA_{key.upper()}={value}\n")
+                f.flush()
 
-# FIXME: Settings does not load from cea config
+
 @lru_cache
 def get_settings():
     return Settings()

--- a/cea/interfaces/dashboard/settings.py
+++ b/cea/interfaces/dashboard/settings.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
             for key, value in self.__dict__.items():
                 if value is not None:
                     f.write(f"CEA_{key.upper()}={value}\n")
-                f.flush()
+            f.flush()
 
 
 @lru_cache


### PR DESCRIPTION
Pass all settings to uvicorn process in environment variables to ensure FastAPI is able to read it when the process restarts

Solves https://github.com/architecture-building-systems/CityEnergyAnalyst/pull/3786 not working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled automatic fallback to load missing configuration settings from external files.
	- Introduced a feature that exports current settings into an environment file for seamless integration.

- **Refactor**
	- Streamlined the initialization process for configuration management.
	- Enhanced error handling to ensure the validity of essential configuration paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->