### PR TITLE
Move pure python packages to pip

### DIFF
--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -13,10 +13,10 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: 9c431cded27c7e2d89c86bbae4994b909489649f45382ab63e033bf3e6c1cd23
-    osx-arm64: f159c2632d3b3aadda5eac968f8086570265645a205ca8ee837098fdd4123079
-    osx-64: 5ed5e8f10064c5adb4228c1304e412ada08c81006f7c95a00524309fcdc83f84
-    win-64: 8b4d47d776d3e805fa61b548683a60c3cc831417b8d07b9bb1e60143ef708192
+    linux-64: 958a1adf52b920f46cd772ab1bd9e99433a5979b6247c70c3324cfa91409d6dd
+    osx-arm64: fff31ce7cc5e7bd64ff6970c404c4476f827ab2372df17751b4cb30877008e51
+    osx-64: 337f86de6f6e8344f20746dbaccf00c2287b4ceb544e78684e329d2127f473f2
+    win-64: e55636f708b691666b5bdf0fd2f5a2f1aa7cdd10a46bb77309f69f50df9015d7
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -266,8 +266,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     frozenlist: '>=1.1.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: d1e1eb7e21a9e2c74279d87dafb68156
@@ -279,8 +279,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     frozenlist: '>=1.1.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: d1e1eb7e21a9e2c74279d87dafb68156
@@ -336,11 +336,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing_extensions: ''
     exceptiongroup: ''
+    idna: '>=2.8'
     python: '>=3.7'
     sniffio: '>=1.1'
-    idna: '>=2.8'
+    typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.1-pyhd8ed1ab_0.conda
   hash:
     md5: 7b517e7a6f0790337906c055aa97ca49
@@ -352,11 +352,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    typing_extensions: '>=4.1'
-    sniffio: '>=1.1'
-    idna: '>=2.8'
     exceptiongroup: '>=1.0.2'
+    idna: '>=2.8'
+    python: '>=3.8'
+    sniffio: '>=1.1'
+    typing_extensions: '>=4.1'
   url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.5.0-pyhd8ed1ab_0.conda
   hash:
     md5: c720e5c85c349c5cbc99d9dfc4b200f8
@@ -471,9 +471,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing-extensions: ''
     argon2-cffi-bindings: ''
     python: '>=3.7'
+    typing-extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 3afef1f55a1366b4d3b6a0d92e2235e4
@@ -485,9 +485,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    typing-extensions: ''
     argon2-cffi-bindings: ''
     python: '>=3.7'
+    typing-extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 3afef1f55a1366b4d3b6a0d92e2235e4
@@ -1818,11 +1818,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
     packaging: ''
-    webencodings: ''
     python: '>=3.6'
+    setuptools: ''
     six: '>=1.9.0'
+    webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
@@ -1834,11 +1834,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
     packaging: ''
-    webencodings: ''
     python: '>=3.6'
+    setuptools: ''
     six: '>=1.9.0'
+    webencodings: ''
   url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
   hash:
     md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
@@ -2011,8 +2011,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     jinja2: '>=3'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
   hash:
     md5: 5f1c719f1cac0aee5e6bd6ca7d54a7fa
@@ -2024,8 +2024,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     jinja2: '>=3'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
   hash:
     md5: 5f1c719f1cac0aee5e6bd6ca7d54a7fa
@@ -2310,51 +2310,51 @@ package:
   category: main
   optional: false
 - name: ca-certificates
-  version: 2025.1.31
+  version: 2025.4.26
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.1.31-hbd8a1cb_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
   hash:
-    md5: e74273d9fc5ab633d613cde474b55157
-    sha256: 43878eddf8eb46e3ba7fcbe77a2f8d00aab9a66d9ff63bc4d072b7af17481197
+    md5: 95db94f75ba080a22eb623590993167b
+    sha256: 2a70ed95ace8a3f8a29e6cd1476a943df294a7111dfb3e152e3478c4c889b7ac
   category: main
   optional: false
 - name: ca-certificates
-  version: 2025.1.31
+  version: 2025.4.26
   manager: conda
   platform: osx-64
   dependencies:
     __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.1.31-hbd8a1cb_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
   hash:
-    md5: e74273d9fc5ab633d613cde474b55157
-    sha256: 43878eddf8eb46e3ba7fcbe77a2f8d00aab9a66d9ff63bc4d072b7af17481197
+    md5: 95db94f75ba080a22eb623590993167b
+    sha256: 2a70ed95ace8a3f8a29e6cd1476a943df294a7111dfb3e152e3478c4c889b7ac
   category: main
   optional: false
 - name: ca-certificates
-  version: 2025.1.31
+  version: 2025.4.26
   manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.1.31-hbd8a1cb_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
   hash:
-    md5: e74273d9fc5ab633d613cde474b55157
-    sha256: 43878eddf8eb46e3ba7fcbe77a2f8d00aab9a66d9ff63bc4d072b7af17481197
+    md5: 95db94f75ba080a22eb623590993167b
+    sha256: 2a70ed95ace8a3f8a29e6cd1476a943df294a7111dfb3e152e3478c4c889b7ac
   category: main
   optional: false
 - name: ca-certificates
-  version: 2025.1.31
+  version: 2025.4.26
   manager: conda
   platform: win-64
   dependencies:
     __win: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.1.31-h4c7d964_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-h4c7d964_0.conda
   hash:
-    md5: fb8af741d752521fb48b8d116c9b044e
-    sha256: d6326613de7aea644f4c3b5fadd87d7b19714fe2ba31c9e2d2cdd65830f95cd4
+    md5: 23c7fd5062b48d8294fc7f61bf157fba
+    sha256: 1454f3f53a3b828d3cb68a3440cb0fa9f1cc0e3c8c26e9e023773dc19d88cc06
   category: main
   optional: false
 - name: cached-property
@@ -2849,8 +2849,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: ''
     click: '>=3.0'
+    python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
   hash:
     md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
@@ -2862,8 +2862,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: ''
     click: '>=3.0'
+    python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
   hash:
     md5: 4fd2c6b53934bd7d96d1f3fdaf99b79f
@@ -2901,8 +2901,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: <4.0
     click: '>=4.0'
+    python: <4.0
   url: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
   hash:
     md5: a29b7c141d6b2de4bb67788a5f107734
@@ -2914,8 +2914,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: <4.0
     click: '>=4.0'
+    python: <4.0
   url: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
   hash:
     md5: a29b7c141d6b2de4bb67788a5f107734
@@ -3280,71 +3280,6 @@ package:
     sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
   category: main
   optional: false
-- name: deap
-  version: 1.4.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/deap-1.4.1-py38h495e488_2.conda
-  hash:
-    md5: 5c1d01aecdfe89f0b6a83c853c95d7ba
-    sha256: 63784e70ddd22b1f3ef3262110e48a0786a60ba4dc6f652ae48137b4e41f119c
-  category: main
-  optional: false
-- name: deap
-  version: 1.4.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.13'
-    libcxx: '>=16'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/deap-1.4.1-py38h168d7cc_2.conda
-  hash:
-    md5: d9f851e48347b2f99a4a8314d82e7659
-    sha256: cfc7abba5bb5b2948a50f7fab811178b4d852393f79294bc3caa69dac3b9057e
-  category: main
-  optional: false
-- name: deap
-  version: 1.4.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=16'
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/deap-1.4.1-py38h0dc1a42_2.conda
-  hash:
-    md5: 45e63b45728bed4f50a86e1328a91a2d
-    sha256: fe729e9405e4566dd771cb9b3357073f8cf77dd64f1f07ba5168bd908d9b90b1
-  category: main
-  optional: false
-- name: deap
-  version: 1.4.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    numpy: '>=1.22.4,<2.0a0'
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/deap-1.4.1-py38hb7c6f16_2.conda
-  hash:
-    md5: 72aca163ac7723b55685356b154c4eb7
-    sha256: 1e2de5650d4a05a6e46df5fc10219e2236f7ef7a6aaf7c8c96716773b6bab4f6
-  category: main
-  optional: false
 - name: debugpy
   version: 1.8.5
   manager: conda
@@ -3501,54 +3436,6 @@ package:
   hash:
     md5: 961b3a227b437d82ad7054484cfa71b2
     sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
-  category: main
-  optional: false
-- name: dill
-  version: 0.3.9
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/dill-0.3.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: 27faec84454995f6774786c7e5833cd6
-    sha256: e597a41dcfb1a3b33d01d9d231975e2a931c3e1aeb8b5f3c40abbb10061f64b2
-  category: main
-  optional: false
-- name: dill
-  version: 0.3.9
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/dill-0.3.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: 27faec84454995f6774786c7e5833cd6
-    sha256: e597a41dcfb1a3b33d01d9d231975e2a931c3e1aeb8b5f3c40abbb10061f64b2
-  category: main
-  optional: false
-- name: dill
-  version: 0.3.9
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/dill-0.3.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: 27faec84454995f6774786c7e5833cd6
-    sha256: e597a41dcfb1a3b33d01d9d231975e2a931c3e1aeb8b5f3c40abbb10061f64b2
-  category: main
-  optional: false
-- name: dill
-  version: 0.3.9
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/dill-0.3.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: 27faec84454995f6774786c7e5833cd6
-    sha256: e597a41dcfb1a3b33d01d9d231975e2a931c3e1aeb8b5f3c40abbb10061f64b2
   category: main
   optional: false
 - name: double-conversion
@@ -3813,54 +3700,6 @@ package:
   hash:
     md5: 28e1ad1fd30c173ac5b4b629e425233a
     sha256: ab88ff466df6e03158aac313dcfa4c0aa27137bcf1f1a7ac20aa8dc4bc2b1041
-  category: main
-  optional: false
-- name: et_xmlfile
-  version: 2.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: cdcdbe90dfab4075fc1f3c4cf2e4b4e5
-    sha256: 385e7f1cd141ce535f30bfefb49d6f21aaecfca710c8cfa49b5ce2fa88f1d27d
-  category: main
-  optional: false
-- name: et_xmlfile
-  version: 2.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: cdcdbe90dfab4075fc1f3c4cf2e4b4e5
-    sha256: 385e7f1cd141ce535f30bfefb49d6f21aaecfca710c8cfa49b5ce2fa88f1d27d
-  category: main
-  optional: false
-- name: et_xmlfile
-  version: 2.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: cdcdbe90dfab4075fc1f3c4cf2e4b4e5
-    sha256: 385e7f1cd141ce535f30bfefb49d6f21aaecfca710c8cfa49b5ce2fa88f1d27d
-  category: main
-  optional: false
-- name: et_xmlfile
-  version: 2.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: cdcdbe90dfab4075fc1f3c4cf2e4b4e5
-    sha256: 385e7f1cd141ce535f30bfefb49d6f21aaecfca710c8cfa49b5ce2fa88f1d27d
   category: main
   optional: false
 - name: exceptiongroup
@@ -4332,12 +4171,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    branca: '>=0.6.0'
+    jinja2: '>=2.9'
     numpy: ''
+    python: '>=3.8'
     requests: ''
     xyzservices: ''
-    python: '>=3.8'
-    jinja2: '>=2.9'
-    branca: '>=0.6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/folium-0.18.0-pyhd8ed1ab_0.conda
   hash:
     md5: 26a1457f3e698dc0c9e656874cc6b623
@@ -4349,12 +4188,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    branca: '>=0.6.0'
+    jinja2: '>=2.9'
     numpy: ''
+    python: '>=3.8'
     requests: ''
     xyzservices: ''
-    python: '>=3.8'
-    jinja2: '>=2.9'
-    branca: '>=0.6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/folium-0.18.0-pyhd8ed1ab_0.conda
   hash:
     md5: 26a1457f3e698dc0c9e656874cc6b623
@@ -4685,10 +4524,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    font-ttf-ubuntu: ''
+    font-ttf-dejavu-sans-mono: ''
     font-ttf-inconsolata: ''
     font-ttf-source-code-pro: ''
-    font-ttf-dejavu-sans-mono: ''
+    font-ttf-ubuntu: ''
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
@@ -4700,10 +4539,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    font-ttf-ubuntu: ''
+    font-ttf-dejavu-sans-mono: ''
     font-ttf-inconsolata: ''
     font-ttf-source-code-pro: ''
-    font-ttf-dejavu-sans-mono: ''
+    font-ttf-ubuntu: ''
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
@@ -5198,14 +5037,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    fiona: '>=1.8.19'
+    folium: ''
+    geopandas-base: 0.13.2
+    mapclassify: '>=2.4.0'
     matplotlib-base: ''
+    python: '>=3.8'
     rtree: ''
     xyzservices: ''
-    folium: ''
-    python: '>=3.8'
-    mapclassify: '>=2.4.0'
-    fiona: '>=1.8.19'
-    geopandas-base: 0.13.2
   url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.13.2-pyhd8ed1ab_1.conda
   hash:
     md5: 47226a55e4ae3bc9feb3a17925874817
@@ -5217,14 +5056,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    fiona: '>=1.8.19'
+    folium: ''
+    geopandas-base: 0.13.2
+    mapclassify: '>=2.4.0'
     matplotlib-base: ''
+    python: '>=3.8'
     rtree: ''
     xyzservices: ''
-    folium: ''
-    python: '>=3.8'
-    mapclassify: '>=2.4.0'
-    fiona: '>=1.8.19'
-    geopandas-base: 0.13.2
   url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.13.2-pyhd8ed1ab_1.conda
   hash:
     md5: 47226a55e4ae3bc9feb3a17925874817
@@ -5269,10 +5108,10 @@ package:
   platform: osx-arm64
   dependencies:
     packaging: ''
-    python: '>=3.8'
     pandas: '>=1.1.0'
-    shapely: '>=1.7.1'
     pyproj: '>=3.0.1'
+    python: '>=3.8'
+    shapely: '>=1.7.1'
   url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.13.2-pyha770c72_1.conda
   hash:
     md5: c6036236caae7d8ac684c41c64073b9e
@@ -5285,10 +5124,10 @@ package:
   platform: win-64
   dependencies:
     packaging: ''
-    python: '>=3.8'
     pandas: '>=1.1.0'
-    shapely: '>=1.7.1'
     pyproj: '>=3.0.1'
+    python: '>=3.8'
+    shapely: '>=1.7.1'
   url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.13.2-pyha770c72_1.conda
   hash:
     md5: c6036236caae7d8ac684c41c64073b9e
@@ -5418,64 +5257,64 @@ package:
   category: main
   optional: false
 - name: gettext
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    gettext-tools: 0.23.1
-    libasprintf: 0.23.1
-    libasprintf-devel: 0.23.1
+    gettext-tools: 0.24.1
+    libasprintf: 0.24.1
+    libasprintf-devel: 0.24.1
     libgcc: '>=13'
-    libgettextpo: 0.23.1
-    libgettextpo-devel: 0.23.1
+    libgettextpo: 0.24.1
+    libgettextpo-devel: 0.24.1
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.23.1-h5888daf_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.24.1-h5888daf_0.conda
   hash:
-    md5: 0754038c806eae440582da1c3af85577
-    sha256: 9d93e75a63a8ca8f86d1be09f68f1211754e6f1e9ee4fa6d90b9d46ee0f1dabb
+    md5: c63e7590d4d6f4c85721040ed8b12888
+    sha256: 88db27c666e1f8515174bf622a3e2ad983c94d69e3a23925089e476b9b06ad00
   category: main
   optional: false
 - name: gettext
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    gettext-tools: 0.23.1
-    libasprintf: 0.23.1
-    libasprintf-devel: 0.23.1
+    gettext-tools: 0.24.1
+    libasprintf: 0.24.1
+    libasprintf-devel: 0.24.1
     libcxx: '>=18'
-    libgettextpo: 0.23.1
-    libgettextpo-devel: 0.23.1
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.23.1
-    libintl-devel: 0.23.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.23.1-hd385c8e_0.conda
+    libgettextpo: 0.24.1
+    libgettextpo-devel: 0.24.1
+    libiconv: '>=1.18,<2.0a0'
+    libintl: 0.24.1
+    libintl-devel: 0.24.1
+  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.24.1-hd385c8e_0.conda
   hash:
-    md5: 22d89ca70e22979c38bd0146abf21c2a
-    sha256: b0a259a09b23892fb93b93badb1b0badee183ba1fb1dbf8c443c3564641800fd
+    md5: 7bd8192fb137ff0434fb468332a1a623
+    sha256: f98d37d037c03e201d36009352e99dcfe22c05cce0fdc96257c5461797359617
   category: main
   optional: false
 - name: gettext
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    gettext-tools: 0.23.1
-    libasprintf: 0.23.1
-    libasprintf-devel: 0.23.1
+    gettext-tools: 0.24.1
+    libasprintf: 0.24.1
+    libasprintf-devel: 0.24.1
     libcxx: '>=18'
-    libgettextpo: 0.23.1
-    libgettextpo-devel: 0.23.1
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.23.1
-    libintl-devel: 0.23.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.23.1-h3dcc1bd_0.conda
+    libgettextpo: 0.24.1
+    libgettextpo-devel: 0.24.1
+    libiconv: '>=1.18,<2.0a0'
+    libintl: 0.24.1
+    libintl-devel: 0.24.1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.24.1-h3dcc1bd_0.conda
   hash:
-    md5: 123c4d62e1bcba6274511af8c7cf40d5
-    sha256: 9311cd9e64f0ae3bccae58b5b68a4804abd8b3c49f4f327b9573b50b026b317e
+    md5: 6b5294d638ac03333bd7a176b97825a0
+    sha256: 2f02be79abd983d4ce21c54ed6aea706487d315f6e35e2f350318bb014b33ec0
   category: main
   optional: false
 - name: gettext
@@ -5498,44 +5337,44 @@ package:
   category: main
   optional: false
 - name: gettext-tools
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.23.1-h5888daf_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.24.1-h5888daf_0.conda
   hash:
-    md5: 2f659535feef3cfb782f7053c8775a32
-    sha256: dd2b54a823ea994c2a7908fcce40e1e612ca00cb9944f2382624ff2d3aa8db03
+    md5: d54305672f0361c2f3886750e7165b5f
+    sha256: 3ba33868630b903e3cda7a9176363cdf02710fb8f961efed5f8200c4d53fb4e3
   category: main
   optional: false
 - name: gettext-tools
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.23.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-tools-0.23.1-h27064b9_0.conda
+    libiconv: '>=1.18,<2.0a0'
+    libintl: 0.24.1
+  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-tools-0.24.1-h27064b9_0.conda
   hash:
-    md5: a6bc310a08cf42286627c818da4c0ba1
-    sha256: e9e9afb674b0ec5af38ca42b5518d8ee52b0aada90151b76199764bb956ebb3a
+    md5: 28df2ea800bc20b9afa271165f3ee0c2
+    sha256: 5cb72a0565d83ec0ad9db163340efb89a45dda7071c3c9c02855e3095f974c6d
   category: main
   optional: false
 - name: gettext-tools
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.23.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-tools-0.23.1-h493aca8_0.conda
+    libiconv: '>=1.18,<2.0a0'
+    libintl: 0.24.1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-tools-0.24.1-h493aca8_0.conda
   hash:
-    md5: 4086817e75778198f96c9b2ed4bc5a6e
-    sha256: c26b38bcff84b3af52f061f55de27a45fb2e9a0544c32b3cbddf8be97c80c296
+    md5: 8a3a2c7c4a60f8b179f46d3568bb9f70
+    sha256: b0aac8a3cc5453912af515c70340fd3b2857f59bd412817d45f750a77d934d99
   category: main
   optional: false
 - name: gettext-tools
@@ -5692,10 +5531,10 @@ package:
   manager: conda
   platform: win-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/git-2.49.0-h57928b3_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/git-2.49.0-h57928b3_1.conda
   hash:
-    md5: 30c89cbda81237c8501ba98adac10ad7
-    sha256: 23c313d9a6e7784bdacc71d7fe9d5cd36d6984908e716422ed8ad9b38162d85f
+    md5: 4005324dbb3cc47767ab259856b6d687
+    sha256: ec2e366e4dbd350621ce8c73b91dd6ce5cc1b156ab2c6c006eaa7942f3635d0f
   category: main
   optional: false
 - name: gl2ps
@@ -6391,8 +6230,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing_extensions: ''
     python: '>=3'
+    typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b21ed0883505ba1910994f1df031a428
@@ -6404,8 +6243,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    typing_extensions: ''
     python: '>=3'
+    typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b21ed0883505ba1910994f1df031a428
@@ -6445,9 +6284,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6.1'
     hpack: '>=4.0,<5'
     hyperframe: '>=6.0,<7'
+    python: '>=3.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b748fbf7060927a6e82df7cb5ee8f097
@@ -6459,76 +6298,13 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6.1'
     hpack: '>=4.0,<5'
     hyperframe: '>=6.0,<7'
+    python: '>=3.6.1'
   url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b748fbf7060927a6e82df7cb5ee8f097
     sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
-  category: main
-  optional: false
-- name: h3-py
-  version: 3.7.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    numpy: ''
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/h3-py-3.7.7-py38h17151c0_0.conda
-  hash:
-    md5: 1246e1fcc5588357951d3d71912e9c31
-    sha256: 9e33d5a53eeffa608bfdd8a18791cfd24eebe5eff85223c3a5826a3aedff2e10
-  category: main
-  optional: false
-- name: h3-py
-  version: 3.7.7
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libcxx: '>=16'
-    numpy: ''
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/h3-py-3.7.7-py38h1f5f77c_0.conda
-  hash:
-    md5: b4fdedcd82ed63e64c62061280b2b630
-    sha256: b640e4fbdf4166b0e33e3dff160b13bd8376161b210630e59ba79d6d2c32792c
-  category: main
-  optional: false
-- name: h3-py
-  version: 3.7.7
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libcxx: '>=16'
-    numpy: ''
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/h3-py-3.7.7-py38hb9fa5a8_0.conda
-  hash:
-    md5: d336f14d18ae82870cd4ab2261a476c3
-    sha256: 81b6f87b59263d1207bbd525d2c39da2ff2df431b5af6eecc7754d9c308983d9
-  category: main
-  optional: false
-- name: h3-py
-  version: 3.7.7
-  manager: conda
-  platform: win-64
-  dependencies:
-    numpy: ''
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/h3-py-3.7.7-py38hd3f51b4_0.conda
-  hash:
-    md5: 69bfc9fb5e01108ca77617521253bc16
-    sha256: 09cf0bf98c55104ea0f65a664995fa1690952321721e460877a019aed20c6578
   category: main
   optional: false
 - name: h5py
@@ -6805,12 +6581,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-    h11: '>=0.13,<0.15'
-    h2: '>=3,<5'
-    sniffio: 1.*
     anyio: '>=3.0,<5.0'
     certifi: ''
+    h11: '>=0.13,<0.15'
+    h2: '>=3,<5'
+    python: '>=3.8'
+    sniffio: 1.*
   url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
   hash:
     md5: 2ca8e6dbc86525c8b95e3c0ffa26442e
@@ -6822,12 +6598,12 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-    h11: '>=0.13,<0.15'
-    h2: '>=3,<5'
-    sniffio: 1.*
     anyio: '>=3.0,<5.0'
     certifi: ''
+    h11: '>=0.13,<0.15'
+    h2: '>=3,<5'
+    python: '>=3.8'
+    sniffio: 1.*
   url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
   hash:
     md5: 2ca8e6dbc86525c8b95e3c0ffa26442e
@@ -6839,12 +6615,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    anyio: '>=3.0,<5.0'
     certifi: ''
+    h11: '>=0.13,<0.15'
+    h2: '>=3,<5'
     python: '>=3.8'
     sniffio: 1.*
-    h2: '>=3,<5'
-    anyio: '>=3.0,<5.0'
-    h11: '>=0.13,<0.15'
   url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
   hash:
     md5: 2ca8e6dbc86525c8b95e3c0ffa26442e
@@ -6856,12 +6632,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    anyio: '>=3.0,<5.0'
     certifi: ''
+    h11: '>=0.13,<0.15'
+    h2: '>=3,<5'
     python: '>=3.8'
     sniffio: 1.*
-    h2: '>=3,<5'
-    anyio: '>=3.0,<5.0'
-    h11: '>=0.13,<0.15'
   url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
   hash:
     md5: 2ca8e6dbc86525c8b95e3c0ffa26442e
@@ -6907,12 +6683,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    certifi: ''
-    sniffio: ''
     anyio: ''
+    certifi: ''
+    httpcore: 1.*
     idna: ''
     python: '>=3.8'
-    httpcore: 1.*
+    sniffio: ''
   url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
   hash:
     md5: 7e9ac3faeebdbd7b53b462c41891e7f7
@@ -6924,12 +6700,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    certifi: ''
-    sniffio: ''
     anyio: ''
+    certifi: ''
+    httpcore: 1.*
     idna: ''
     python: '>=3.8'
-    httpcore: 1.*
+    sniffio: ''
   url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
   hash:
     md5: 7e9ac3faeebdbd7b53b462c41891e7f7
@@ -7220,8 +6996,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     importlib_resources: '>=6.4.5,<6.4.6.0a0'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.5-pyhd8ed1ab_0.conda
   hash:
     md5: 67f4772681cf86652f3e2261794cf045
@@ -7233,8 +7009,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     importlib_resources: '>=6.4.5,<6.4.6.0a0'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.5-pyhd8ed1ab_0.conda
   hash:
     md5: 67f4772681cf86652f3e2261794cf045
@@ -7408,20 +7184,20 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
-    psutil: ''
-    nest-asyncio: ''
     __osx: ''
     appnope: ''
-    python: '>=3.8'
-    tornado: '>=6.1'
+    comm: '>=0.1.1'
+    debugpy: '>=1.6.5'
+    ipython: '>=7.23.1'
     jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
-    ipython: '>=7.23.1'
     matplotlib-inline: '>=0.1'
-    debugpy: '>=1.6.5'
+    nest-asyncio: ''
+    packaging: ''
+    psutil: ''
+    python: '>=3.8'
     pyzmq: '>=24'
-    comm: '>=0.1.1'
+    tornado: '>=6.1'
     traitlets: '>=5.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
   hash:
@@ -7434,19 +7210,19 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
-    psutil: ''
     __win: ''
-    nest-asyncio: ''
-    python: '>=3.8'
-    tornado: '>=6.1'
+    comm: '>=0.1.1'
+    debugpy: '>=1.6.5'
+    ipython: '>=7.23.1'
     jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
-    ipython: '>=7.23.1'
     matplotlib-inline: '>=0.1'
-    debugpy: '>=1.6.5'
+    nest-asyncio: ''
+    packaging: ''
+    psutil: ''
+    python: '>=3.8'
     pyzmq: '>=24'
-    comm: '>=0.1.1'
+    tornado: '>=6.1'
     traitlets: '>=5.4.0'
   url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
   hash:
@@ -7508,20 +7284,20 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing_extensions: ''
-    decorator: ''
     __osx: ''
-    matplotlib-inline: ''
-    stack_data: ''
-    pickleshare: ''
     appnope: ''
     backcall: ''
-    python: '>=3.8'
-    pygments: '>=2.4.0'
+    decorator: ''
     jedi: '>=0.16'
-    traitlets: '>=5'
+    matplotlib-inline: ''
     pexpect: '>4.3'
+    pickleshare: ''
     prompt_toolkit: '>=3.0.30,<3.1.0,!=3.0.37'
+    pygments: '>=2.4.0'
+    python: '>=3.8'
+    stack_data: ''
+    traitlets: '>=5'
+    typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.12.2-pyhd1c38e8_0.conda
   hash:
     md5: acc618532cbc899f5721cc96407b16cc
@@ -7533,19 +7309,19 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    typing_extensions: ''
     __win: ''
+    backcall: ''
     colorama: ''
     decorator: ''
-    matplotlib-inline: ''
-    stack_data: ''
-    pickleshare: ''
-    backcall: ''
-    python: '>=3.8'
-    pygments: '>=2.4.0'
     jedi: '>=0.16'
-    traitlets: '>=5'
+    matplotlib-inline: ''
+    pickleshare: ''
     prompt_toolkit: '>=3.0.30,<3.1.0,!=3.0.37'
+    pygments: '>=2.4.0'
+    python: '>=3.8'
+    stack_data: ''
+    traitlets: '>=5'
+    typing_extensions: ''
   url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.12.2-pyh08f2357_0.conda
   hash:
     md5: f289f9dc26526b8bd9f5845486f53a4d
@@ -7583,8 +7359,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     arrow: '>=0.15.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 4cb68948e0b8429534380243d063a27a
@@ -7596,8 +7372,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     arrow: '>=0.15.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 4cb68948e0b8429534380243d063a27a
@@ -7651,8 +7427,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
     parso: '>=0.8.3,<0.9.0'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
   hash:
     md5: 81a3be0b2023e1ea8555781f0ad904a2
@@ -7664,8 +7440,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6'
     parso: '>=0.8.3,<0.9.0'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
   hash:
     md5: 81a3be0b2023e1ea8555781f0ad904a2
@@ -7703,8 +7479,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     markupsafe: '>=2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
   hash:
     md5: 7b86ecb7d3557821c649b3c31e3eb9f2
@@ -7716,8 +7492,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     markupsafe: '>=2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
   hash:
     md5: 7b86ecb7d3557821c649b3c31e3eb9f2
@@ -7755,8 +7531,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: ''
     python: '>=3.8'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
   hash:
     md5: 25df261d4523d9f9783bcdb7208d872f
@@ -7768,8 +7544,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: ''
     python: '>=3.8'
+    setuptools: ''
   url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
   hash:
     md5: 25df261d4523d9f9783bcdb7208d872f
@@ -8049,11 +7825,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     attrs: '>=22.2.0'
     importlib_resources: '>=1.4.0'
-    pkgutil-resolve-name: '>=1.3.10'
     jsonschema-specifications: '>=2023.03.6'
+    pkgutil-resolve-name: '>=1.3.10'
+    python: '>=3.8'
     referencing: '>=0.28.4'
     rpds-py: '>=0.7.1'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
@@ -8067,11 +7843,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     attrs: '>=22.2.0'
     importlib_resources: '>=1.4.0'
-    pkgutil-resolve-name: '>=1.3.10'
     jsonschema-specifications: '>=2023.03.6'
+    pkgutil-resolve-name: '>=1.3.10'
+    python: '>=3.8'
     referencing: '>=0.28.4'
     rpds-py: '>=0.7.1'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
@@ -8177,14 +7953,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    idna: ''
-    rfc3339-validator: ''
-    uri-template: ''
     fqdn: ''
+    idna: ''
     isoduration: ''
     jsonpointer: '>1.13'
-    rfc3986-validator: '>0.1.0'
     jsonschema: '>=4.23.0,<4.23.1.0a0'
+    rfc3339-validator: ''
+    rfc3986-validator: '>0.1.0'
+    uri-template: ''
     webcolors: '>=24.6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_1.conda
   hash:
@@ -8197,14 +7973,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    idna: ''
-    rfc3339-validator: ''
-    uri-template: ''
     fqdn: ''
+    idna: ''
     isoduration: ''
     jsonpointer: '>1.13'
-    rfc3986-validator: '>0.1.0'
     jsonschema: '>=4.23.0,<4.23.1.0a0'
+    rfc3339-validator: ''
+    rfc3986-validator: '>0.1.0'
+    uri-template: ''
     webcolors: '>=24.6.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_1.conda
   hash:
@@ -8245,9 +8021,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.1.2'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
   hash:
     md5: 885867f6adab3d7ecdf8ab6ca0785f51
@@ -8259,9 +8035,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     importlib-metadata: '>=4.8.3'
     jupyter_server: '>=1.1.2'
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
   hash:
     md5: 885867f6adab3d7ecdf8ab6ca0785f51
@@ -8309,13 +8085,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    importlib-metadata: '>=4.8.3'
+    jupyter_core: '>=4.12,!=5.0.*'
     python: '>=3.8'
     python-dateutil: '>=2.8.2'
-    jupyter_core: '>=4.12,!=5.0.*'
-    importlib-metadata: '>=4.8.3'
-    traitlets: '>=5.3'
-    tornado: '>=6.2'
     pyzmq: '>=23.0'
+    tornado: '>=6.2'
+    traitlets: '>=5.3'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_0.conda
   hash:
     md5: a14218cfb29662b4a19ceb04e93e298e
@@ -8327,13 +8103,13 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    importlib-metadata: '>=4.8.3'
+    jupyter_core: '>=4.12,!=5.0.*'
     python: '>=3.8'
     python-dateutil: '>=2.8.2'
-    jupyter_core: '>=4.12,!=5.0.*'
-    importlib-metadata: '>=4.8.3'
-    traitlets: '>=5.3'
-    tornado: '>=6.2'
     pyzmq: '>=23.0'
+    tornado: '>=6.2'
+    traitlets: '>=5.3'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_0.conda
   hash:
     md5: a14218cfb29662b4a19ceb04e93e298e
@@ -8341,7 +8117,7 @@ package:
   category: main
   optional: false
 - name: jupyter_core
-  version: 5.7.2
+  version: 5.8.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -8349,14 +8125,14 @@ package:
     platformdirs: '>=2.5'
     python: '>=3.8'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.8.1-pyh31011fe_0.conda
   hash:
-    md5: 0a2980dada0dd7fd0998f0342308b1b1
-    sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
+    md5: b7d89d860ebcda28a5303526cdee68ab
+    sha256: 56a7a7e907f15cca8c4f9b0c99488276d4cb10821d2d15df9245662184872e81
   category: main
   optional: false
 - name: jupyter_core
-  version: 5.7.2
+  version: 5.8.1
   manager: conda
   platform: osx-64
   dependencies:
@@ -8364,25 +8140,25 @@ package:
     platformdirs: '>=2.5'
     python: '>=3.8'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.8.1-pyh31011fe_0.conda
   hash:
-    md5: 0a2980dada0dd7fd0998f0342308b1b1
-    sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
+    md5: b7d89d860ebcda28a5303526cdee68ab
+    sha256: 56a7a7e907f15cca8c4f9b0c99488276d4cb10821d2d15df9245662184872e81
   category: main
   optional: false
 - name: jupyter_core
-  version: 5.7.2
+  version: 5.8.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __unix: ''
+    platformdirs: '>=2.5'
     python: '>=3.8'
     traitlets: '>=5.3'
-    platformdirs: '>=2.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.8.1-pyh31011fe_0.conda
   hash:
-    md5: 0a2980dada0dd7fd0998f0342308b1b1
-    sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
+    md5: b7d89d860ebcda28a5303526cdee68ab
+    sha256: 56a7a7e907f15cca8c4f9b0c99488276d4cb10821d2d15df9245662184872e81
   category: main
   optional: false
 - name: jupyter_core
@@ -8444,14 +8220,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    jsonschema-with-format-nongpl: '>=4.18.0'
+    python: '>=3.8'
+    python-json-logger: '>=2.0.4'
+    pyyaml: '>=5.3'
     referencing: ''
     rfc3339-validator: ''
-    python: '>=3.8'
-    pyyaml: '>=5.3'
     rfc3986-validator: '>=0.1.1'
     traitlets: '>=5.3'
-    python-json-logger: '>=2.0.4'
-    jsonschema-with-format-nongpl: '>=4.18.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
   hash:
     md5: ed45423c41b3da15ea1df39b1f80c2ca
@@ -8463,14 +8239,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    jsonschema-with-format-nongpl: '>=4.18.0'
+    python: '>=3.8'
+    python-json-logger: '>=2.0.4'
+    pyyaml: '>=5.3'
     referencing: ''
     rfc3339-validator: ''
-    python: '>=3.8'
-    pyyaml: '>=5.3'
     rfc3986-validator: '>=0.1.1'
     traitlets: '>=5.3'
-    python-json-logger: '>=2.0.4'
-    jsonschema-with-format-nongpl: '>=4.18.0'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
   hash:
     md5: ed45423c41b3da15ea1df39b1f80c2ca
@@ -8542,25 +8318,25 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
-    jinja2: ''
-    prometheus_client: ''
-    websocket-client: ''
-    argon2-cffi: ''
-    send2trash: ''
-    overrides: ''
-    jupyter_server_terminals: ''
-    python: '>=3.8'
-    terminado: '>=0.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    tornado: '>=6.2.0'
-    pyzmq: '>=24'
-    nbconvert-core: '>=6.4.4'
-    jupyter_client: '>=7.4.4'
     anyio: '>=3.1.0,<4'
-    nbformat: '>=5.3.0'
-    traitlets: '>=5.6.0'
+    argon2-cffi: ''
+    jinja2: ''
+    jupyter_client: '>=7.4.4'
+    jupyter_core: '>=4.12,!=5.0.*'
     jupyter_events: '>=0.4.0'
+    jupyter_server_terminals: ''
+    nbconvert-core: '>=6.4.4'
+    nbformat: '>=5.3.0'
+    overrides: ''
+    packaging: ''
+    prometheus_client: ''
+    python: '>=3.8'
+    pyzmq: '>=24'
+    send2trash: ''
+    terminado: '>=0.8.3'
+    tornado: '>=6.2.0'
+    traitlets: '>=5.6.0'
+    websocket-client: ''
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.7.0-pyhd8ed1ab_0.conda
   hash:
     md5: 7488cd1f4d35a2af96faa765b7e5b2f0
@@ -8572,24 +8348,24 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    terminado: '>=0.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    tornado: '>=6.2.0'
-    jinja2: '>=3.0.3'
-    packaging: '>=22.0'
-    pyzmq: '>=24'
-    nbconvert-core: '>=6.4.4'
-    jupyter_client: '>=7.4.4'
-    nbformat: '>=5.3.0'
-    traitlets: '>=5.6.0'
     anyio: '>=3.1.0'
-    send2trash: '>=1.8.2'
-    jupyter_events: '>=0.9.0'
     argon2-cffi: '>=21.1'
+    jinja2: '>=3.0.3'
+    jupyter_client: '>=7.4.4'
+    jupyter_core: '>=4.12,!=5.0.*'
+    jupyter_events: '>=0.9.0'
     jupyter_server_terminals: '>=0.4.4'
+    nbconvert-core: '>=6.4.4'
+    nbformat: '>=5.3.0'
     overrides: '>=5.0'
+    packaging: '>=22.0'
     prometheus_client: '>=0.9'
+    python: '>=3.8'
+    pyzmq: '>=24'
+    send2trash: '>=1.8.2'
+    terminado: '>=0.8.3'
+    tornado: '>=6.2.0'
+    traitlets: '>=5.6.0'
     websocket-client: '>=1.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
   hash:
@@ -8710,23 +8486,23 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
-    traitlets: ''
-    jupyter_core: ''
-    python: '>=3.8'
-    tornado: '>=6.2.0'
-    tomli: '>=1.2.2'
-    jinja2: '>=3.0.3'
-    jupyter_server: '>=2.4.0,<3'
-    importlib_metadata: '>=4.8.3'
-    httpx: '>=0.25.0'
-    jupyter-lsp: '>=2.0.0'
     async-lru: '>=1.0.0'
-    notebook-shim: '>=0.2'
+    httpx: '>=0.25.0'
+    importlib_metadata: '>=4.8.3'
     importlib_resources: '>=1.4'
-    setuptools: '>=40.1.0'
-    jupyterlab_server: '>=2.27.1,<3'
     ipykernel: '>=6.5.0'
+    jinja2: '>=3.0.3'
+    jupyter-lsp: '>=2.0.0'
+    jupyter_core: ''
+    jupyter_server: '>=2.4.0,<3'
+    jupyterlab_server: '>=2.27.1,<3'
+    notebook-shim: '>=0.2'
+    packaging: ''
+    python: '>=3.8'
+    setuptools: '>=40.1.0'
+    tomli: '>=1.2.2'
+    tornado: '>=6.2.0'
+    traitlets: ''
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.2.5-pyhd8ed1ab_0.conda
   hash:
     md5: 594762eddc55b82feac6097165a88e3c
@@ -8738,23 +8514,23 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
-    traitlets: ''
-    jupyter_core: ''
-    python: '>=3.8'
-    tornado: '>=6.2.0'
-    tomli: '>=1.2.2'
-    jinja2: '>=3.0.3'
-    jupyter_server: '>=2.4.0,<3'
-    importlib_metadata: '>=4.8.3'
-    httpx: '>=0.25.0'
-    jupyter-lsp: '>=2.0.0'
     async-lru: '>=1.0.0'
-    notebook-shim: '>=0.2'
+    httpx: '>=0.25.0'
+    importlib_metadata: '>=4.8.3'
     importlib_resources: '>=1.4'
-    setuptools: '>=40.1.0'
-    jupyterlab_server: '>=2.27.1,<3'
     ipykernel: '>=6.5.0'
+    jinja2: '>=3.0.3'
+    jupyter-lsp: '>=2.0.0'
+    jupyter_core: ''
+    jupyter_server: '>=2.4.0,<3'
+    jupyterlab_server: '>=2.27.1,<3'
+    notebook-shim: '>=0.2'
+    packaging: ''
+    python: '>=3.8'
+    setuptools: '>=40.1.0'
+    tomli: '>=1.2.2'
+    tornado: '>=6.2.0'
+    traitlets: ''
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.2.5-pyhd8ed1ab_0.conda
   hash:
     md5: 594762eddc55b82feac6097165a88e3c
@@ -8792,8 +8568,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     pygments: '>=2.4.1,<3'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
   hash:
     md5: afcd1b53bcac8844540358e33f33d28f
@@ -8805,8 +8581,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     pygments: '>=2.4.1,<3'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
   hash:
     md5: afcd1b53bcac8844540358e33f33d28f
@@ -8858,15 +8634,15 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    packaging: '>=21.3'
-    jinja2: '>=3.0.3'
+    babel: '>=2.10'
     importlib-metadata: '>=4.8.3'
-    requests: '>=2.31'
+    jinja2: '>=3.0.3'
+    json5: '>=0.9.0'
     jsonschema: '>=4.18'
     jupyter_server: '>=1.21,<3'
-    babel: '>=2.10'
-    json5: '>=0.9.0'
+    packaging: '>=21.3'
+    python: '>=3.8'
+    requests: '>=2.31'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
   hash:
     md5: af8239bf1ba7e8c69b689f780f653488
@@ -8878,15 +8654,15 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    packaging: '>=21.3'
-    jinja2: '>=3.0.3'
+    babel: '>=2.10'
     importlib-metadata: '>=4.8.3'
-    requests: '>=2.31'
+    jinja2: '>=3.0.3'
+    json5: '>=0.9.0'
     jsonschema: '>=4.18'
     jupyter_server: '>=1.21,<3'
-    babel: '>=2.10'
-    json5: '>=0.9.0'
+    packaging: '>=21.3'
+    python: '>=3.8'
+    requests: '>=2.31'
   url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
   hash:
     md5: af8239bf1ba7e8c69b689f780f653488
@@ -9390,9 +9166,9 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgfortran5: '>=13.3.0'
-    libgfortran: ''
     libgcc: '>=13'
+    libgfortran: ''
+    libgfortran5: '>=13.3.0'
     libsuitesparseconfig: '>=7.10.1,<8.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libamd-3.3.3-h456b2da_7100101.conda
   hash:
@@ -9405,9 +9181,9 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.13'
     libgfortran: '>=5'
     libgfortran5: '>=13.2.0'
-    __osx: '>=10.13'
     libsuitesparseconfig: '>=7.10.1,<8.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-64/libamd-3.3.3-ha5840a7_7100102.conda
   hash:
@@ -9560,43 +9336,43 @@ package:
   category: main
   optional: false
 - name: libasprintf
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.23.1-h8e693c7_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.24.1-h8e693c7_0.conda
   hash:
-    md5: 988f4937281a66ca19d1adb3b5e3f859
-    sha256: 13b863584fccbb9089de73a2442e540703ce4873e4719c9d98c98e4a8e12f9d1
+    md5: 57566a81dd1e5aa3d98ac7582e8bfe03
+    sha256: e30733a729eb6efd9cb316db0202897c882d46f6c20a0e647b4de8ec921b7218
   category: main
   optional: false
 - name: libasprintf
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     libcxx: '>=18'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.23.1-h27064b9_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.24.1-h27064b9_0.conda
   hash:
-    md5: 43e1d9e1712208ac61941a513259248d
-    sha256: d6a4fbf497040ab4733c5dc65dd273ed6fa827ce6e67fd12abbe08c3cc3e192e
+    md5: 9d7c96ed1ebdf2f180b20d3e09a4c694
+    sha256: 86febbb2cc53b0978cb22057da2e9dc8f07ffe96305148d011c241c3eae668d0
   category: main
   optional: false
 - name: libasprintf
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=18'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.23.1-h493aca8_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.24.1-h493aca8_0.conda
   hash:
-    md5: baf9e4423f10a15ca7eab26480007639
-    sha256: 2b27d2ede7867fd362f94644aac1d7fb9af7f7fc3f122cb014647b47ffd402a4
+    md5: b5a77d2b7c2013b3b1ffce193764302f
+    sha256: 54293ab2ce43085ac424dc62804fd4d7ec62cce404a77f0c99a9a48857bca0a9
   category: main
   optional: false
 - name: libasprintf
@@ -9611,43 +9387,43 @@ package:
   category: main
   optional: false
 - name: libasprintf-devel
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libasprintf: 0.23.1
+    libasprintf: 0.24.1
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.23.1-h8e693c7_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.24.1-h8e693c7_0.conda
   hash:
-    md5: 2827e722a963b779ce878ef9b5474534
-    sha256: b05a859fe5a2b43574f3a5d93552061232b92d17017b27ecab1eccca1dbb2fe4
+    md5: 8f66ed2e34507b7ae44afa31c3e4ec79
+    sha256: ccbfc465456133042eea3e8d69bae009893f57a47a786f772c0af382bda7ad99
   category: main
   optional: false
 - name: libasprintf-devel
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libasprintf: 0.23.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-devel-0.23.1-h27064b9_0.conda
+    libasprintf: 0.24.1
+  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-devel-0.24.1-h27064b9_0.conda
   hash:
-    md5: 85b6f23aab6898c44f477f354c675721
-    sha256: 7962374bc3052db086277fd7e83fd3b05b01a66aa0d7e75c96248b35bee9277e
+    md5: 9504ed22ac4f9b0bbe7cab188c85aa2e
+    sha256: d4b578dec06a63278152c2eaae034f595083b23773638220cb2f870cc88cf6c7
   category: main
   optional: false
 - name: libasprintf-devel
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libasprintf: 0.23.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-devel-0.23.1-h493aca8_0.conda
+    libasprintf: 0.24.1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-devel-0.24.1-h493aca8_0.conda
   hash:
-    md5: 13d4d79418eb3137fc94fe61e9e572e7
-    sha256: 25999d3c78270440e7e9e06c2e6f4a2e1ac11d2df84ac7b24280c6f530eed06f
+    md5: ae1153389db4100dc7f6f4f50facf6bc
+    sha256: 0ebda4d9d20b1fb43a9b7cf38e260c92469000300b6abe796e2a65f3e1257657
   category: main
   optional: false
 - name: libasprintf-devel
@@ -9867,8 +9643,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc: '>=13'
     __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     libsuitesparseconfig: '>=7.10.1,<8.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libbtf-2.3.2-hf02c80a_7100101.conda
   hash:
@@ -9907,8 +9683,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc: '>=13'
     __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     libsuitesparseconfig: '>=7.10.1,<8.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libcamd-3.3.3-hf02c80a_7100101.conda
   hash:
@@ -10008,8 +9784,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc: '>=13'
     __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     libsuitesparseconfig: '>=7.10.1,<8.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libccolamd-3.3.4-hf02c80a_7100101.conda
   hash:
@@ -10048,17 +9824,17 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc: '>=13'
-    libstdcxx: '>=13'
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-    liblapack: '>=3.9.0,<4.0a0'
-    libcolamd: '>=3.3.4,<4.0a0'
     libamd: '>=3.3.3,<4.0a0'
-    libsuitesparseconfig: '>=7.10.1,<8.0a0'
-    libccolamd: '>=3.3.4,<4.0a0'
     libblas: '>=3.9.0,<4.0a0'
     libcamd: '>=3.3.3,<4.0a0'
+    libccolamd: '>=3.3.4,<4.0a0'
+    libcolamd: '>=3.3.4,<4.0a0'
+    libgcc: '>=13'
+    liblapack: '>=3.9.0,<4.0a0'
+    libstdcxx: '>=13'
+    libsuitesparseconfig: '>=7.10.1,<8.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libcholmod-5.3.1-h9cf07ce_7100101.conda
   hash:
     md5: f51e24ce110ae24c92074736a308e47e
@@ -10070,16 +9846,16 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=18'
     __osx: '>=10.13'
-    llvm-openmp: '>=18.1.8'
+    libamd: '>=3.3.3,<4.0a0'
     libblas: '>=3.9.0,<4.0a0'
     libcamd: '>=3.3.3,<4.0a0'
-    libcolamd: '>=3.3.4,<4.0a0'
-    libsuitesparseconfig: '>=7.10.1,<8.0a0'
-    libamd: '>=3.3.3,<4.0a0'
     libccolamd: '>=3.3.4,<4.0a0'
+    libcolamd: '>=3.3.4,<4.0a0'
+    libcxx: '>=18'
     liblapack: '>=3.9.0,<4.0a0'
+    libsuitesparseconfig: '>=7.10.1,<8.0a0'
+    llvm-openmp: '>=18.1.8'
   url: https://conda.anaconda.org/conda-forge/osx-64/libcholmod-5.3.1-h7ea7d7c_7100102.conda
   hash:
     md5: fec9cd11025ca7b0c7a58f4d88036ba8
@@ -10091,16 +9867,16 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=18'
     __osx: '>=11.0'
-    llvm-openmp: '>=18.1.8'
-    libccolamd: '>=3.3.4,<4.0a0'
     libamd: '>=3.3.3,<4.0a0'
-    libcamd: '>=3.3.3,<4.0a0'
-    libsuitesparseconfig: '>=7.10.1,<8.0a0'
-    liblapack: '>=3.9.0,<4.0a0'
-    libcolamd: '>=3.3.4,<4.0a0'
     libblas: '>=3.9.0,<4.0a0'
+    libcamd: '>=3.3.3,<4.0a0'
+    libccolamd: '>=3.3.4,<4.0a0'
+    libcolamd: '>=3.3.4,<4.0a0'
+    libcxx: '>=18'
+    liblapack: '>=3.9.0,<4.0a0'
+    libsuitesparseconfig: '>=7.10.1,<8.0a0'
+    llvm-openmp: '>=18.1.8'
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libcholmod-5.3.1-hbba04d7_7100102.conda
   hash:
     md5: a780c27386527ac7fe7526415a3b9b23
@@ -10217,8 +9993,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc: '>=13'
     __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
     libsuitesparseconfig: '>=7.10.1,<8.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libcolamd-3.3.4-hf02c80a_7100101.conda
   hash:
@@ -10392,8 +10168,8 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
     _openmp_mutex: '>=4.5'
+    libgcc: '>=13'
     libsuitesparseconfig: '>=7.10.1,<8.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libcxsparse-4.4.1-hf02c80a_7100101.conda
   hash:
@@ -10407,8 +10183,8 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    llvm-openmp: '>=18.1.8'
     libsuitesparseconfig: '>=7.10.1,<8.0a0'
+    llvm-openmp: '>=18.1.8'
   url: https://conda.anaconda.org/conda-forge/osx-64/libcxsparse-4.4.1-h3868ee3_7100102.conda
   hash:
     md5: acfddd738ba2d4e19738434f13800842
@@ -10421,8 +10197,8 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    llvm-openmp: '>=18.1.8'
     libsuitesparseconfig: '>=7.10.1,<8.0a0'
+    llvm-openmp: '>=18.1.8'
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxsparse-4.4.1-h9e79f82_7100102.conda
   hash:
     md5: d3b711fc46f75a04e71738d3e2c4fdc9
@@ -10430,27 +10206,27 @@ package:
   category: main
   optional: false
 - name: libcxx
-  version: 20.1.3
+  version: 20.1.6
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-20.1.3-hf95d169_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-20.1.6-hf95d169_0.conda
   hash:
-    md5: 022f109787a9624301ddbeb39519ff13
-    sha256: a4b493e0f76b20ff14e0f1f93c92882663c4f23c4488d8de3f6bbf1311b9c41e
+    md5: 460934df319a215557816480e9ea78cf
+    sha256: fbc7a8ef613669f3133bb2b0bc5b36f4c51987bb74769b018377fac96610863b
   category: main
   optional: false
 - name: libcxx
-  version: 20.1.3
+  version: 20.1.6
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.3-ha82da77_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.6-ha82da77_0.conda
   hash:
-    md5: 379db9caa727cab4d3a6c4327e4e7053
-    sha256: aa45cf608430e713575ef4193e4c0bcdfd7972db51f1c3af2fece26c173f5e67
+    md5: 95c1830841844ef54e07efed1654b47f
+    sha256: b74ec832ec05571f8747c9bd5f96b93d76489909b4f6f37d99d576dc955f21e9
   category: main
   optional: false
 - name: libcxx-devel
@@ -10545,9 +10321,9 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    ncurses: '>=6.5,<7.0a0'
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
+    ncurses: '>=6.5,<7.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
   hash:
     md5: c277e0a4d549b03ac1e9d6cbbe3d017b
@@ -10559,8 +10335,8 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    ncurses: '>=6.5,<7.0a0'
     __osx: '>=10.13'
+    ncurses: '>=6.5,<7.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20250104-pl5321ha958ccf_0.conda
   hash:
     md5: 1f4ed31220402fcddc083b4bff406868
@@ -10572,8 +10348,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    ncurses: '>=6.5,<7.0a0'
     __osx: '>=11.0'
+    ncurses: '>=6.5,<7.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
   hash:
     md5: 44083d2d2c2025afca315c7a172eab2b
@@ -10891,85 +10667,85 @@ package:
   category: main
   optional: false
 - name: libgcc
-  version: 14.2.0
+  version: 15.1.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.2.0-h767d61c_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
   hash:
-    md5: ef504d1acbd74b7cc6849ef8af47dd03
-    sha256: 3a572d031cb86deb541d15c1875aaa097baefc0c580b54dc61f5edab99215792
+    md5: ea8ac52380885ed41c1baa8f1d6d2b93
+    sha256: 0024f9ab34c09629621aefd8603ef77bf9d708129b0dd79029e502c39ffc2195
   category: main
   optional: false
 - name: libgcc-ng
-  version: 14.2.0
+  version: 15.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc: 14.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.2.0-h69a702a_2.conda
+    libgcc: 15.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_2.conda
   hash:
-    md5: a2222a6ada71fb478682efe483ce0f92
-    sha256: fb7558c328b38b2f9d2e412c48da7890e7721ba018d733ebdfea57280df01904
+    md5: ddca86c7040dd0e73b2b69bd7833d225
+    sha256: 0ab5421a89f090f3aa33841036bb3af4ed85e1f91315b528a9d75fab9aad51ae
   category: main
   optional: false
 - name: libgcrypt
-  version: 1.11.0
+  version: 1.11.1
   manager: conda
   platform: linux-64
   dependencies:
-    libgcrypt-devel: 1.11.0
-    libgcrypt-lib: 1.11.0
-    libgcrypt-tools: 1.11.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.11.0-ha770c72_2.conda
+    libgcrypt-devel: 1.11.1
+    libgcrypt-lib: 1.11.1
+    libgcrypt-tools: 1.11.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.11.1-ha770c72_0.conda
   hash:
-    md5: 92aaf7c067a5e63ac7f035bbd8864415
-    sha256: 2a6e2416db13816609541fd3fa680f1ff41dccb968ef22de2b0168e32e5902f2
+    md5: 6ae6fce1fc70ffc08191b124ece985e2
+    sha256: d2e6bb3b70d0aea67a56e80d38b21bffcc9a2b5dc7bc525f21481521101b5560
   category: main
   optional: false
 - name: libgcrypt-devel
-  version: 1.11.0
+  version: 1.11.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libgcrypt-lib: 1.11.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-devel-1.11.0-hb9d3cd8_2.conda
+    libgcrypt-lib: 1.11.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-devel-1.11.1-hb9d3cd8_0.conda
   hash:
-    md5: bf888b6a37286e9ae3749a114f878a6e
-    sha256: 5e066ca7a3dc6b44ecfee25b92a6941e38393f5ee82528b76ff299963f16c66a
+    md5: 0ca6814d958b87c6a1cfd45595bab974
+    sha256: 68fa82c08d10dc9ff4c32f0035f76038b53372313f68d4472dead7a4459763c3
   category: main
   optional: false
 - name: libgcrypt-lib
-  version: 1.11.0
+  version: 1.11.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libgpg-error: '>=1.51,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.0-hb9d3cd8_2.conda
+    libgpg-error: '>=1.55,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.1-hb9d3cd8_0.conda
   hash:
-    md5: e55712ff40a054134d51b89afca57dbc
-    sha256: ffc3602f9298da248786f46b00d0594d26a18feeb1b07ce88f3d7d61075e39e6
+    md5: 8504a291085c9fb809b66cabd5834307
+    sha256: dc9c7d7a6c0e6639deee6fde2efdc7e119e7739a6b229fa5f9049a449bae6109
   category: main
   optional: false
 - name: libgcrypt-tools
-  version: 1.11.0
+  version: 1.11.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libgcrypt-lib: 1.11.0
-    libgpg-error: '>=1.51,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-tools-1.11.0-hb9d3cd8_2.conda
+    libgcrypt-lib: 1.11.1
+    libgpg-error: '>=1.55,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-tools-1.11.1-hb9d3cd8_0.conda
   hash:
-    md5: 342389a8c9eef45fd8bb144b7522e28d
-    sha256: 6adba58f3f4eb3f2ba07d5f309748499989f71f55ba46acdf7f643f8da18ed9d
+    md5: 5430a506fc720a733645681173c1ef4c
+    sha256: 291588b3625a7209116232cceab1daabc076303903421756ef3c23dc6d58db1c
   category: main
   optional: false
 - name: libgdal
@@ -11176,44 +10952,44 @@ package:
   category: main
   optional: false
 - name: libgettextpo
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.23.1-h5888daf_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.24.1-h5888daf_0.conda
   hash:
-    md5: a09ce5decdef385bcce78c32809fa794
-    sha256: 190097140d9c16637aa516757d8087f17e8c22cc844c87288da64404b81ef43c
+    md5: 2ee6d71b72f75d50581f2f68e965efdb
+    sha256: 104f2341546e295d1136ab3010e81391bd3fd5be0f095db59266e8eba2082d37
   category: main
   optional: false
 - name: libgettextpo
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.23.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.23.1-h27064b9_0.conda
+    libiconv: '>=1.18,<2.0a0'
+    libintl: 0.24.1
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.24.1-h27064b9_0.conda
   hash:
-    md5: 352ffb2b7788775a65a32c018d972a8a
-    sha256: 52c2423df75223df4ebee991eb33e3827b9d360957211022246145b99c672dc5
+    md5: facba41133c6e10d9f67b1a12f66bd3a
+    sha256: e26e5bfe706c37cfbcbfe7598d3ebcdf4c39d89a9497e6c9bfe9069b0a18e3f3
   category: main
   optional: false
 - name: libgettextpo
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.23.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.23.1-h493aca8_0.conda
+    libiconv: '>=1.18,<2.0a0'
+    libintl: 0.24.1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.24.1-h493aca8_0.conda
   hash:
-    md5: 18ad77def4cb7326692033eded9c815d
-    sha256: 4dbd3f698d027330033f06778567eda5b985e2348ca92900083654a114ddd051
+    md5: 218a45f477876644cf75c7ed0b5158c7
+    sha256: 0f380fee5d5dc870b6b9d3134cca344965d68bbf454f6ac741907fee4cc3e07a
   category: main
   optional: false
 - name: libgettextpo
@@ -11230,47 +11006,47 @@ package:
   category: main
   optional: false
 - name: libgettextpo-devel
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libgettextpo: 0.23.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.23.1-h5888daf_0.conda
+    libgettextpo: 0.24.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.24.1-h5888daf_0.conda
   hash:
-    md5: 7a5d5c245a6807deab87558e9efd3ef0
-    sha256: 90f29ec7a7e2d758cb61459e643dcb54933dcf92194be6c29b0a1591fcbb163e
+    md5: 8f04c7aae6a46503bc36d1ed5abc8c7c
+    sha256: a9a0cba030778eb2944a1f235dba51e503b66f8be0ce6f55f745173a515c3644
   category: main
   optional: false
 - name: libgettextpo-devel
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libgettextpo: 0.23.1
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.23.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-devel-0.23.1-h27064b9_0.conda
+    libgettextpo: 0.24.1
+    libiconv: '>=1.18,<2.0a0'
+    libintl: 0.24.1
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-devel-0.24.1-h27064b9_0.conda
   hash:
-    md5: fea8af9c8a5d38b3b1b7f72dc3d7080a
-    sha256: b027dcc98ef20813c73e8aba8de7028ee0641cb0f7eec5f3b153fce4271669e0
+    md5: adf631df406cfd04909d7da784bfef5a
+    sha256: 774fbc023afcfe34ef218d8f72b678121c4e65b6fda4f9571a5dbc81775d07a0
   category: main
   optional: false
 - name: libgettextpo-devel
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libgettextpo: 0.23.1
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.23.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-devel-0.23.1-h493aca8_0.conda
+    libgettextpo: 0.24.1
+    libiconv: '>=1.18,<2.0a0'
+    libintl: 0.24.1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-devel-0.24.1-h493aca8_0.conda
   hash:
-    md5: e6f75805f4b533d449a5a6d60cbc9a71
-    sha256: 6031e57ba3c03ca34422b847b98fb70e697a5c10556c8d7b30410a96754c25d8
+    md5: 90c8817b50a32cc63bd2c4f85a6f4589
+    sha256: f1874034577a09d15486e10935ee6eb942a7ef2745b22e4c250b7904deff6e79
   category: main
   optional: false
 - name: libgettextpo-devel
@@ -11288,15 +11064,15 @@ package:
   category: main
   optional: false
 - name: libgfortran
-  version: 14.2.0
+  version: 15.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgfortran5: 14.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.2.0-h69a702a_2.conda
+    libgfortran5: 15.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_2.conda
   hash:
-    md5: fb54c4ea68b460c278d26eea89cfbcc3
-    sha256: e05263e8960da03c341650f2a3ffa4ccae4e111cb198e8933a2908125459e5a6
+    md5: f92e6e0a3c0c0c85561ef61aa59d555d
+    sha256: 914daa4f632b786827ea71b5e07cd00d25fc6e67789db2f830dc481eec660342
   category: main
   optional: false
 - name: libgfortran
@@ -11324,28 +11100,28 @@ package:
   category: main
   optional: false
 - name: libgfortran-ng
-  version: 14.2.0
+  version: 15.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgfortran: 14.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.2.0-h69a702a_2.conda
+    libgfortran: 15.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.1.0-h69a702a_2.conda
   hash:
-    md5: 4056c857af1a99ee50589a941059ec55
-    sha256: 688a5968852e677d2a64974c8869ffb120eac21997ced7d15c599f152ef6857e
+    md5: a483a87b71e974bb75d1b9413d4436dd
+    sha256: 0665170a98c8ec586352929d45a9c833c0dcdbead38b0b8f3af7a0deee2af755
   category: main
   optional: false
 - name: libgfortran5
-  version: 14.2.0
+  version: 15.1.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.2.0-hf1ad2bd_2.conda
+    libgcc: '>=15.1.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_2.conda
   hash:
-    md5: 556a4fdfac7287d349b8f09aba899693
-    sha256: c17b7cf3073a1f4e1f34d50872934fa326346e104d3c445abc1e62481ad6085c
+    md5: 01de444988ed960031dbe84cf4f9b1fc
+    sha256: be23750f3ca1a5cb3ada858c4f633effe777487d1ea35fddca04c0965c073350
   category: main
   optional: false
 - name: libgfortran5
@@ -11446,28 +11222,42 @@ package:
   category: main
   optional: false
 - name: libglu
-  version: 9.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=7.3.0'
-    libstdcxx-ng: '>=7.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-he1b5a44_1001.tar.bz2
-  hash:
-    md5: 8208602aec4826053c116552369a394c
-    sha256: 5bd76151994096908231712e1539bd18372bb66fedc1d28dfd36fe086e8f58e4
-  category: main
-  optional: false
-- name: libgomp
-  version: 14.2.0
+  version: 9.0.3
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.2.0-h767d61c_2.conda
+    libgcc: '>=13'
+    libopengl: '>=1.7.0,<2.0a0'
+    libstdcxx: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.3-h5888daf_1.conda
   hash:
-    md5: 06d02030237f4d5b3d9a7e7d348fe3c6
-    sha256: 1a3130e0b9267e781b89399580f3163632d59fe5b0142900d63052ab1a53490e
+    md5: 8422fcc9e5e172c91e99aef703b3ce65
+    sha256: a0105eb88f76073bbb30169312e797ed5449ebb4e964a756104d6e54633d17ef
+  category: main
+  optional: false
+- name: libglvnd
+  version: 1.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+  hash:
+    md5: 434ca7e50e40f4918ab701e3facd59a0
+    sha256: 1175f8a7a0c68b7f81962699751bb6574e6f07db4c9f72825f978e3016f46850
+  category: main
+  optional: false
+- name: libgomp
+  version: 15.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_2.conda
+  hash:
+    md5: fbe7d535ff9d3a168c148e07358cd5b1
+    sha256: 05fff3dc7e80579bc28de13b511baec281c4343d703c406aefd54389959154fb
   category: main
   optional: false
 - name: libgoogle-cloud
@@ -11546,17 +11336,17 @@ package:
   category: main
   optional: false
 - name: libgpg-error
-  version: '1.54'
+  version: '1.55'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.54-hbd13f7d_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.55-h3f2d84a_0.conda
   hash:
-    md5: 53fab32c797ccdb5bb7a4c147ea154d8
-    sha256: 6800627debbed15421bc211366df399ad8aa80ec9fb749c276e8bf5260ef1ec3
+    md5: 2bd47db5807daade8500ed7ca4c512a4
+    sha256: 697334de4786a1067ea86853e520c64dd72b11a05137f5b318d8a444007b5e60
   category: main
   optional: false
 - name: libgrpc
@@ -11765,29 +11555,29 @@ package:
   category: main
   optional: false
 - name: libintl
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libiconv: '>=1.17,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.23.1-h27064b9_0.conda
+    libiconv: '>=1.18,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.24.1-h27064b9_0.conda
   hash:
-    md5: 4182fe11073548596723d9cd2c23b1ac
-    sha256: 1bce54e6c76064032129ba138898a5b188d9415c533eb585f89d48b04e00e576
+    md5: b3f498d87404090f731cb6a474045150
+    sha256: f0a759b35784d5a31aeaf519f8f24019415321e62e52579a3ec854a413a1509d
   category: main
   optional: false
 - name: libintl
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libiconv: '>=1.17,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.23.1-h493aca8_0.conda
+    libiconv: '>=1.18,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.24.1-h493aca8_0.conda
   hash:
-    md5: 7b8faf3b5fc52744bda99c4cd1d6438d
-    sha256: 30d2a8a37070615a61777ce9317968b54c2197d04e9c6c2eea6cdb46e47f94dc
+    md5: 0dca9914f2722b773c863508723dfe6e
+    sha256: fb6d211d9e75e6becfbf339d255ea01f7bd3a61fe6237b3dad740de1b74b3b81
   category: main
   optional: false
 - name: libintl
@@ -11803,31 +11593,31 @@ package:
   category: main
   optional: false
 - name: libintl-devel
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.23.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.23.1-h27064b9_0.conda
+    libiconv: '>=1.18,<2.0a0'
+    libintl: 0.24.1
+  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.24.1-h27064b9_0.conda
   hash:
-    md5: 6d4a30603b01f15bb643e14a9807e46c
-    sha256: 2a2cfacee2c345f79866487921d222b17e93a826ac9a80b80901a41c0b094633
+    md5: 415f3453e007c6260c98be29ec67d693
+    sha256: 1e39c4c57cb77f0bab5f5738b6a8a807a00a65d8b42e778b2fb2c02b15cef71e
   category: main
   optional: false
 - name: libintl-devel
-  version: 0.23.1
+  version: 0.24.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libiconv: '>=1.17,<2.0a0'
-    libintl: 0.23.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.23.1-h493aca8_0.conda
+    libiconv: '>=1.18,<2.0a0'
+    libintl: 0.24.1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.24.1-h493aca8_0.conda
   hash:
-    md5: f9c6d5edc5951ef4010be8cbde9f12d4
-    sha256: 5db07fa57b8cb916784353aa035fbf32aa7ee2905e38a8e70b168160372833f0
+    md5: 42ce4a88aa2fd300aa128c9c599f9676
+    sha256: 5e71abebd1340f3051bcd441bbd23e97c65d6f1de1738b71aef455dde7253c65
   category: main
   optional: false
 - name: libintl-devel
@@ -11848,20 +11638,20 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc: '>=13'
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-    metis: '>=5.1.0,<5.1.1.0a0'
-    libcamd: '>=3.3.3,<4.0a0'
-    liblapack: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libsuitesparseconfig: '>=7.10.1,<8.0a0'
-    libcolamd: '>=3.3.4,<4.0a0'
     libamd: '>=3.3.3,<4.0a0'
-    libcholmod: '>=5.3.1,<6.0a0'
     libblas: '>=3.9.0,<4.0a0'
     libbtf: '>=2.3.2,<3.0a0'
+    libcamd: '>=3.3.3,<4.0a0'
+    libcblas: '>=3.9.0,<4.0a0'
     libccolamd: '>=3.3.4,<4.0a0'
+    libcholmod: '>=5.3.1,<6.0a0'
+    libcolamd: '>=3.3.4,<4.0a0'
+    libgcc: '>=13'
+    liblapack: '>=3.9.0,<4.0a0'
+    libsuitesparseconfig: '>=7.10.1,<8.0a0'
+    metis: '>=5.1.0,<5.1.1.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libklu-2.3.5-h95ff59c_7100101.conda
   hash:
     md5: efaa5e7dc6989363585fbb591480b256
@@ -11874,18 +11664,18 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
+    libamd: '>=3.3.3,<4.0a0'
+    libblas: '>=3.9.0,<4.0a0'
+    libbtf: '>=2.3.2,<3.0a0'
+    libcamd: '>=3.3.3,<4.0a0'
+    libcblas: '>=3.9.0,<4.0a0'
+    libccolamd: '>=3.3.4,<4.0a0'
+    libcholmod: '>=5.3.1,<6.0a0'
+    libcolamd: '>=3.3.4,<4.0a0'
+    liblapack: '>=3.9.0,<4.0a0'
+    libsuitesparseconfig: '>=7.10.1,<8.0a0'
     llvm-openmp: '>=18.1.8'
     metis: '>=5.1.0,<5.1.1.0a0'
-    libbtf: '>=2.3.2,<3.0a0'
-    libcholmod: '>=5.3.1,<6.0a0'
-    libsuitesparseconfig: '>=7.10.1,<8.0a0'
-    libamd: '>=3.3.3,<4.0a0'
-    libcolamd: '>=3.3.4,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libblas: '>=3.9.0,<4.0a0'
-    liblapack: '>=3.9.0,<4.0a0'
-    libcamd: '>=3.3.3,<4.0a0'
-    libccolamd: '>=3.3.4,<4.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-64/libklu-2.3.5-hc7f8671_7100102.conda
   hash:
     md5: f8f2969a094871051542a39670de0081
@@ -11898,17 +11688,17 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    llvm-openmp: '>=18.1.8'
-    libccolamd: '>=3.3.4,<4.0a0'
-    libcamd: '>=3.3.3,<4.0a0'
-    libsuitesparseconfig: '>=7.10.1,<8.0a0'
-    libcolamd: '>=3.3.4,<4.0a0'
-    libbtf: '>=2.3.2,<3.0a0'
     libamd: '>=3.3.3,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
     libblas: '>=3.9.0,<4.0a0'
+    libbtf: '>=2.3.2,<3.0a0'
+    libcamd: '>=3.3.3,<4.0a0'
+    libcblas: '>=3.9.0,<4.0a0'
+    libccolamd: '>=3.3.4,<4.0a0'
     libcholmod: '>=5.3.1,<6.0a0'
+    libcolamd: '>=3.3.4,<4.0a0'
     liblapack: '>=3.9.0,<4.0a0'
+    libsuitesparseconfig: '>=7.10.1,<8.0a0'
+    llvm-openmp: '>=18.1.8'
     metis: '>=5.1.0,<5.1.1.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libklu-2.3.5-h4370aa4_7100102.conda
   hash:
@@ -12159,10 +11949,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
   hash:
-    md5: 0e87378639676987af32fee53ba32258
-    sha256: f4f21dfc54b08d462f707b771ecce3fa9bc702a2a05b55654f64154f48b141ef
+    md5: 1a580f7796c7bf6393fddb8bbbde58dc
+    sha256: f2591c0069447bbe28d4d696b7fcb0c5bd0b4ac582769b89addbcf26fb3430d8
   category: main
   optional: false
 - name: liblzma
@@ -12171,10 +11961,10 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
   hash:
-    md5: 8e1197f652c67e87a9ece738d82cef4f
-    sha256: 3369b8ef0b544d17aebc530a687c0480051e825e8ffcd001b1a5f594fe276159
+    md5: 8468beea04b9065b9807fc8b9cdc5894
+    sha256: 7e22fd1bdb8bf4c2be93de2d4e718db5c548aa082af47a7430eb23192de6bb36
   category: main
   optional: false
 - name: liblzma
@@ -12183,10 +11973,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
   hash:
-    md5: ba24e6f25225fea3d5b6912e2ac562f8
-    sha256: 4291dde55ebe9868491dc29716b84ac3de21b8084cbd4d05c9eea79d206b8ab7
+    md5: d6df911d4564d77c4374b02552cb17d1
+    sha256: 0cb92a9e026e7bd4842f410a5c5c665c89b2eb97794ffddba519a626b8ce7285
   category: main
   optional: false
 - name: liblzma
@@ -12197,10 +11987,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
   hash:
-    md5: 8d5cb0016b645d6688e2ff57c5d51302
-    sha256: 1477e9bff05318f3129d37be0e64c76cce0973c4b8c73d13a467d0b7f03d157c
+    md5: c15148b2e18da456f5108ccb5e411446
+    sha256: 55764956eb9179b98de7cc0e55696f2eff8f7b83fc3ebff5e696ca358bca28cc
   category: main
   optional: false
 - name: liblzma-devel
@@ -12211,10 +12001,10 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     liblzma: 5.8.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.1-hb9d3cd8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.1-hb9d3cd8_2.conda
   hash:
-    md5: 8f456db836b4d3d00d3b6a6cc47009d8
-    sha256: 09738df1c1475cc7d35c4bf1062b8cdd4a110809aa49c240a4131e63609c974e
+    md5: f61edadbb301530bd65a32646bd81552
+    sha256: 329e66330a8f9cbb6a8d5995005478188eb4ba8a6b6391affa849744f4968492
   category: main
   optional: false
 - name: liblzma-devel
@@ -12224,10 +12014,10 @@ package:
   dependencies:
     __osx: '>=10.13'
     liblzma: 5.8.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-devel-5.8.1-hd471939_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-devel-5.8.1-hd471939_2.conda
   hash:
-    md5: 0ebd6c7640cc60f9e2939f1472704aa7
-    sha256: a1aa6d12c408fe99dab45dfe99627cdb7b0d08efd2c5e92dd879967a4298dbf2
+    md5: 2e16f5b4f6c92b96f6a346f98adc4e3e
+    sha256: a020ad9f1e27d4f7a522cbbb9613b99f64a5cc41f80caf62b9fdd1cf818acf18
   category: main
   optional: false
 - name: liblzma-devel
@@ -12237,10 +12027,10 @@ package:
   dependencies:
     __osx: '>=11.0'
     liblzma: 5.8.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.1-h39f12f2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-devel-5.8.1-h39f12f2_2.conda
   hash:
-    md5: 04d3b0bd4202147c9b54581931c075b4
-    sha256: c59b54ce0cb82800367b1070a56dfdd4e0ddc804a16eab2f3ecd7aa56b4cdb7a
+    md5: 1201137f1a5ec9556032ffc04dcdde8d
+    sha256: 974804430e24f0b00f3a48b67ec10c9f5441c9bb3d82cc0af51ba45b8a75a241
   category: main
   optional: false
 - name: liblzma-devel
@@ -12252,10 +12042,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/liblzma-devel-5.8.1-h2466b09_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/liblzma-devel-5.8.1-h2466b09_2.conda
   hash:
-    md5: 49e625c0a8617d41e45c8767ee6e10c0
-    sha256: a7eb016634ed90e6b252d631a5ba12c6d8fb8df7f2d8d558695f5bc11a642ad7
+    md5: 42c90c4941c59f1b9f8fab627ad8ae76
+    sha256: 1ccff927a2d768403bad85e36ca3e931d96890adb4f503e1780c3412dd1e1298
   category: main
   optional: false
 - name: libnetcdf
@@ -12425,11 +12215,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-h4ab18f5_0.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
   hash:
-    md5: 601bfb4b3c6f0b844443bb81a56651e0
-    sha256: 5eda3fe92b99b25dd4737226a9485078ab405672d9f621be75edcb68f1e9026d
+    md5: 68e52064ed3897463c0e958ab5c8f91b
+    sha256: ffb066ddf2e76953f92e06677021c73c85536098f1c21fcd15360dbc859e22e4
   category: main
   optional: false
 - name: libogg
@@ -12438,10 +12229,10 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libogg-1.3.5-hfdf4475_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libogg-1.3.5-he3325bb_1.conda
   hash:
-    md5: 7497372c91a31d3e8d64ce3f1a9632e8
-    sha256: bebf5797e2a278fd2094f2b0c29ccdfc51d400f4736701108a7e544a49705c64
+    md5: d0f30c7fe90d08e9bd9c13cd60be6400
+    sha256: 26691d40c70e83d3955a8daaee713aa7d087aa351c5a1f43786bbb0e871f29da
   category: main
   optional: false
 - name: libogg
@@ -12450,10 +12241,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.5-h99b78c6_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.5-h48c0fde_1.conda
   hash:
-    md5: 57b668b9b78dea2c08e44bb2385d57c0
-    sha256: 685f73b7241978007dfe0cecb9cae46c6a26d87d192b6f85a09eb65023c0b99e
+    md5: 29b8b11f6d7e6bd0e76c029dcf9dd024
+    sha256: 28bd1fe20fe43da105da41b95ac201e95a1616126f287985df8e86ddebd1c3d8
   category: main
   optional: false
 - name: libogg
@@ -12464,10 +12255,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_1.conda
   hash:
-    md5: 44a4d173e62c5ed6d715f18ae7c46b7a
-    sha256: fcffdf32c620569738b85c98ddd25e1c84c8add80cd732743d90d469b7b532bb
+    md5: b67ed8c9ca072695ff482e50d888a523
+    sha256: c63e5fb169dbd192aacdcee6e37235407f106b8ca9c9036942a25e0366cbc73c
   category: main
   optional: false
 - name: libopenblas
@@ -12512,13 +12303,26 @@ package:
     sha256: b112e0d500bc0314ea8d393efac3ab8c67857e5a2b345348c98e703ee92723e5
   category: main
   optional: false
+- name: libopengl
+  version: 1.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libglvnd: 1.7.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
+  hash:
+    md5: 7df50d44d4a14d6c31a2c54f2cd92157
+    sha256: 215086c108d80349e96051ad14131b751d17af3ed2cb5a34edd62fa89bfe8ead
+  category: main
+  optional: false
 - name: libopus
   version: 1.5.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc: '>=13'
     __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
   url: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.5.2-hd0c01bc_0.conda
   hash:
     md5: b64523fb87ac6f87f0790f324ad43046
@@ -12554,9 +12358,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-    ucrt: '>=10.0.20348.0'
   url: https://conda.anaconda.org/conda-forge/win-64/libopus-1.5.2-h2466b09_0.conda
   hash:
     md5: 67c18f2110921f6307a608050cd153f8
@@ -12568,12 +12372,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc: '>=13'
-    libstdcxx: '>=13'
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-    libsuitesparseconfig: '>=7.10.1,<8.0a0'
     libblas: '>=3.9.0,<4.0a0'
+    libgcc: '>=13'
+    libstdcxx: '>=13'
+    libsuitesparseconfig: '>=7.10.1,<8.0a0'
     libumfpack: '>=6.3.5,<7.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libparu-1.0.0-hc6afc67_7100101.conda
   hash:
@@ -12587,11 +12391,11 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libcxx: '>=18'
-    llvm-openmp: '>=18.1.8'
-    libumfpack: '>=6.3.5,<7.0a0'
-    libsuitesparseconfig: '>=7.10.1,<8.0a0'
     libblas: '>=3.9.0,<4.0a0'
+    libcxx: '>=18'
+    libsuitesparseconfig: '>=7.10.1,<8.0a0'
+    libumfpack: '>=6.3.5,<7.0a0'
+    llvm-openmp: '>=18.1.8'
   url: https://conda.anaconda.org/conda-forge/osx-64/libparu-1.0.0-hf1a04d7_7100102.conda
   hash:
     md5: 879ff76875e7dceef61b38aea3ede3a6
@@ -12603,12 +12407,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=18'
     __osx: '>=11.0'
-    llvm-openmp: '>=18.1.8'
+    libblas: '>=3.9.0,<4.0a0'
+    libcxx: '>=18'
     libsuitesparseconfig: '>=7.10.1,<8.0a0'
     libumfpack: '>=6.3.5,<7.0a0'
-    libblas: '>=3.9.0,<4.0a0'
+    llvm-openmp: '>=18.1.8'
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libparu-1.0.0-h317a14d_7100102.conda
   hash:
     md5: a4a9867ec265528a89b4759951957504
@@ -12676,10 +12480,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.47-had7236b_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.47-h7a4582a_0.conda
   hash:
-    md5: 7d717163d9dab337c65f2bf21a676b8f
-    sha256: cf8a594b697de103025dcae2c917ec9c100609caf7c917a94c64a683cb1db1ac
+    md5: ad620e92b82d2948bc019e029c574ebb
+    sha256: e12c46ca882080d901392ae45e0e5a1c96fc3e5acd5cd1a23c2632eb7f024f26
   category: main
   optional: false
 - name: libpq
@@ -12850,17 +12654,17 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    requests: ''
-    packaging: ''
-    jinja2: ''
-    geopandas: ''
     beautifulsoup4: ''
+    geopandas: ''
+    jinja2: ''
+    numpy: '>=1.3'
+    packaging: ''
+    pandas: '>=1.4'
     platformdirs: ''
     python: '>=3.8'
-    pandas: '>=1.4'
-    shapely: '>=2.0'
+    requests: ''
     scipy: '>=1.8'
-    numpy: '>=1.3'
+    shapely: '>=2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/libpysal-4.8.0-pyhd8ed1ab_1.conda
   hash:
     md5: ea5d04d8018c1f2ba75a1fd3c30e830b
@@ -12872,17 +12676,17 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    requests: ''
-    packaging: ''
-    jinja2: ''
-    geopandas: ''
     beautifulsoup4: ''
+    geopandas: ''
+    jinja2: ''
+    numpy: '>=1.3'
+    packaging: ''
+    pandas: '>=1.4'
     platformdirs: ''
     python: '>=3.8'
-    pandas: '>=1.4'
-    shapely: '>=2.0'
+    requests: ''
     scipy: '>=1.8'
-    numpy: '>=1.3'
+    shapely: '>=2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/libpysal-4.8.0-pyhd8ed1ab_1.conda
   hash:
     md5: ea5d04d8018c1f2ba75a1fd3c30e830b
@@ -13262,13 +13066,13 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc: '>=13'
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
+    gmp: '>=6.3.0,<7.0a0'
     libamd: '>=3.3.3,<4.0a0'
     libcolamd: '>=3.3.4,<4.0a0'
+    libgcc: '>=13'
     libsuitesparseconfig: '>=7.10.1,<8.0a0'
-    gmp: '>=6.3.0,<7.0a0'
     mpfr: '>=4.2.1,<5.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libspex-3.2.3-h9226d62_7100101.conda
   hash:
@@ -13282,12 +13086,12 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    llvm-openmp: '>=18.1.8'
-    libsuitesparseconfig: '>=7.10.1,<8.0a0'
-    mpfr: '>=4.2.1,<5.0a0'
-    libcolamd: '>=3.3.4,<4.0a0'
     gmp: '>=6.3.0,<7.0a0'
     libamd: '>=3.3.3,<4.0a0'
+    libcolamd: '>=3.3.4,<4.0a0'
+    libsuitesparseconfig: '>=7.10.1,<8.0a0'
+    llvm-openmp: '>=18.1.8'
+    mpfr: '>=4.2.1,<5.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-64/libspex-3.2.3-hc5c4b0d_7100102.conda
   hash:
     md5: e89ed2a1b8c7d5101049ea041e30763b
@@ -13300,12 +13104,12 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    llvm-openmp: '>=18.1.8'
-    libcolamd: '>=3.3.4,<4.0a0'
-    mpfr: '>=4.2.1,<5.0a0'
-    libsuitesparseconfig: '>=7.10.1,<8.0a0'
-    libamd: '>=3.3.3,<4.0a0'
     gmp: '>=6.3.0,<7.0a0'
+    libamd: '>=3.3.3,<4.0a0'
+    libcolamd: '>=3.3.4,<4.0a0'
+    libsuitesparseconfig: '>=7.10.1,<8.0a0'
+    llvm-openmp: '>=18.1.8'
+    mpfr: '>=4.2.1,<5.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libspex-3.2.3-h15d103f_7100102.conda
   hash:
     md5: 36b461a2ccf825c682fe8918b82c2f7a
@@ -13317,12 +13121,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc: '>=13'
-    libstdcxx: '>=13'
     __glibc: '>=2.17,<3.0.a0'
-    libcholmod: '>=5.3.1,<6.0a0'
     libblas: '>=3.9.0,<4.0a0'
+    libcholmod: '>=5.3.1,<6.0a0'
+    libgcc: '>=13'
     liblapack: '>=3.9.0,<4.0a0'
+    libstdcxx: '>=13'
     libsuitesparseconfig: '>=7.10.1,<8.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libspqr-4.3.4-h23b7119_7100101.conda
   hash:
@@ -13335,12 +13139,12 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=18'
     __osx: '>=10.13'
-    libsuitesparseconfig: '>=7.10.1,<8.0a0'
     libblas: '>=3.9.0,<4.0a0'
-    liblapack: '>=3.9.0,<4.0a0'
     libcholmod: '>=5.3.1,<6.0a0'
+    libcxx: '>=18'
+    liblapack: '>=3.9.0,<4.0a0'
+    libsuitesparseconfig: '>=7.10.1,<8.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-64/libspqr-4.3.4-h795628b_7100102.conda
   hash:
     md5: e8f29a760db892904186a4254050cdcf
@@ -13353,11 +13157,11 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=18'
-    libcholmod: '>=5.3.1,<6.0a0'
-    libsuitesparseconfig: '>=7.10.1,<8.0a0'
-    liblapack: '>=3.9.0,<4.0a0'
     libblas: '>=3.9.0,<4.0a0'
+    libcholmod: '>=5.3.1,<6.0a0'
+    libcxx: '>=18'
+    liblapack: '>=3.9.0,<4.0a0'
+    libsuitesparseconfig: '>=7.10.1,<8.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libspqr-4.3.4-h775d698_7100102.conda
   hash:
     md5: cbac21c5e5ffcd4bcee5dba052535565
@@ -13365,57 +13169,57 @@ package:
   category: main
   optional: false
 - name: libsqlite
-  version: 3.49.1
+  version: 3.50.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.49.1-hee588c1_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.1-hee588c1_0.conda
   hash:
-    md5: 962d6ac93c30b1dfc54c9cccafd1003e
-    sha256: a086289bf75c33adc1daed3f1422024504ffb5c3c8b3285c49f025c29708ed16
+    md5: 96a7e36bff29f1d0ddf5b771e0da373a
+    sha256: cd15ab1b9f0d53507e7ad7a01e52f6756ab3080bf623ab0e438973b6e4dba3c0
   category: main
   optional: false
 - name: libsqlite
-  version: 3.49.1
+  version: 3.50.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.49.1-hdb6dae5_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.50.1-hdb6dae5_0.conda
   hash:
-    md5: 1819e770584a7e83a81541d8253cbabe
-    sha256: 82695c9b16a702de615c8303387384c6ec5cf8b98e16458e5b1935b950e4ec38
+    md5: 00116248e7b4025ae01632472b300d29
+    sha256: 619fbc556a621beafc7ec712f16648ee30bf2d029b6d7aea2c84839fbb2b4e14
   category: main
   optional: false
 - name: libsqlite
-  version: 3.49.1
+  version: 3.50.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.49.1-h3f77e49_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.1-h3f77e49_0.conda
   hash:
-    md5: 3b1e330d775170ac46dff9a94c253bd0
-    sha256: 907a95f73623c343fc14785cbfefcb7a6b4f2bcf9294fcb295c121611c3a590d
+    md5: 73df23998b27dd6774d03db626d031d3
+    sha256: f39e22a00396c048dcfcb5d8c9dbedb2d69f06edcd8dba98b87f263eeb6d2049
   category: main
   optional: false
 - name: libsqlite
-  version: 3.49.1
+  version: 3.50.1
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.49.1-h67fdade_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.1-h67fdade_0.conda
   hash:
-    md5: b58b66d4ad1aaf1c2543cbbd6afb1a59
-    sha256: c092d42d00fd85cf609cc58574ba2b03c141af5762283f36f5dd445ef7c0f4fe
+    md5: 0e11a893eeeb46510520fd3fdd9c346a
+    sha256: 0dda5b3f21ad2c7e823f21b0e173194347fbfccb73a06ddc9366da1877020bda
   category: main
   optional: false
 - name: libssh2
@@ -13475,28 +13279,28 @@ package:
   category: main
   optional: false
 - name: libstdcxx
-  version: 14.2.0
+  version: 15.1.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: 14.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-h8f9b012_2.conda
+    libgcc: 15.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_2.conda
   hash:
-    md5: a78c856b6dc6bf4ea8daeb9beaaa3fb0
-    sha256: 8f5bd92e4a24e1d35ba015c5252e8f818898478cb3bc50bd8b12ab54707dc4da
+    md5: 1cb1c67961f6dd257eae9e9691b341aa
+    sha256: 6ae3d153e78f6069d503d9309f2cac6de5b93d067fc6433160a4c05226a5dad4
   category: main
   optional: false
 - name: libstdcxx-ng
-  version: 14.2.0
+  version: 15.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libstdcxx: 14.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_2.conda
+    libstdcxx: 15.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_2.conda
   hash:
-    md5: c75da67f045c2627f59e6fcb5f4e3a9b
-    sha256: e86f38b007cf97cc2c67cd519f2de12a313c4ee3f5ef11652ad08932a5e34189
+    md5: 9d2072af184b5caa29492bf2344597bb
+    sha256: 11bea86e11de7d6bce87589197a383344df3fa0a3552dab7e931785ff1159a5b
   category: main
   optional: false
 - name: libsuitesparseconfig
@@ -13504,11 +13308,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc: '>=13'
     __glibc: '>=2.17,<3.0.a0'
-    libgfortran5: '>=13.3.0'
-    libgfortran: ''
     _openmp_mutex: '>=4.5'
+    libgcc: '>=13'
+    libgfortran: ''
+    libgfortran5: '>=13.3.0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libsuitesparseconfig-7.10.1-h901830b_7100101.conda
   hash:
     md5: 57ae1dd979da7aa88a9b38bfa2e1d6b2
@@ -13535,9 +13339,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=11.0'
     libgfortran: '>=5'
     libgfortran5: '>=13.2.0'
-    __osx: '>=11.0'
     llvm-openmp: '>=18.1.8'
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libsuitesparseconfig-7.10.1-h4a8fc20_7100102.conda
   hash:
@@ -13832,11 +13636,11 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
+    libamd: '>=3.3.3,<4.0a0'
+    libblas: '>=3.9.0,<4.0a0'
+    libcholmod: '>=5.3.1,<6.0a0'
     libgcc: '>=13'
     libsuitesparseconfig: '>=7.10.1,<8.0a0'
-    libcholmod: '>=5.3.1,<6.0a0'
-    libblas: '>=3.9.0,<4.0a0'
-    libamd: '>=3.3.3,<4.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libumfpack-6.3.5-h873dde6_7100101.conda
   hash:
     md5: 9626fc7667bc6c901c7a0a4004938c71
@@ -13849,10 +13653,10 @@ package:
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libsuitesparseconfig: '>=7.10.1,<8.0a0'
     libamd: '>=3.3.3,<4.0a0'
-    libcholmod: '>=5.3.1,<6.0a0'
     libblas: '>=3.9.0,<4.0a0'
+    libcholmod: '>=5.3.1,<6.0a0'
+    libsuitesparseconfig: '>=7.10.1,<8.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-64/libumfpack-6.3.5-h0658b90_7100102.conda
   hash:
     md5: 5bbb030bebe81147dc7a0bfa1f821cdc
@@ -13866,9 +13670,9 @@ package:
   dependencies:
     __osx: '>=11.0'
     libamd: '>=3.3.3,<4.0a0'
-    libsuitesparseconfig: '>=7.10.1,<8.0a0'
     libblas: '>=3.9.0,<4.0a0'
     libcholmod: '>=5.3.1,<6.0a0'
+    libsuitesparseconfig: '>=7.10.1,<8.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libumfpack-6.3.5-h7c2c975_7100102.conda
   hash:
     md5: ca1a54d25f34317fecb0a134e94d3cab
@@ -13970,40 +13774,6 @@ package:
   hash:
     md5: 40b61aab5c7ba9ff276c41cfffe6b80b
     sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
-  category: main
-  optional: false
-- name: libuv
-  version: 1.44.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.44.2-hd590300_1.conda
-  hash:
-    md5: d5447f6f8c208232db63db85e053574d
-    sha256: 4910371113afddc55b9a70f468e0c921600ff76e2e5da4084e6039f685ab8151
-  category: main
-  optional: false
-- name: libuv
-  version: 1.44.2
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.44.2-h0dc2134_1.conda
-  hash:
-    md5: 850901f879c13361e0f767c3b3449b8d
-    sha256: 9f815da1ae9edc9c70c0a6dd4fbdf8c615e0198f7a4b7258729e552925e490de
-  category: main
-  optional: false
-- name: libuv
-  version: 1.44.2
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.44.2-hb547adb_1.conda
-  hash:
-    md5: 6991ee4e88e2df061b2635236807f1c5
-    sha256: 62ec5250295b088f7ef93971e06cbf1bcd11ea86ad94c7f5a1aeca2af30135e1
   category: main
   optional: false
 - name: libva
@@ -14297,7 +14067,7 @@ package:
   category: main
   optional: false
 - name: libxml2
-  version: 2.13.7
+  version: 2.13.8
   manager: conda
   platform: win-64
   dependencies:
@@ -14306,10 +14076,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.7-h442d1da_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.13.8-h442d1da_0.conda
   hash:
-    md5: c14ff7f05e57489df9244917d2b55763
-    sha256: 0a013527f784f4702dc18460070d8ec79d1ebb5087dd9e678d6afbeaca68d2ac
+    md5: 833c2dbc1a5020007b520b044c713ed3
+    sha256: 473b8a53c8df714d676ab41711551c8d250f8d799f2db5cb7cb2b177a0ce13f6
   category: main
   optional: false
 - name: libzip
@@ -14424,27 +14194,27 @@ package:
   category: main
   optional: false
 - name: llvm-openmp
-  version: 20.1.3
+  version: 20.1.6
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-20.1.3-ha54dae1_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-20.1.6-ha54dae1_0.conda
   hash:
-    md5: 16b29a91c8177de8910477ded0f80191
-    sha256: deaba16df3fd04910255188dfbd2924d07476375a2e75472859b3c6a9fabd60b
+    md5: c55751d61e1f8be539e0e4beffad3e5a
+    sha256: 75aa1b58b86a17aaa3b7882fe994d8f72440aa938d2d3c84e434b4104cfca096
   category: main
   optional: false
 - name: llvm-openmp
-  version: 20.1.3
+  version: 20.1.6
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-20.1.3-hdb05f8b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-20.1.6-hdb05f8b_0.conda
   hash:
-    md5: 9f2cc154dd184ff808c2c6afd21cb12c
-    sha256: daddebd6ebf2960bb3bae945230ed07b254f430642c739c00ebfb4a8c747a033
+    md5: 7a3b28d59940a28e761e0a623241a832
+    sha256: 99c8aa89a77870d6ee16d62b858be67e30f2ad4fe13555570c7660cc38f9557b
   category: main
   optional: false
 - name: llvmlite
@@ -14725,12 +14495,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    scikit-learn: ''
     networkx: ''
-    python: '>=3.6'
-    pandas: '>=1.0'
-    scipy: '>=1.0'
     numpy: '>=1.3'
+    pandas: '>=1.0'
+    python: '>=3.6'
+    scikit-learn: ''
+    scipy: '>=1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.5.0-pyhd8ed1ab_1.conda
   hash:
     md5: db1aeaff6e248db425e049feffded7a9
@@ -14742,12 +14512,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    scikit-learn: ''
     networkx: ''
-    python: '>=3.6'
-    pandas: '>=1.0'
-    scipy: '>=1.0'
     numpy: '>=1.3'
+    pandas: '>=1.0'
+    python: '>=3.6'
+    scikit-learn: ''
+    scipy: '>=1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.5.0-pyhd8ed1ab_1.conda
   hash:
     md5: db1aeaff6e248db425e049feffded7a9
@@ -15012,8 +14782,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    traitlets: ''
     python: '>=3.6'
+    traitlets: ''
   url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
   hash:
     md5: 779345c95648be40d22aaa89de7d4254
@@ -15025,8 +14795,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    traitlets: ''
     python: '>=3.6'
+    traitlets: ''
   url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
   hash:
     md5: 779345c95648be40d22aaa89de7d4254
@@ -15314,66 +15084,6 @@ package:
     sha256: 65c20dba815abfc72e17ca188ebac21d7f79d80e1efbf353ba7b1e1f9d66943a
   category: main
   optional: false
-- name: multiprocess
-  version: 0.70.16
-  manager: conda
-  platform: linux-64
-  dependencies:
-    dill: '>=0.3.8'
-    libgcc-ng: '>=12'
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.16-py38h01eb140_0.conda
-  hash:
-    md5: aa0527b7755f9ddb78aa067dab1e6786
-    sha256: 48a7f1e8d1be9500db9942684ded96177076b836209fb52b5b406b6adffe7180
-  category: main
-  optional: false
-- name: multiprocess
-  version: 0.70.16
-  manager: conda
-  platform: osx-64
-  dependencies:
-    dill: '>=0.3.8'
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/multiprocess-0.70.16-py38hae2e43d_0.conda
-  hash:
-    md5: 143c830eb3155d9bdb0de3c5298eb9fa
-    sha256: cd21fd76602a75f18a0b2614dc30df49d90a973dcac3e36e6472339b16e18c08
-  category: main
-  optional: false
-- name: multiprocess
-  version: 0.70.16
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    dill: '>=0.3.8'
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.16-py38h336bac9_0.conda
-  hash:
-    md5: 7200161854c60b54b58fe01adb782568
-    sha256: a3337d3fd7966a17aba0b3c344e4a9ab59bb4dcb3916f212630559b41ca90633
-  category: main
-  optional: false
-- name: multiprocess
-  version: 0.70.16
-  manager: conda
-  platform: win-64
-  dependencies:
-    dill: '>=0.3.8'
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/multiprocess-0.70.16-py38h91455d4_0.conda
-  hash:
-    md5: 83d82a994a475373f23340468c492c07
-    sha256: 4d280abf0dea79369c8ec92cc3556ab2394737982d6478ee06c38fbe8b487316
-  category: main
-  optional: false
 - name: munch
   version: 4.0.0
   manager: conda
@@ -15600,10 +15310,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
     nbformat: '>=5.1'
+    python: '>=3.8'
     traitlets: '>=5.4'
   url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
   hash:
@@ -15616,10 +15326,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
     nbformat: '>=5.1'
+    python: '>=3.8'
     traitlets: '>=5.4'
   url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
   hash:
@@ -15688,23 +15398,23 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: ''
     beautifulsoup4: ''
-    defusedxml: ''
     bleach: ''
-    tinycss2: ''
-    jupyterlab_pygments: ''
-    python: '>=3.8'
+    defusedxml: ''
+    entrypoints: '>=0.2.2'
     jinja2: '>=3.0'
     jupyter_core: '>=4.7'
-    entrypoints: '>=0.2.2'
+    jupyterlab_pygments: ''
     markupsafe: '>=2.0'
-    traitlets: '>=5.0'
-    nbformat: '>=5.1'
-    pandocfilters: '>=1.4.1'
-    nbclient: '>=0.5.0'
-    pygments: '>=2.4.1'
     mistune: '>=2.0.3,<3.1'
+    nbclient: '>=0.5.0'
+    nbformat: '>=5.1'
+    packaging: ''
+    pandocfilters: '>=1.4.1'
+    pygments: '>=2.4.1'
+    python: '>=3.8'
+    tinycss2: ''
+    traitlets: '>=5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
   hash:
     md5: 0457fdf55c88e52e0e7b63691eafcc48
@@ -15716,23 +15426,23 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    packaging: ''
     beautifulsoup4: ''
-    defusedxml: ''
     bleach: ''
-    tinycss2: ''
-    jupyterlab_pygments: ''
-    python: '>=3.8'
+    defusedxml: ''
+    entrypoints: '>=0.2.2'
     jinja2: '>=3.0'
     jupyter_core: '>=4.7'
-    entrypoints: '>=0.2.2'
+    jupyterlab_pygments: ''
     markupsafe: '>=2.0'
-    traitlets: '>=5.0'
-    nbformat: '>=5.1'
-    pandocfilters: '>=1.4.1'
-    nbclient: '>=0.5.0'
-    pygments: '>=2.4.1'
     mistune: '>=2.0.3,<3.1'
+    nbclient: '>=0.5.0'
+    nbformat: '>=5.1'
+    packaging: ''
+    pandocfilters: '>=1.4.1'
+    pygments: '>=2.4.1'
+    python: '>=3.8'
+    tinycss2: ''
+    traitlets: '>=5.0'
   url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhff2d567_2.conda
   hash:
     md5: 0457fdf55c88e52e0e7b63691eafcc48
@@ -15776,11 +15486,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    jupyter_core: '>=4.12,!=5.0.*'
-    traitlets: '>=5.1'
     jsonschema: '>=2.6'
+    jupyter_core: '>=4.12,!=5.0.*'
+    python: '>=3.8'
     python-fastjsonschema: '>=2.15'
+    traitlets: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
   hash:
     md5: 0b57b5368ab7fc7cdc9e3511fa867214
@@ -15792,11 +15502,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    jupyter_core: '>=4.12,!=5.0.*'
-    traitlets: '>=5.1'
     jsonschema: '>=2.6'
+    jupyter_core: '>=4.12,!=5.0.*'
+    python: '>=3.8'
     python-fastjsonschema: '>=2.15'
+    traitlets: '>=5.1'
   url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
   hash:
     md5: 0b57b5368ab7fc7cdc9e3511fa867214
@@ -15923,51 +15633,51 @@ package:
   category: main
   optional: false
 - name: networkx
-  version: 2.8.8
+  version: '3.1'
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/networkx-2.8.8-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: bb45ff9deddb045331fd039949f39650
-    sha256: a8e3531fdb6f9acfde885dd94c8639c020013215dab98ff4ed82db7aa745277a
+    md5: 254f787d5068bc89f578bf63893ce8b4
+    sha256: 6b955c8530985fa727ad3323653a54af44ecf453cfdb1b549b3edff609bd3728
   category: main
   optional: false
 - name: networkx
-  version: 2.8.8
+  version: '3.1'
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/networkx-2.8.8-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: bb45ff9deddb045331fd039949f39650
-    sha256: a8e3531fdb6f9acfde885dd94c8639c020013215dab98ff4ed82db7aa745277a
+    md5: 254f787d5068bc89f578bf63893ce8b4
+    sha256: 6b955c8530985fa727ad3323653a54af44ecf453cfdb1b549b3edff609bd3728
   category: main
   optional: false
 - name: networkx
-  version: 2.8.8
+  version: '3.1'
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/networkx-2.8.8-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: bb45ff9deddb045331fd039949f39650
-    sha256: a8e3531fdb6f9acfde885dd94c8639c020013215dab98ff4ed82db7aa745277a
+    md5: 254f787d5068bc89f578bf63893ce8b4
+    sha256: 6b955c8530985fa727ad3323653a54af44ecf453cfdb1b549b3edff609bd3728
   category: main
   optional: false
 - name: networkx
-  version: 2.8.8
+  version: '3.1'
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/networkx-2.8.8-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.1-pyhd8ed1ab_0.conda
   hash:
-    md5: bb45ff9deddb045331fd039949f39650
-    sha256: a8e3531fdb6f9acfde885dd94c8639c020013215dab98ff4ed82db7aa745277a
+    md5: 254f787d5068bc89f578bf63893ce8b4
+    sha256: 6b955c8530985fa727ad3323653a54af44ecf453cfdb1b549b3edff609bd3728
   category: main
   optional: false
 - name: nlohmann_json
@@ -16014,70 +15724,6 @@ package:
     sha256: 046a033594e87705de4edab215ceb567ea24e205fbd058d3fbfd7055b8a80fa4
   category: main
   optional: false
-- name: nodejs
-  version: 18.15.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=70.1,<71.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libuv: '>=1.44.2,<1.45.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.1.0,<4.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-18.15.0-h8d033a5_0.conda
-  hash:
-    md5: c2f93c68ce2b365821f99ff036512a18
-    sha256: 40e1df04674afc9b258fc3e5147e2855290983b7938087a03b3db22dd9847ddb
-  category: main
-  optional: false
-- name: nodejs
-  version: 18.15.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    icu: '>=70.1,<71.0a0'
-    libcxx: '>=14.0.6'
-    libuv: '>=1.44.2,<1.45.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.1.0,<4.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-18.15.0-hd0c9b3c_0.conda
-  hash:
-    md5: 4c7eb1947ecaa10394cf1cbcca343131
-    sha256: 8383c0f4794f1ffe443c35e58914b610bd82c410cdd5bb12a17d4151810b09ee
-  category: main
-  optional: false
-- name: nodejs
-  version: 18.15.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    icu: '>=70.1,<71.0a0'
-    libcxx: '>=14.0.6'
-    libuv: '>=1.44.2,<1.45.0a0'
-    libzlib: '>=1.2.13,<2.0.0a0'
-    openssl: '>=3.1.0,<4.0a0'
-    zlib: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-18.15.0-h26a3f6d_0.conda
-  hash:
-    md5: 36ff7b79cb93c5f2d2ef8faddd1e1fd0
-    sha256: 18675f772d52ade4332e34ef0161637e226e7380d24d78a24487d15e563c00fc
-  category: main
-  optional: false
-- name: nodejs
-  version: 22.13.0
-  manager: conda
-  platform: win-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/nodejs-22.13.0-hfeaa22a_0.conda
-  hash:
-    md5: bd7dde69cfd032aec6ba645297315aff
-    sha256: 2e72f510715960a0579a2a5452104d20044e8ba74742b87899e24c11cb72d578
-  category: main
-  optional: false
 - name: notebook
   version: 7.2.2
   manager: conda
@@ -16117,12 +15763,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    tornado: '>=6.2.0'
     jupyter_server: '>=2.4.0,<3'
+    jupyterlab: '>=4.2.0,<4.3'
     jupyterlab_server: '>=2.27.1,<3'
     notebook-shim: '>=0.2,<0.3'
-    jupyterlab: '>=4.2.0,<4.3'
+    python: '>=3.8'
+    tornado: '>=6.2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.2-pyhd8ed1ab_0.conda
   hash:
     md5: c4d5a58f43ce9ffa430e6ecad6c30a42
@@ -16134,12 +15780,12 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    tornado: '>=6.2.0'
     jupyter_server: '>=2.4.0,<3'
+    jupyterlab: '>=4.2.0,<4.3'
     jupyterlab_server: '>=2.27.1,<3'
     notebook-shim: '>=0.2,<0.3'
-    jupyterlab: '>=4.2.0,<4.3'
+    python: '>=3.8'
+    tornado: '>=6.2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.2.2-pyhd8ed1ab_0.conda
   hash:
     md5: c4d5a58f43ce9ffa430e6ecad6c30a42
@@ -16177,8 +15823,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     jupyter_server: '>=1.8,<3'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
   hash:
     md5: 3d85618e2c97ab896b5b5e298d32b5b3
@@ -16190,8 +15836,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     jupyter_server: '>=1.8,<3'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
   hash:
     md5: 3d85618e2c97ab896b5b5e298d32b5b3
@@ -16239,52 +15885,52 @@ package:
   category: main
   optional: false
 - name: nss
-  version: '3.110'
+  version: '3.112'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libsqlite: '>=3.49.1,<4.0a0'
+    libsqlite: '>=3.49.2,<4.0a0'
     libstdcxx: '>=13'
     libzlib: '>=1.3.1,<2.0a0'
     nspr: '>=4.36,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.110-h159eef7_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.112-h159eef7_0.conda
   hash:
-    md5: 945659af183e87429c8aa7e0be3cc91d
-    sha256: 7f33c2c7af50c0d2dd1232c8552a03cf84120ccaa6d26eae6fe106a5a89a3d98
+    md5: 688a8bc02e57e6b741a040c84e931a7d
+    sha256: fba790fc41c331878480fcc818a5bd76f58fd9f3ab273569994faf100d4e6013
   category: main
   optional: false
 - name: nss
-  version: '3.110'
+  version: '3.112'
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     libcxx: '>=18'
-    libsqlite: '>=3.49.1,<4.0a0'
+    libsqlite: '>=3.49.2,<4.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     nspr: '>=4.36,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/nss-3.110-h32a8879_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/nss-3.112-h32a8879_0.conda
   hash:
-    md5: 76f724a9608a404c723362119a7212a1
-    sha256: 4dc83a24bb2e3fba49cfc5d980c143602db0a778df8d1fe69c934d0ce2ca86e8
+    md5: 4b93144855a3240459265b6f3106a438
+    sha256: fe5c6e39facbf019009d787f28743516d12c527fe14d0c1c4571936fdc9c7145
   category: main
   optional: false
 - name: nss
-  version: '3.110'
+  version: '3.112'
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=18'
-    libsqlite: '>=3.49.1,<4.0a0'
+    libsqlite: '>=3.49.2,<4.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     nspr: '>=4.36,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.110-ha3c76ea_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.112-ha3c76ea_0.conda
   hash:
-    md5: f37aa81a9810876db4182125bd6ab3ec
-    sha256: 864a927e68e5df75a863e680d48b2d74fa1fad444deea983ab8e2a8eb08d8e38
+    md5: 0a1c593b7349a50bbefcbf67a017d927
+    sha256: e0c5ad991f3305bc39aef185138422fa0c490c645a543ab327fadcf600bbcec9
   category: main
   optional: false
 - name: numba
@@ -16429,58 +16075,6 @@ package:
   hash:
     md5: bb13551a7913ff4de74df687f03ba14e
     sha256: 490f2cc120d6ebe3f68fb5b0335c16c0c7822acac500198fc63060bd9fe9e227
-  category: main
-  optional: false
-- name: numpy-financial
-  version: 1.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    numpy: '>=1.15'
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/numpy-financial-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3483f2da98bccd9363d09e1c9fee6f72
-    sha256: 894ed19eedd634a485a1bc274814a33bc995b3804fd74b1fb16c4df9c0833ce4
-  category: main
-  optional: false
-- name: numpy-financial
-  version: 1.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    numpy: '>=1.15'
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/numpy-financial-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3483f2da98bccd9363d09e1c9fee6f72
-    sha256: 894ed19eedd634a485a1bc274814a33bc995b3804fd74b1fb16c4df9c0833ce4
-  category: main
-  optional: false
-- name: numpy-financial
-  version: 1.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.5'
-    numpy: '>=1.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/numpy-financial-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3483f2da98bccd9363d09e1c9fee6f72
-    sha256: 894ed19eedd634a485a1bc274814a33bc995b3804fd74b1fb16c4df9c0833ce4
-  category: main
-  optional: false
-- name: numpy-financial
-  version: 1.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.5'
-    numpy: '>=1.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/numpy-financial-1.0.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3483f2da98bccd9363d09e1c9fee6f72
-    sha256: 894ed19eedd634a485a1bc274814a33bc995b3804fd74b1fb16c4df9c0833ce4
   category: main
   optional: false
 - name: occt
@@ -16732,66 +16326,6 @@ package:
     sha256: 1fb72db47e9b1cdb4980a1fd031e31fad2c6a4a632fc602e7d6fa74f4f491608
   category: main
   optional: false
-- name: openpyxl
-  version: 3.1.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    et_xmlfile: ''
-    libgcc-ng: '>=12'
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/openpyxl-3.1.5-py38h01eb140_0.conda
-  hash:
-    md5: 77621fa0746ea1bfd50b6ea4c1245b90
-    sha256: 9207bb79e10806fce45c7083d4928692e85d2e72d9e3d76c90b5b98df1a6fa35
-  category: main
-  optional: false
-- name: openpyxl
-  version: 3.1.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    et_xmlfile: ''
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/openpyxl-3.1.5-py38h51c390a_0.conda
-  hash:
-    md5: c3932a9f963163e6e66ce538423c837e
-    sha256: 4c344b5039693cfe5d8fbba8979d5a5048057b06a51d1ec2f3fc0c7aee462401
-  category: main
-  optional: false
-- name: openpyxl
-  version: 3.1.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    et_xmlfile: ''
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openpyxl-3.1.5-py38had79a0c_0.conda
-  hash:
-    md5: fc030f44750836963edb0b483db9800a
-    sha256: f7d3905a5e635e540142daa58e4f6d9983d572551bec503c52ec31ed4643c1a6
-  category: main
-  optional: false
-- name: openpyxl
-  version: 3.1.5
-  manager: conda
-  platform: win-64
-  dependencies:
-    et_xmlfile: ''
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/openpyxl-3.1.5-py38h91455d4_0.conda
-  hash:
-    md5: ae3a7a39a6ce311fd6660f198952ce40
-    sha256: 98d1d8113ff63f813af48c9db2da31ca3ca71763266329730abb3eb23391da24
-  category: main
-  optional: false
 - name: openssl
   version: 3.1.8
   manager: conda
@@ -16971,18 +16505,18 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    numpy: ''
-    requests: ''
-    pandas: ''
-    scipy: ''
-    matplotlib-base: ''
-    scikit-learn: ''
-    networkx: ''
-    geopandas: ''
-    rasterio: ''
-    gdal: ''
     folium: ''
+    gdal: ''
+    geopandas: ''
+    matplotlib-base: ''
+    networkx: ''
+    numpy: ''
+    pandas: ''
     python: '>=3.8'
+    rasterio: ''
+    requests: ''
+    scikit-learn: ''
+    scipy: ''
     shapely: '>=2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/osmnx-1.8.1-pyhd8ed1ab_0.conda
   hash:
@@ -16995,18 +16529,18 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    numpy: ''
-    requests: ''
-    pandas: ''
-    scipy: ''
-    matplotlib-base: ''
-    scikit-learn: ''
-    networkx: ''
-    geopandas: ''
-    rasterio: ''
-    gdal: ''
     folium: ''
+    gdal: ''
+    geopandas: ''
+    matplotlib-base: ''
+    networkx: ''
+    numpy: ''
+    pandas: ''
     python: '>=3.8'
+    rasterio: ''
+    requests: ''
+    scikit-learn: ''
+    scipy: ''
     shapely: '>=2.0'
   url: https://conda.anaconda.org/conda-forge/noarch/osmnx-1.8.1-pyhd8ed1ab_0.conda
   hash:
@@ -17045,8 +16579,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing_utils: ''
     python: '>=3.6'
+    typing_utils: ''
   url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
   hash:
     md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
@@ -17058,8 +16592,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    typing_utils: ''
     python: '>=3.6'
+    typing_utils: ''
   url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
   hash:
     md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
@@ -17123,7 +16657,7 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: ''
+    python: '>=3.8'
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
   hash:
     md5: 58335b26c38bf4a20f399384c33cbcf9
@@ -17135,7 +16669,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
+    python: ''
   url: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
   hash:
     md5: 58335b26c38bf4a20f399384c33cbcf9
@@ -17325,70 +16859,6 @@ package:
     sha256: bfe404eebb930cc41782d34f8fc04c0388ea692eeebe2c5fc28df8ec8d4d61ae
   category: main
   optional: false
-- name: pathos
-  version: 0.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    dill: '>=0.3.8'
-    multiprocess: '>=0.70.16'
-    pox: '>=0.3.4'
-    ppft: '>=1.7.6.8'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pathos-0.3.2-pyhd8ed1ab_1.conda
-  hash:
-    md5: 22ed208c1b54e7c2ec6616665fba6b0f
-    sha256: c073284379eb37753f87ea14cf6156dddbfef4239b6813ab573c03825299adf4
-  category: main
-  optional: false
-- name: pathos
-  version: 0.3.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    dill: '>=0.3.8'
-    multiprocess: '>=0.70.16'
-    pox: '>=0.3.4'
-    ppft: '>=1.7.6.8'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pathos-0.3.2-pyhd8ed1ab_1.conda
-  hash:
-    md5: 22ed208c1b54e7c2ec6616665fba6b0f
-    sha256: c073284379eb37753f87ea14cf6156dddbfef4239b6813ab573c03825299adf4
-  category: main
-  optional: false
-- name: pathos
-  version: 0.3.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    dill: '>=0.3.8'
-    pox: '>=0.3.4'
-    multiprocess: '>=0.70.16'
-    ppft: '>=1.7.6.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pathos-0.3.2-pyhd8ed1ab_1.conda
-  hash:
-    md5: 22ed208c1b54e7c2ec6616665fba6b0f
-    sha256: c073284379eb37753f87ea14cf6156dddbfef4239b6813ab573c03825299adf4
-  category: main
-  optional: false
-- name: pathos
-  version: 0.3.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    dill: '>=0.3.8'
-    pox: '>=0.3.4'
-    multiprocess: '>=0.70.16'
-    ppft: '>=1.7.6.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pathos-0.3.2-pyhd8ed1ab_1.conda
-  hash:
-    md5: 22ed208c1b54e7c2ec6616665fba6b0f
-    sha256: c073284379eb37753f87ea14cf6156dddbfef4239b6813ab573c03825299adf4
-  category: main
-  optional: false
 - name: patsy
   version: 0.5.6
   manager: conda
@@ -17422,9 +16892,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    six: ''
-    python: '>=3.6'
     numpy: '>=1.4.0'
+    python: '>=3.6'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/patsy-0.5.6-pyhd8ed1ab_0.conda
   hash:
     md5: a5b55d1cb110cdcedc748b5c3e16e687
@@ -17436,9 +16906,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    six: ''
-    python: '>=3.6'
     numpy: '>=1.4.0'
+    python: '>=3.6'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/patsy-0.5.6-pyhd8ed1ab_0.conda
   hash:
     md5: a5b55d1cb110cdcedc748b5c3e16e687
@@ -17567,8 +17037,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     ptyprocess: '>=0.5'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
   hash:
     md5: 629f3203c99b32e0988910c93e77f3b6
@@ -17748,9 +17218,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    python: '>=3.8,<3.13.0a0'
     setuptools: ''
     wheel: ''
-    python: '>=3.8,<3.13.0a0'
   url: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
   hash:
     md5: 5dd546fe99b44fda83963d15f84263b7
@@ -17762,9 +17232,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    python: '>=3.8,<3.13.0a0'
     setuptools: ''
     wheel: ''
-    python: '>=3.8,<3.13.0a0'
   url: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_0.conda
   hash:
     md5: 5dd546fe99b44fda83963d15f84263b7
@@ -17772,57 +17242,57 @@ package:
   category: main
   optional: false
 - name: pixman
-  version: 0.44.2
+  version: 0.46.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.44.2-h29eaf8c_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.0-h29eaf8c_0.conda
   hash:
-    md5: 5e2a7acfa2c24188af39e7944e1b3604
-    sha256: 747c58db800d5583fee78e76240bf89cbaeedf7ab1ef339c2990602332b9c4be
+    md5: d2f1c87d4416d1e7344cf92b1aaee1c4
+    sha256: 1330c3fd424fa2deec6a30678f235049c0ed1b0fad8d2d81ef995c9322d5e49a
   category: main
   optional: false
 - name: pixman
-  version: 0.44.2
+  version: 0.46.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
     libcxx: '>=18'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.44.2-h1fd1274_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.46.0-h1fd1274_0.conda
   hash:
-    md5: 9d3ed4c1a6e21051bf4ce53851acdc96
-    sha256: 7e5a9823e7e759355b954037f97d4aa53c26db1d73408571e749f8375b363743
+    md5: 808d70603573b87f3427b61501fa376d
+    sha256: 4d8184a8d453e8218017ed2fe024496b6ccf5ba05b994d3a60a8871022ec7a76
   category: main
   optional: false
 - name: pixman
-  version: 0.44.2
+  version: 0.46.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=18'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.44.2-h2f9eb0b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.0-h2f9eb0b_0.conda
   hash:
-    md5: fa8e429fdb9e5b757281f69b8cc4330b
-    sha256: 28855d4cb2d9fc9a6bd9196dadbaecd6868ec706394cec2f88824a61ba4b1bc0
+    md5: d098a1cca9d588cd4d258d06a08a454e
+    sha256: ed22ffec308e798d50066286e5b184c64bb47a3787840883249377ae4e6d684b
   category: main
   optional: false
 - name: pixman
-  version: 0.44.2
+  version: 0.46.0
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.44.2-had0cd8c_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.46.0-had0cd8c_0.conda
   hash:
-    md5: c720ac9a3bd825bf8b4dc7523ea49be4
-    sha256: 6648bd6e050f37c062ced1bbd4201dee617c3dacda1fc3a0de70335cf736f11b
+    md5: 01617534ef71b5385ebba940a6d6150d
+    sha256: d41f4d9faf6aefa138c609b64fe2a22cf252d88e8c393b25847e909d02870491
   category: main
   optional: false
 - name: pkgutil-resolve-name
@@ -17919,62 +17389,6 @@ package:
   hash:
     md5: fd8f2b18b65bbf62e8f653100690c8d2
     sha256: c81bdeadc4adcda216b2c7b373f0335f5c78cc480d1d55d10f21823590d7e46f
-  category: main
-  optional: false
-- name: plotly
-  version: 5.24.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    packaging: ''
-    python: '>=3.6'
-    tenacity: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotly-5.24.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 81bb643d6c3ab4cbeaf724e9d68d0a6a
-    sha256: 39cef6d3056211840709054b90badfa4efd6f61ea37935a89ab0b549a54cc83f
-  category: main
-  optional: false
-- name: plotly
-  version: 5.24.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    packaging: ''
-    python: '>=3.6'
-    tenacity: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotly-5.24.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 81bb643d6c3ab4cbeaf724e9d68d0a6a
-    sha256: 39cef6d3056211840709054b90badfa4efd6f61ea37935a89ab0b549a54cc83f
-  category: main
-  optional: false
-- name: plotly
-  version: 5.24.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    packaging: ''
-    python: '>=3.6'
-    tenacity: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotly-5.24.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 81bb643d6c3ab4cbeaf724e9d68d0a6a
-    sha256: 39cef6d3056211840709054b90badfa4efd6f61ea37935a89ab0b549a54cc83f
-  category: main
-  optional: false
-- name: plotly
-  version: 5.24.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    packaging: ''
-    python: '>=3.6'
-    tenacity: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/plotly-5.24.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 81bb643d6c3ab4cbeaf724e9d68d0a6a
-    sha256: 39cef6d3056211840709054b90badfa4efd6f61ea37935a89ab0b549a54cc83f
   category: main
   optional: false
 - name: ply
@@ -18036,10 +17450,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     packaging: '>=20.0'
-    requests: '>=2.19.0'
     platformdirs: '>=2.5.0'
+    python: '>=3.7'
+    requests: '>=2.19.0'
   url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_0.conda
   hash:
     md5: 8dab97d8a9616e07d779782995710aed
@@ -18051,10 +17465,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     packaging: '>=20.0'
-    requests: '>=2.19.0'
     platformdirs: '>=2.5.0'
+    python: '>=3.7'
+    requests: '>=2.19.0'
   url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_0.conda
   hash:
     md5: 8dab97d8a9616e07d779782995710aed
@@ -18304,102 +17718,6 @@ package:
     sha256: 51a4f9a5537d2ba0dd6df0ddcc3547f5c76a38bf686cdec1ec52f0251a8e2acb
   category: main
   optional: false
-- name: pox
-  version: 0.3.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: 2.7.*|>=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pox-0.3.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: b8065a08cc0dd3ce6364652bb99a7cca
-    sha256: 5a024a0f60f43fc4017b671587c43f66444aaf4b364f046e53f70093fee9505c
-  category: main
-  optional: false
-- name: pox
-  version: 0.3.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: 2.7.*|>=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pox-0.3.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: b8065a08cc0dd3ce6364652bb99a7cca
-    sha256: 5a024a0f60f43fc4017b671587c43f66444aaf4b364f046e53f70093fee9505c
-  category: main
-  optional: false
-- name: pox
-  version: 0.3.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: 2.7.*|>=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pox-0.3.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: b8065a08cc0dd3ce6364652bb99a7cca
-    sha256: 5a024a0f60f43fc4017b671587c43f66444aaf4b364f046e53f70093fee9505c
-  category: main
-  optional: false
-- name: pox
-  version: 0.3.5
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: 2.7.*|>=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pox-0.3.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: b8065a08cc0dd3ce6364652bb99a7cca
-    sha256: 5a024a0f60f43fc4017b671587c43f66444aaf4b364f046e53f70093fee9505c
-  category: main
-  optional: false
-- name: ppft
-  version: 1.7.6.9
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/ppft-1.7.6.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: c6a44e882a693a9790de29c8a8f06255
-    sha256: 3567d0247d32bafbf6ad3125c873096fb14a2dc52659f9ef3bc862b1350949f1
-  category: main
-  optional: false
-- name: ppft
-  version: 1.7.6.9
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/ppft-1.7.6.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: c6a44e882a693a9790de29c8a8f06255
-    sha256: 3567d0247d32bafbf6ad3125c873096fb14a2dc52659f9ef3bc862b1350949f1
-  category: main
-  optional: false
-- name: ppft
-  version: 1.7.6.9
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/ppft-1.7.6.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: c6a44e882a693a9790de29c8a8f06255
-    sha256: 3567d0247d32bafbf6ad3125c873096fb14a2dc52659f9ef3bc862b1350949f1
-  category: main
-  optional: false
-- name: ppft
-  version: 1.7.6.9
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/ppft-1.7.6.9-pyhd8ed1ab_0.conda
-  hash:
-    md5: c6a44e882a693a9790de29c8a8f06255
-    sha256: 3567d0247d32bafbf6ad3125c873096fb14a2dc52659f9ef3bc862b1350949f1
-  category: main
-  optional: false
 - name: proj
   version: 9.1.1
   manager: conda
@@ -18546,8 +17864,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    wcwidth: ''
     python: '>=3.7'
+    wcwidth: ''
   url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
   hash:
     md5: 4c05134c48b6a74f33bbb9938e4a115e
@@ -18559,8 +17877,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    wcwidth: ''
     python: '>=3.7'
+    wcwidth: ''
   url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.48-pyha770c72_0.conda
   hash:
     md5: 4c05134c48b6a74f33bbb9938e4a115e
@@ -18977,18 +18295,18 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    requests: ''
-    h5py: ''
-    pytz: ''
-    importlib-metadata: ''
-    pip: ''
-    statsmodels: ''
     ephem: ''
-    python: '>=3.8'
-    scipy: '>=1.6.0'
+    h5py: ''
+    importlib-metadata: ''
+    numba: '>=0.17.0'
     numpy: '>=1.17.3'
     pandas: '>=1.3.0'
-    numba: '>=0.17.0'
+    pip: ''
+    python: '>=3.8'
+    pytz: ''
+    requests: ''
+    scipy: '>=1.6.0'
+    statsmodels: ''
   url: https://conda.anaconda.org/conda-forge/noarch/pvlib-0.11.0-pyha770c72_0.conda
   hash:
     md5: c9f4459108b58bd349251f93ebd561cb
@@ -19000,70 +18318,22 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    requests: ''
-    h5py: ''
-    pytz: ''
-    importlib-metadata: ''
-    pip: ''
-    statsmodels: ''
     ephem: ''
-    python: '>=3.8'
-    scipy: '>=1.6.0'
+    h5py: ''
+    importlib-metadata: ''
+    numba: '>=0.17.0'
     numpy: '>=1.17.3'
     pandas: '>=1.3.0'
-    numba: '>=0.17.0'
+    pip: ''
+    python: '>=3.8'
+    pytz: ''
+    requests: ''
+    scipy: '>=1.6.0'
+    statsmodels: ''
   url: https://conda.anaconda.org/conda-forge/noarch/pvlib-0.11.0-pyha770c72_0.conda
   hash:
     md5: c9f4459108b58bd349251f93ebd561cb
     sha256: 71e35104c1e0f4b25df2b3b1d625f0af1e7efd0955030f62ff926b40fe63715f
-  category: main
-  optional: false
-- name: pvlib-python
-  version: 0.11.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    pvlib: 0.11.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pvlib-python-0.11.0-hd8ed1ab_0.conda
-  hash:
-    md5: 7f548535e783e8bd63233f5ec97364ee
-    sha256: 3a0321cd252eb91c712cc2aa72140b983cc8a9633e6f7041afa0834a757d0aa6
-  category: main
-  optional: false
-- name: pvlib-python
-  version: 0.11.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    pvlib: 0.11.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pvlib-python-0.11.0-hd8ed1ab_0.conda
-  hash:
-    md5: 7f548535e783e8bd63233f5ec97364ee
-    sha256: 3a0321cd252eb91c712cc2aa72140b983cc8a9633e6f7041afa0834a757d0aa6
-  category: main
-  optional: false
-- name: pvlib-python
-  version: 0.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    pvlib: 0.11.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pvlib-python-0.11.0-hd8ed1ab_0.conda
-  hash:
-    md5: 7f548535e783e8bd63233f5ec97364ee
-    sha256: 3a0321cd252eb91c712cc2aa72140b983cc8a9633e6f7041afa0834a757d0aa6
-  category: main
-  optional: false
-- name: pvlib-python
-  version: 0.11.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    pvlib: 0.11.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pvlib-python-0.11.0-hd8ed1ab_0.conda
-  hash:
-    md5: 7f548535e783e8bd63233f5ec97364ee
-    sha256: 3a0321cd252eb91c712cc2aa72140b983cc8a9633e6f7041afa0834a757d0aa6
   category: main
   optional: false
 - name: pyarrow
@@ -19492,8 +18762,8 @@ package:
   platform: win-64
   dependencies:
     __win: ''
-    win_inet_pton: ''
     python: '>=3.8'
+    win_inet_pton: ''
   url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
   hash:
     md5: 56cd9fe388baac0e90c7149cfac95b60
@@ -19515,10 +18785,10 @@ package:
     libzlib: '>=1.2.13,<2.0.0a0'
     ncurses: '>=6.4,<7.0a0'
     openssl: '>=3.1.3,<4.0a0'
+    pip: ''
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     xz: '>=5.2.6,<6.0a0'
-    pip: ''
   url: https://conda.anaconda.org/conda-forge/linux-64/python-3.8.18-hd12c33a_0_cpython.conda
   hash:
     md5: 334cb629e10d209f1c17630f653168b1
@@ -19536,10 +18806,10 @@ package:
     libzlib: '>=1.2.13,<2.0.0a0'
     ncurses: '>=6.4,<7.0a0'
     openssl: '>=3.1.3,<4.0a0'
+    pip: ''
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     xz: '>=5.2.6,<6.0a0'
-    pip: ''
   url: https://conda.anaconda.org/conda-forge/osx-64/python-3.8.18-h5ba8234_0_cpython.conda
   hash:
     md5: d57653799bb19c13703a696f46dadce4
@@ -19557,10 +18827,10 @@ package:
     libzlib: '>=1.2.13,<2.0.0a0'
     ncurses: '>=6.4,<7.0a0'
     openssl: '>=3.1.3,<4.0a0'
+    pip: ''
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     xz: '>=5.2.6,<6.0a0'
-    pip: ''
   url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.8.18-h2469fbe_0_cpython.conda
   hash:
     md5: 4d4d405b55e99713f832e8d670cb4b0b
@@ -19577,11 +18847,11 @@ package:
     libsqlite: '>=3.43.0,<4.0a0'
     libzlib: '>=1.2.13,<2.0.0a0'
     openssl: '>=3.1.3,<4.0a0'
+    pip: ''
     tk: '>=8.6.13,<8.7.0a0'
     vc: '>=14.1,<15'
     vc14_runtime: '>=14.16.27033'
     xz: '>=5.2.6,<6.0a0'
-    pip: ''
   url: https://conda.anaconda.org/conda-forge/win-64/python-3.8.18-h4de0772_0_cpython.conda
   hash:
     md5: d261509b6d608edf6027143f205cf19b
@@ -19734,62 +19004,6 @@ package:
   hash:
     md5: a61bf9ec79426938ff785eb69dbb1960
     sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
-  category: main
-  optional: false
-- name: python-louvain
-  version: '0.16'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    networkx: ''
-    numpy: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-louvain-0.16-pyhd8ed1ab_0.conda
-  hash:
-    md5: db29f9a0f9ee3495b4eda33c5dde7628
-    sha256: 2802225f77c2c03e027e8b08eff46a6a333dc686b68d3ceb271916018f6ee508
-  category: main
-  optional: false
-- name: python-louvain
-  version: '0.16'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    networkx: ''
-    numpy: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-louvain-0.16-pyhd8ed1ab_0.conda
-  hash:
-    md5: db29f9a0f9ee3495b4eda33c5dde7628
-    sha256: 2802225f77c2c03e027e8b08eff46a6a333dc686b68d3ceb271916018f6ee508
-  category: main
-  optional: false
-- name: python-louvain
-  version: '0.16'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    numpy: ''
-    networkx: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-louvain-0.16-pyhd8ed1ab_0.conda
-  hash:
-    md5: db29f9a0f9ee3495b4eda33c5dde7628
-    sha256: 2802225f77c2c03e027e8b08eff46a6a333dc686b68d3ceb271916018f6ee508
-  category: main
-  optional: false
-- name: python-louvain
-  version: '0.16'
-  manager: conda
-  platform: win-64
-  dependencies:
-    numpy: ''
-    networkx: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-louvain-0.16-pyhd8ed1ab_0.conda
-  hash:
-    md5: db29f9a0f9ee3495b4eda33c5dde7628
-    sha256: 2802225f77c2c03e027e8b08eff46a6a333dc686b68d3ceb271916018f6ee508
   category: main
   optional: false
 - name: python-tzdata
@@ -20309,9 +19523,9 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     libstdcxx: '>=13'
-    __glibc: '>=2.17,<3.0.a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/rapidjson-1.1.0.post20240409-h3f2d84a_2.conda
   hash:
     md5: 65e2f30d532b4ae2063a424c185cc678
@@ -20349,9 +19563,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-    ucrt: '>=10.0.20348.0'
   url: https://conda.anaconda.org/conda-forge/win-64/rapidjson-1.1.0.post20240409-he0c23c2_2.conda
   hash:
     md5: 473596080645129ca9939cbac7c4a2cc
@@ -20596,8 +19810,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     attrs: '>=22.2.0'
+    python: '>=3.8'
     rpds-py: '>=0.7.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
   hash:
@@ -20610,8 +19824,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     attrs: '>=22.2.0'
+    python: '>=3.8'
     rpds-py: '>=0.7.0'
   url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
   hash:
@@ -20656,10 +19870,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    idna: '>=2.5,<4'
     certifi: '>=2017.4.17'
     charset-normalizer: '>=2,<4'
+    idna: '>=2.5,<4'
+    python: '>=3.8'
     urllib3: '>=1.21.1,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
   hash:
@@ -20672,10 +19886,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    idna: '>=2.5,<4'
     certifi: '>=2017.4.17'
     charset-normalizer: '>=2,<4'
+    idna: '>=2.5,<4'
+    python: '>=3.8'
     urllib3: '>=1.21.1,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
   hash:
@@ -20714,8 +19928,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    six: ''
     python: '>=3.5'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: fed45fc5ea0813240707998abe49f520
@@ -20727,8 +19941,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    six: ''
     python: '>=3.5'
+    six: ''
   url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: fed45fc5ea0813240707998abe49f520
@@ -20909,78 +20123,6 @@ package:
   hash:
     md5: 413d96a0b655c8f8aacc36473a2dbb04
     sha256: 9e58ac9781b7e0c0b4a66da23d02889673b9b8b6db0ffef9ef4da003d83795a2
-  category: main
-  optional: false
-- name: salib
-  version: 1.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    matplotlib-base: ''
-    multiprocess: ''
-    numpy: '>=1.20.3'
-    pandas: '>=1.1.2'
-    pathos: '>=0.2.5'
-    python: '>=3.8'
-    scipy: '>=1.7.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/salib-1.5.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6d4649f3efbb2e94be6d09982a18926c
-    sha256: d37a178eae0b9cc3ac2858bd6c772fd918c83e686221a80b40a2cf1b0326b0c6
-  category: main
-  optional: false
-- name: salib
-  version: 1.5.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    matplotlib-base: ''
-    multiprocess: ''
-    numpy: '>=1.20.3'
-    pandas: '>=1.1.2'
-    pathos: '>=0.2.5'
-    python: '>=3.8'
-    scipy: '>=1.7.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/salib-1.5.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6d4649f3efbb2e94be6d09982a18926c
-    sha256: d37a178eae0b9cc3ac2858bd6c772fd918c83e686221a80b40a2cf1b0326b0c6
-  category: main
-  optional: false
-- name: salib
-  version: 1.5.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    matplotlib-base: ''
-    multiprocess: ''
-    python: '>=3.8'
-    scipy: '>=1.7.3'
-    numpy: '>=1.20.3'
-    pandas: '>=1.1.2'
-    pathos: '>=0.2.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/salib-1.5.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6d4649f3efbb2e94be6d09982a18926c
-    sha256: d37a178eae0b9cc3ac2858bd6c772fd918c83e686221a80b40a2cf1b0326b0c6
-  category: main
-  optional: false
-- name: salib
-  version: 1.5.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    matplotlib-base: ''
-    multiprocess: ''
-    python: '>=3.8'
-    scipy: '>=1.7.3'
-    numpy: '>=1.20.3'
-    pandas: '>=1.1.2'
-    pathos: '>=0.2.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/salib-1.5.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6d4649f3efbb2e94be6d09982a18926c
-    sha256: d37a178eae0b9cc3ac2858bd6c772fd918c83e686221a80b40a2cf1b0326b0c6
   category: main
   optional: false
 - name: scikit-learn
@@ -21195,8 +20337,8 @@ package:
   platform: win-64
   dependencies:
     __win: ''
-    pywin32: ''
     python: '>=3.7'
+    pywin32: ''
   url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
   hash:
     md5: 5a86a21050ca3831ec7f77fb302f1132
@@ -21533,8 +20675,8 @@ package:
   platform: osx-arm64
   dependencies:
     numpy: ''
-    python: '>=3.6'
     pyparsing: '>=2.1.6'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_1.conda
   hash:
     md5: 5abeaa41ec50d4d1421a8bc8fbc93054
@@ -21547,8 +20689,8 @@ package:
   platform: win-64
   dependencies:
     numpy: ''
-    python: '>=3.6'
     pyparsing: '>=2.1.6'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_1.conda
   hash:
     md5: 5abeaa41ec50d4d1421a8bc8fbc93054
@@ -21556,115 +20698,115 @@ package:
   category: main
   optional: false
 - name: soupsieve
-  version: '2.5'
+  version: '2.6'
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.6-pyhd8ed1ab_0.conda
   hash:
-    md5: 3f144b2c34f8cb5a9abd9ed23a39c561
-    sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+    md5: cbee5eb469aa483fee70f6a1b4e955dd
+    sha256: e44fad3b8ebfab36585fbf8a373ef3b54be556d671406b2ed578338619fe6259
   category: main
   optional: false
 - name: soupsieve
-  version: '2.5'
+  version: '2.6'
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.6-pyhd8ed1ab_0.conda
   hash:
-    md5: 3f144b2c34f8cb5a9abd9ed23a39c561
-    sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+    md5: cbee5eb469aa483fee70f6a1b4e955dd
+    sha256: e44fad3b8ebfab36585fbf8a373ef3b54be556d671406b2ed578338619fe6259
   category: main
   optional: false
 - name: soupsieve
-  version: '2.5'
+  version: '2.6'
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.6-pyhd8ed1ab_0.conda
   hash:
-    md5: 3f144b2c34f8cb5a9abd9ed23a39c561
-    sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+    md5: cbee5eb469aa483fee70f6a1b4e955dd
+    sha256: e44fad3b8ebfab36585fbf8a373ef3b54be556d671406b2ed578338619fe6259
   category: main
   optional: false
 - name: soupsieve
-  version: '2.5'
+  version: '2.6'
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.6-pyhd8ed1ab_0.conda
   hash:
-    md5: 3f144b2c34f8cb5a9abd9ed23a39c561
-    sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
+    md5: cbee5eb469aa483fee70f6a1b4e955dd
+    sha256: e44fad3b8ebfab36585fbf8a373ef3b54be556d671406b2ed578338619fe6259
   category: main
   optional: false
 - name: sqlite
-  version: 3.49.1
+  version: 3.50.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
-    libsqlite: 3.49.1
+    libsqlite: 3.50.1
     libzlib: '>=1.3.1,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
     readline: '>=8.2,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.49.1-h9eae976_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.50.1-h9eae976_0.conda
   hash:
-    md5: 1894a9d3a8c3ffa53f8ca09fcd2fac25
-    sha256: 85c5b96686a900411ad8bdd424dcc2efb2044f15488bb89e57dff3bfcb74cc65
+    md5: e12789602c09a875957c1c78ff47cdf6
+    sha256: 937862e5bb72ef471a1043feab0a847f4b7f3f10bb8df53ecdc9f95767bd0e04
   category: main
   optional: false
 - name: sqlite
-  version: 3.49.1
+  version: 3.50.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libsqlite: 3.49.1
+    libsqlite: 3.50.1
     libzlib: '>=1.3.1,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
     readline: '>=8.2,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.49.1-h2e4c9dc_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.50.1-h2e4c9dc_0.conda
   hash:
-    md5: 775febaf021c23b27b8b04b2fa428388
-    sha256: 38fff9dddfa80f01a9f0cba3d5f00ff2ca29a8a246cb9cf41177b7cead78005c
+    md5: fc084e090d8f4664235545f83b7eccbe
+    sha256: cd1b873885987b5926307f4110649764938df6c96fd90c675fc2bd84e88f8969
   category: main
   optional: false
 - name: sqlite
-  version: 3.49.1
+  version: 3.50.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libsqlite: 3.49.1
+    libsqlite: 3.50.1
     libzlib: '>=1.3.1,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
     readline: '>=8.2,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.49.1-hd7222ec_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.50.1-hd7222ec_0.conda
   hash:
-    md5: 69dd1428d6a7d068bfc1d2ad70ab6701
-    sha256: d359322cb4404df74d938a11a22b932e49d5f8c931a03e63d34127c9fecac200
+    md5: ace9b3f5e4ff7ecf573751fdb51291de
+    sha256: 48fb30bc3aa07bb6de38b815a02a94449fa0fdda5607c4ad71a56f3be6aea3e9
   category: main
   optional: false
 - name: sqlite
-  version: 3.49.1
+  version: 3.50.1
   manager: conda
   platform: win-64
   dependencies:
-    libsqlite: 3.49.1
+    libsqlite: 3.50.1
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.49.1-h2466b09_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.50.1-h2466b09_0.conda
   hash:
-    md5: e30b7cd408f01cc06073d9e68bfc1710
-    sha256: 0b072d1fd075fdf5d41ff2689c6db2c6246ca58979c0f13dc15fb89d26ee83ed
+    md5: b4b06802480ac6215349f8ea4a599977
+    sha256: 83776804da2db2c14303d5c2cfffa981c1fd29416fcebe0456a863588a22879b
   category: main
   optional: false
 - name: stack_data
@@ -21808,21 +20950,21 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libsuitesparseconfig: ==7.10.1
     libamd: ==3.3.3
     libbtf: ==2.3.2
     libcamd: ==3.3.3
     libccolamd: ==3.3.4
-    libcolamd: ==3.3.4
     libcholmod: ==5.3.1
+    libcolamd: ==3.3.4
     libcxsparse: ==4.4.1
-    libldl: ==3.3.2
     libklu: ==2.3.5
-    libumfpack: ==6.3.5
+    libldl: ==3.3.2
     libparu: ==1.0.0
     librbio: ==4.3.4
     libspex: ==3.2.3
     libspqr: ==4.3.4
+    libsuitesparseconfig: ==7.10.1
+    libumfpack: ==6.3.5
   url: https://conda.anaconda.org/conda-forge/linux-64/suitesparse-7.10.1-h5b2951e_7100101.conda
   hash:
     md5: e927e0f248a498050443dab8bb1203a9
@@ -21834,21 +20976,21 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    libsuitesparseconfig: ==7.10.1
     libamd: ==3.3.3
     libbtf: ==2.3.2
     libcamd: ==3.3.3
     libccolamd: ==3.3.4
-    libcolamd: ==3.3.4
     libcholmod: ==5.3.1
+    libcolamd: ==3.3.4
     libcxsparse: ==4.4.1
-    libldl: ==3.3.2
     libklu: ==2.3.5
-    libumfpack: ==6.3.5
+    libldl: ==3.3.2
     libparu: ==1.0.0
     librbio: ==4.3.4
     libspex: ==3.2.3
     libspqr: ==4.3.4
+    libsuitesparseconfig: ==7.10.1
+    libumfpack: ==6.3.5
   url: https://conda.anaconda.org/conda-forge/osx-64/suitesparse-7.10.1-h033788e_7100102.conda
   hash:
     md5: 1578e907091a780fc34c99e2a1ecb453
@@ -21860,21 +21002,21 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    libsuitesparseconfig: ==7.10.1
     libamd: ==3.3.3
     libbtf: ==2.3.2
     libcamd: ==3.3.3
     libccolamd: ==3.3.4
-    libcolamd: ==3.3.4
     libcholmod: ==5.3.1
+    libcolamd: ==3.3.4
     libcxsparse: ==4.4.1
-    libldl: ==3.3.2
     libklu: ==2.3.5
-    libumfpack: ==6.3.5
+    libldl: ==3.3.2
     libparu: ==1.0.0
     librbio: ==4.3.4
     libspex: ==3.2.3
     libspqr: ==4.3.4
+    libsuitesparseconfig: ==7.10.1
+    libumfpack: ==6.3.5
   url: https://conda.anaconda.org/conda-forge/osx-arm64/suitesparse-7.10.1-h3071b36_7100102.conda
   hash:
     md5: 6c58a1e4f8a473cac74f660bc996bafa
@@ -21912,8 +21054,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
     pyparsing: '>=2.0.1'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/svgwrite-1.4.3-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 9d1eb6e4bf36cf72e0662ed9246f4e1b
@@ -21925,8 +21067,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6'
     pyparsing: '>=2.0.1'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/svgwrite-1.4.3-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 9d1eb6e4bf36cf72e0662ed9246f4e1b
@@ -22088,54 +21230,6 @@ package:
     sha256: c290681bb8e03f13ec490e7ed048dc74da884f23d146c7f98283c0d218532dcb
   category: main
   optional: false
-- name: tenacity
-  version: 9.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 42af51ad3b654ece73572628ad2882ae
-    sha256: 0d33171e1d303b57867f0cfcffb8a35031700acb3c52b1862064d8f4e1085538
-  category: main
-  optional: false
-- name: tenacity
-  version: 9.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 42af51ad3b654ece73572628ad2882ae
-    sha256: 0d33171e1d303b57867f0cfcffb8a35031700acb3c52b1862064d8f4e1085538
-  category: main
-  optional: false
-- name: tenacity
-  version: 9.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 42af51ad3b654ece73572628ad2882ae
-    sha256: 0d33171e1d303b57867f0cfcffb8a35031700acb3c52b1862064d8f4e1085538
-  category: main
-  optional: false
-- name: tenacity
-  version: 9.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 42af51ad3b654ece73572628ad2882ae
-    sha256: 0d33171e1d303b57867f0cfcffb8a35031700acb3c52b1862064d8f4e1085538
-  category: main
-  optional: false
 - name: terminado
   version: 0.18.1
   manager: conda
@@ -22188,8 +21282,8 @@ package:
   dependencies:
     __win: ''
     python: '>=3.8'
-    tornado: '>=6.1.0'
     pywinpty: '>=1.1.0'
+    tornado: '>=6.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
   hash:
     md5: 4abd500577430a942a995fd0d09b76a2
@@ -22323,167 +21417,96 @@ package:
     sha256: 96c2de92dce5de54c923d9242163196bff6bce8e0fbfdbcfd4d9c47ce2fb1123
   category: main
   optional: false
-- name: timezonefinder
-  version: 6.5.2
+- name: tinycss2
+  version: 1.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    cffi: '>=1.15.1,<2'
-    h3-py: '>=3.7.6,<4'
-    libgcc-ng: '>=12'
-    numpy: '>=1.21,<3'
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-    setuptools: '>=65.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/timezonefinder-6.5.2-py38hfb59056_0.conda
+    python: '>=3.5'
+    webencodings: '>=0.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 7113f5d5f05050f3e7e97e1c1b25c5a0
-    sha256: 6d1e5fe6cd0b25fae12c3778591397f69c53092f400bd5e5c7365257b02fda18
+    md5: f1acf5fdefa8300de697982bcb1761c9
+    sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
   category: main
   optional: false
-- name: timezonefinder
-  version: 6.5.2
+- name: tinycss2
+  version: 1.4.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+    webencodings: '>=0.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: f1acf5fdefa8300de697982bcb1761c9
+    sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
+  category: main
+  optional: false
+- name: tinycss2
+  version: 1.4.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.5'
+    webencodings: '>=0.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: f1acf5fdefa8300de697982bcb1761c9
+    sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
+  category: main
+  optional: false
+- name: tinycss2
+  version: 1.4.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.5'
+    webencodings: '>=0.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: f1acf5fdefa8300de697982bcb1761c9
+    sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=13'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+  hash:
+    md5: a0116df4f4ed05c303811a837d5b39d8
+    sha256: a84ff687119e6d8752346d1d408d5cf360dee0badd487a472aa8ddedfdc219e1
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    cffi: '>=1.15.1,<2'
-    h3-py: '>=3.7.6,<4'
-    numpy: '>=1.21,<3'
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-    setuptools: '>=65.5'
-  url: https://conda.anaconda.org/conda-forge/osx-64/timezonefinder-6.5.2-py38hc718529_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
   hash:
-    md5: 64d2d104541c29a53981c7f253851932
-    sha256: 1f8b4f63e1c52039ddbef9cdbf850db9fa943a263147a933b538df41080982bd
+    md5: 9864891a6946c2fe037c02fca7392ab4
+    sha256: b24468006a96b71a5f4372205ea7ec4b399b0f2a543541e86f883de54cd623fc
   category: main
   optional: false
-- name: timezonefinder
-  version: 6.5.2
+- name: tk
+  version: 8.6.13
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    cffi: '>=1.15.1,<2'
-    h3-py: '>=3.7.6,<4'
-    numpy: '>=1.21,<3'
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-    setuptools: '>=65.5'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/timezonefinder-6.5.2-py38h3237794_0.conda
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
   hash:
-    md5: e9b10411964d2045008c54ce558ff322
-    sha256: c97c17ea6945f4d5049c5b77881c5246bd3803832d11908afa0256b02e2d335a
-  category: main
-  optional: false
-- name: timezonefinder
-  version: 6.5.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    cffi: '>=1.15.1,<2'
-    h3-py: '>=3.7.6,<4'
-    numpy: '>=1.21,<3'
-    python: '>=3.8,<3.9.0a0'
-    python_abi: 3.8.*
-    setuptools: '>=65.5'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/timezonefinder-6.5.2-py38h4cb3324_0.conda
-  hash:
-    md5: c94d4f4d0cfb2c17df843900d925c769
-    sha256: 1273c1c0fb0b85926dda7143a3e56fdfaa17cfcca03780170118de9df68ee17c
-  category: main
-  optional: false
-- name: tinycss2
-  version: 1.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-    webencodings: '>=0.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f1acf5fdefa8300de697982bcb1761c9
-    sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
-  category: main
-  optional: false
-- name: tinycss2
-  version: 1.4.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.5'
-    webencodings: '>=0.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f1acf5fdefa8300de697982bcb1761c9
-    sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
-  category: main
-  optional: false
-- name: tinycss2
-  version: 1.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.5'
-    webencodings: '>=0.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f1acf5fdefa8300de697982bcb1761c9
-    sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
-  category: main
-  optional: false
-- name: tinycss2
-  version: 1.4.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.5'
-    webencodings: '>=0.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f1acf5fdefa8300de697982bcb1761c9
-    sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
-  hash:
-    md5: d453b98d9c83e71da0741bb0ff4d76bc
-    sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
-  hash:
-    md5: bf830ba5afc507c6232d4ef0fb1a882d
-    sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libzlib: '>=1.2.13,<2.0.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
-  hash:
-    md5: b50a57ba89c32b62428b71a875291c9b
-    sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+    md5: 7362396c170252e7b7b0c8fb37fe9c78
+    sha256: cb86c522576fa95c6db4c878849af0bccfd3264daf0cc40dd18e7f4a7bfced0e
   category: main
   optional: false
 - name: tk
@@ -22494,10 +21517,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
   hash:
-    md5: fc048363eb8f03cd1737600a5d08aafe
-    sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
+    md5: ebd0e761de9aa879a51d22cc721bd095
+    sha256: e3614b0eb4abcc70d98eae159db59d9b4059ed743ef402081151a948dce95896
   category: main
   optional: false
 - name: toml
@@ -23160,10 +22183,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
     brotli-python: '>=1.0.9'
-    pysocks: '>=1.5.6,<2.0,!=1.5.7'
     h2: '>=4,<5'
+    pysocks: '>=1.5.6,<2.0,!=1.5.7'
+    python: '>=3.8'
     zstandard: '>=0.18.0'
   url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
   hash:
@@ -23176,10 +22199,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
     brotli-python: '>=1.0.9'
-    pysocks: '>=1.5.6,<2.0,!=1.5.7'
     h2: '>=4,<5'
+    pysocks: '>=1.5.6,<2.0,!=1.5.7'
+    python: '>=3.8'
     zstandard: '>=0.18.0'
   url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
   hash:
@@ -23229,54 +22252,6 @@ package:
   hash:
     md5: 7071f524e58d346948d4ac7ae7b5d2f2
     sha256: 71ee67c739bb32a2b684231f156150e1f7fd6c852aa2ceaae50e56909c073227
-  category: main
-  optional: false
-- name: utm
-  version: 0.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/utm-0.7.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 4864e2f5c746f45e02ec46221caccb7e
-    sha256: da75b1b3b0674bf14d32cb00d6d070bf273772c73c787694d438104a486e7627
-  category: main
-  optional: false
-- name: utm
-  version: 0.7.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/utm-0.7.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 4864e2f5c746f45e02ec46221caccb7e
-    sha256: da75b1b3b0674bf14d32cb00d6d070bf273772c73c787694d438104a486e7627
-  category: main
-  optional: false
-- name: utm
-  version: 0.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/utm-0.7.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 4864e2f5c746f45e02ec46221caccb7e
-    sha256: da75b1b3b0674bf14d32cb00d6d070bf273772c73c787694d438104a486e7627
-  category: main
-  optional: false
-- name: utm
-  version: 0.7.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/utm-0.7.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 4864e2f5c746f45e02ec46221caccb7e
-    sha256: da75b1b3b0674bf14d32cb00d6d070bf273772c73c787694d438104a486e7627
   category: main
   optional: false
 - name: vc
@@ -23811,9 +22786,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     aiohttp: <4
     msgpack-python: '>=1,<2'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/wslink-2.2.1-pyhd8ed1ab_0.conda
   hash:
     md5: 74674b93806167c26da4eca7613bc225
@@ -23825,9 +22800,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     aiohttp: <4
     msgpack-python: '>=1,<2'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/wslink-2.2.1-pyhd8ed1ab_0.conda
   hash:
     md5: 74674b93806167c26da4eca7613bc225
@@ -24065,102 +23040,6 @@ package:
   hash:
     md5: 9ac34337e5101a87e5d91da05d84aa48
     sha256: 0518e65929deded6afc5f91f31febb15e8c93f7ee599a18b787f9fab3f79cfd6
-  category: main
-  optional: false
-- name: xlrd
-  version: 2.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/xlrd-2.0.1-pyhd8ed1ab_3.tar.bz2
-  hash:
-    md5: 97dfcd5ff030d829b55f67e82f928093
-    sha256: a97030fc6cde1a335c035392db47efdb4add7d1db76a11b4bfac6ec7fc42bfe5
-  category: main
-  optional: false
-- name: xlrd
-  version: 2.0.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/xlrd-2.0.1-pyhd8ed1ab_3.tar.bz2
-  hash:
-    md5: 97dfcd5ff030d829b55f67e82f928093
-    sha256: a97030fc6cde1a335c035392db47efdb4add7d1db76a11b4bfac6ec7fc42bfe5
-  category: main
-  optional: false
-- name: xlrd
-  version: 2.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/xlrd-2.0.1-pyhd8ed1ab_3.tar.bz2
-  hash:
-    md5: 97dfcd5ff030d829b55f67e82f928093
-    sha256: a97030fc6cde1a335c035392db47efdb4add7d1db76a11b4bfac6ec7fc42bfe5
-  category: main
-  optional: false
-- name: xlrd
-  version: 2.0.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/xlrd-2.0.1-pyhd8ed1ab_3.tar.bz2
-  hash:
-    md5: 97dfcd5ff030d829b55f67e82f928093
-    sha256: a97030fc6cde1a335c035392db47efdb4add7d1db76a11b4bfac6ec7fc42bfe5
-  category: main
-  optional: false
-- name: xlwt
-  version: 1.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xlwt-1.3.0-py_1.tar.bz2
-  hash:
-    md5: deb0fb0c5977e3aa33050a9c405842a4
-    sha256: 3a019d182779f53c65f1a4466d5c1d3363b200d5e3b554cc2a6303d318b7ca0b
-  category: main
-  optional: false
-- name: xlwt
-  version: 1.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xlwt-1.3.0-py_1.tar.bz2
-  hash:
-    md5: deb0fb0c5977e3aa33050a9c405842a4
-    sha256: 3a019d182779f53c65f1a4466d5c1d3363b200d5e3b554cc2a6303d318b7ca0b
-  category: main
-  optional: false
-- name: xlwt
-  version: 1.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xlwt-1.3.0-py_1.tar.bz2
-  hash:
-    md5: deb0fb0c5977e3aa33050a9c405842a4
-    sha256: 3a019d182779f53c65f1a4466d5c1d3363b200d5e3b554cc2a6303d318b7ca0b
-  category: main
-  optional: false
-- name: xlwt
-  version: 1.3.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/xlwt-1.3.0-py_1.tar.bz2
-  hash:
-    md5: deb0fb0c5977e3aa33050a9c405842a4
-    sha256: 3a019d182779f53c65f1a4466d5c1d3363b200d5e3b554cc2a6303d318b7ca0b
   category: main
   optional: false
 - name: xorg-fixesproto
@@ -24430,51 +23309,51 @@ package:
   category: main
   optional: false
 - name: xyzservices
-  version: 2025.1.0
+  version: 2025.4.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: fdf07e281a9e5e10fc75b2dd444136e9
-    sha256: 9978c22319e85026d5a4134944f73bac820c948ca6b6c32af6b6985b5221cd8a
+    md5: 5663fa346821cd06dc1ece2c2600be2c
+    sha256: ac6d4d4133b1e0f69075158cdf00fccad20e29fc6cc45faa480cec37a84af6ae
   category: main
   optional: false
 - name: xyzservices
-  version: 2025.1.0
+  version: 2025.4.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: fdf07e281a9e5e10fc75b2dd444136e9
-    sha256: 9978c22319e85026d5a4134944f73bac820c948ca6b6c32af6b6985b5221cd8a
+    md5: 5663fa346821cd06dc1ece2c2600be2c
+    sha256: ac6d4d4133b1e0f69075158cdf00fccad20e29fc6cc45faa480cec37a84af6ae
   category: main
   optional: false
 - name: xyzservices
-  version: 2025.1.0
+  version: 2025.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: fdf07e281a9e5e10fc75b2dd444136e9
-    sha256: 9978c22319e85026d5a4134944f73bac820c948ca6b6c32af6b6985b5221cd8a
+    md5: 5663fa346821cd06dc1ece2c2600be2c
+    sha256: ac6d4d4133b1e0f69075158cdf00fccad20e29fc6cc45faa480cec37a84af6ae
   category: main
   optional: false
 - name: xyzservices
-  version: 2025.1.0
+  version: 2025.4.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2025.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: fdf07e281a9e5e10fc75b2dd444136e9
-    sha256: 9978c22319e85026d5a4134944f73bac820c948ca6b6c32af6b6985b5221cd8a
+    md5: 5663fa346821cd06dc1ece2c2600be2c
+    sha256: ac6d4d4133b1e0f69075158cdf00fccad20e29fc6cc45faa480cec37a84af6ae
   category: main
   optional: false
 - name: xz
@@ -24488,10 +23367,10 @@ package:
     liblzma-devel: 5.8.1
     xz-gpl-tools: 5.8.1
     xz-tools: 5.8.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.1-hbcc6ac9_2.conda
   hash:
-    md5: c9880133bf4750a4c848f8d2c78d498c
-    sha256: 65f32402dc69fb20dc9b6307793405f45b6fd979a55534e1a4f2d39bcabea303
+    md5: 68eae977d7d1196d32b636a026dc015d
+    sha256: 802725371682ea06053971db5b4fb7fbbcaee9cb1804ec688f55e51d74660617
   category: main
   optional: false
 - name: xz
@@ -24504,10 +23383,10 @@ package:
     liblzma-devel: 5.8.1
     xz-gpl-tools: 5.8.1
     xz-tools: 5.8.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.8.1-h357f2ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.8.1-h357f2ed_2.conda
   hash:
-    md5: f82538ab4e5702e44596edce4469dd1a
-    sha256: 878d3767eb286940c794cf97c18b83c3482f75e5493f682eb726309c242c0cc5
+    md5: 7eee908c7df8478c1f35b28efa2e42b1
+    sha256: 89248de6c9417522b6fec011dc26b81c25af731a31ba91e668f72f1b9aab05d7
   category: main
   optional: false
 - name: xz
@@ -24520,10 +23399,10 @@ package:
     liblzma-devel: 5.8.1
     xz-gpl-tools: 5.8.1
     xz-tools: 5.8.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.8.1-h9a6d368_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.8.1-h9a6d368_2.conda
   hash:
-    md5: 6cbb460021a53fc29db69a51846e9b36
-    sha256: 339d096f9a08e08ddcedc65dd28635610f629cdb1b57d6851308605f6776d013
+    md5: 39435c82e5a007ef64cbb153ecc40cfd
+    sha256: afb747cf017b67cc31d54c6e6c4bd1b1e179fe487a3d23a856232ed7fd0b099b
   category: main
   optional: false
 - name: xz
@@ -24537,10 +23416,10 @@ package:
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
     xz-tools: 5.8.1
-  url: https://conda.anaconda.org/conda-forge/win-64/xz-5.8.1-h208afaa_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/xz-5.8.1-h208afaa_2.conda
   hash:
-    md5: 72adc29cfcdfadfedf20c7e5b713e562
-    sha256: 93150e68d5d1ee01fe347b11fac8625d17ca1afdc96c94a8231a77d3c0159229
+    md5: fb3fa84ea37de9f12cc8ba730cec0bdc
+    sha256: 22289a81da4698bb8d13ac032a88a4a1f49505b2303885e1add3d8bd1a7b56e6
   category: main
   optional: false
 - name: xz-gpl-tools
@@ -24551,10 +23430,10 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     liblzma: 5.8.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_2.conda
   hash:
-    md5: 9177ea2e6886b8070012e1d68531ab2f
-    sha256: f48787ef798a44d7ef5618427af7881ae0229a930810963c43acc5444abe2437
+    md5: bf627c16aa26231720af037a2709ab09
+    sha256: 840838dca829ec53f1160f3fca6dbfc43f2388b85f15d3e867e69109b168b87b
   category: main
   optional: false
 - name: xz-gpl-tools
@@ -24564,10 +23443,10 @@ package:
   dependencies:
     __osx: '>=10.13'
     liblzma: 5.8.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/xz-gpl-tools-5.8.1-h357f2ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/xz-gpl-tools-5.8.1-h357f2ed_2.conda
   hash:
-    md5: d41e7f7377313e6d44cb37f24bca046d
-    sha256: 0802af7effb3bd823404fa3f059af3f58953a5a0ee47914603659695d9aaf0b1
+    md5: d4044359fad6af47224e9ef483118378
+    sha256: 5cdadfff31de7f50d1b2f919dd80697c0a08d90f8d6fb89f00c93751ec135c3c
   category: main
   optional: false
 - name: xz-gpl-tools
@@ -24577,10 +23456,10 @@ package:
   dependencies:
     __osx: '>=11.0'
     liblzma: 5.8.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.8.1-h9a6d368_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-gpl-tools-5.8.1-h9a6d368_2.conda
   hash:
-    md5: af7ff1efa304098c6aa59fabafaab964
-    sha256: f4ae1e580f46b00c8cc66fbcff0f8ba612e6cb4551f0699b112f6bdbd9472a85
+    md5: 09b1442c1d49ac7c5f758c44695e77d1
+    sha256: a0790cfb48d240e7b655b0d797a00040219cf39e3ee38e2104e548515df4f9c2
   category: main
   optional: false
 - name: xz-tools
@@ -24591,10 +23470,10 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=13'
     liblzma: 5.8.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_2.conda
   hash:
-    md5: 908d29a6cfd9e9a78d07012f5d1a8707
-    sha256: ec01d8c97f77c80a2bf42050b761e199663a4a35d22fc194c950802589e15e59
+    md5: 1bad2995c8f1c8075c6c331bf96e46fb
+    sha256: 58034f3fca491075c14e61568ad8b25de00cb3ae479de3e69be6d7ee5d3ace28
   category: main
   optional: false
 - name: xz-tools
@@ -24604,10 +23483,10 @@ package:
   dependencies:
     __osx: '>=10.13'
     liblzma: 5.8.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/xz-tools-5.8.1-hd471939_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/xz-tools-5.8.1-hd471939_2.conda
   hash:
-    md5: 0feb3570e5d52cb777ccac5bb252d5c9
-    sha256: 4b93d76d483a4a01ff342c767412148726198eb784db1c35749e391f99d2416d
+    md5: 349148960ad74aece88028f2b5c62c51
+    sha256: 3b1d8958f8dceaa4442100d5326b2ec9bcc2e8d7ee55345bf7101dc362fb9868
   category: main
   optional: false
 - name: xz-tools
@@ -24617,10 +23496,10 @@ package:
   dependencies:
     __osx: '>=11.0'
     liblzma: 5.8.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-tools-5.8.1-h39f12f2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-tools-5.8.1-h39f12f2_2.conda
   hash:
-    md5: f9092635d51d9cdebee1864047ceb1f6
-    sha256: cad2b7856f3d3c35e9e86a08e40aa95d2b385f352bb34e35961749f8b1570439
+    md5: 37996935aa33138fca43e4b4563b6a28
+    sha256: 9d1232705e3d175f600dc8e344af9182d0341cdaa73d25330591a28532951063
   category: main
   optional: false
 - name: xz-tools
@@ -24632,10 +23511,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/xz-tools-5.8.1-h2466b09_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/xz-tools-5.8.1-h2466b09_2.conda
   hash:
-    md5: 689bdeecf1e8fea7cb83c1ce36f04b5b
-    sha256: af6278f7228618130b963a57ada926228f3a36c310c68dddf0341b529243a2de
+    md5: e1b62ec0457e6ba10287a49854108fdb
+    sha256: 38712f0e62f61741ab69d7551fa863099f5be769bdf9fdbc28542134874b4e88
   category: main
   optional: false
 - name: yaml
@@ -24747,58 +23626,6 @@ package:
   hash:
     md5: fc8966e18c671d8e8f5f242cd0690641
     sha256: 7cb0fba28768fbee0951a5f3cd796f7a4bb5487eea5622ed8872a584af37e6fa
-  category: main
-  optional: false
-- name: yarn
-  version: 4.9.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: ''
-    nodejs: '>=18.12.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/yarn-4.9.1-hd25539a_1.conda
-  hash:
-    md5: 1e1a45c51540f683abb1fe5e8daf7c2a
-    sha256: b106c12aaf7a74801768936fa29f53a969312d4fcb165f327fc0875b56437619
-  category: main
-  optional: false
-- name: yarn
-  version: 4.9.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __unix: ''
-    nodejs: '>=18.12.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/yarn-4.9.1-hd25539a_1.conda
-  hash:
-    md5: 1e1a45c51540f683abb1fe5e8daf7c2a
-    sha256: b106c12aaf7a74801768936fa29f53a969312d4fcb165f327fc0875b56437619
-  category: main
-  optional: false
-- name: yarn
-  version: 4.9.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __unix: ''
-    nodejs: '>=18.12.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/yarn-4.9.1-hd25539a_1.conda
-  hash:
-    md5: 1e1a45c51540f683abb1fe5e8daf7c2a
-    sha256: b106c12aaf7a74801768936fa29f53a969312d4fcb165f327fc0875b56437619
-  category: main
-  optional: false
-- name: yarn
-  version: 4.9.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    __win: ''
-    nodejs: '>=18.12.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/yarn-4.9.1-h64345c8_1.conda
-  hash:
-    md5: 5d039bb44a01078570d246485d298961
-    sha256: ce19c6f0ba9f3a7ed99147076559762b5e6c3ab0ee8b412b747f3a2e599d528a
   category: main
   optional: false
 - name: zeromq
@@ -25336,14 +24163,138 @@ package:
     sha256: c505d61b6176aaf982c5717ce04e87da5abc9a36a5b39ac03905c4aafe8de7aa
   category: main
   optional: false
+- name: deap
+  version: 1.4.3
+  manager: pip
+  platform: linux-64
+  dependencies:
+    numpy: '*'
+  url: https://files.pythonhosted.org/packages/c9/37/3a3d82ca07e9eb2d8cdc1979ff82add35f1b41988c984db53ae582959c13/deap-1.4.3.tar.gz
+  hash:
+    sha256: 7c97088fb05835bdc255bec475cb0e778de2b43e44cbefbf2bcd655aeec865fd
+  category: main
+  optional: false
+- name: deap
+  version: 1.4.3
+  manager: pip
+  platform: osx-64
+  dependencies:
+    numpy: '*'
+  url: https://files.pythonhosted.org/packages/c9/37/3a3d82ca07e9eb2d8cdc1979ff82add35f1b41988c984db53ae582959c13/deap-1.4.3.tar.gz
+  hash:
+    sha256: 7c97088fb05835bdc255bec475cb0e778de2b43e44cbefbf2bcd655aeec865fd
+  category: main
+  optional: false
+- name: deap
+  version: 1.4.3
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    numpy: '*'
+  url: https://files.pythonhosted.org/packages/c9/37/3a3d82ca07e9eb2d8cdc1979ff82add35f1b41988c984db53ae582959c13/deap-1.4.3.tar.gz
+  hash:
+    sha256: 7c97088fb05835bdc255bec475cb0e778de2b43e44cbefbf2bcd655aeec865fd
+  category: main
+  optional: false
+- name: deap
+  version: 1.4.3
+  manager: pip
+  platform: win-64
+  dependencies:
+    numpy: '*'
+  url: https://files.pythonhosted.org/packages/c9/37/3a3d82ca07e9eb2d8cdc1979ff82add35f1b41988c984db53ae582959c13/deap-1.4.3.tar.gz
+  hash:
+    sha256: 7c97088fb05835bdc255bec475cb0e778de2b43e44cbefbf2bcd655aeec865fd
+  category: main
+  optional: false
+- name: dill
+  version: 0.4.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl
+  hash:
+    sha256: 44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049
+  category: main
+  optional: false
+- name: dill
+  version: 0.4.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl
+  hash:
+    sha256: 44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049
+  category: main
+  optional: false
+- name: dill
+  version: 0.4.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl
+  hash:
+    sha256: 44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049
+  category: main
+  optional: false
+- name: dill
+  version: 0.4.0
+  manager: pip
+  platform: win-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl
+  hash:
+    sha256: 44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049
+  category: main
+  optional: false
+- name: et-xmlfile
+  version: 2.0.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
+  hash:
+    sha256: 7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa
+  category: main
+  optional: false
+- name: et-xmlfile
+  version: 2.0.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
+  hash:
+    sha256: 7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa
+  category: main
+  optional: false
+- name: et-xmlfile
+  version: 2.0.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
+  hash:
+    sha256: 7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa
+  category: main
+  optional: false
+- name: et-xmlfile
+  version: 2.0.0
+  manager: pip
+  platform: win-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
+  hash:
+    sha256: 7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa
+  category: main
+  optional: false
 - name: fastapi
   version: 0.115.11
   manager: pip
   platform: linux-64
   dependencies:
-    starlette: '>=0.40.0,<0.47.0'
     pydantic: '>=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0
       || >2.1.0,<3.0.0'
+    starlette: '>=0.40.0,<0.47.0'
     typing-extensions: '>=4.8.0'
   url: https://files.pythonhosted.org/packages/b3/5d/4d8bbb94f0dbc22732350c06965e40740f4a92ca560e90bb566f4f73af41/fastapi-0.115.11-py3-none-any.whl
   hash:
@@ -25355,9 +24306,9 @@ package:
   manager: pip
   platform: osx-64
   dependencies:
-    starlette: '>=0.40.0,<0.47.0'
     pydantic: '>=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0
       || >2.1.0,<3.0.0'
+    starlette: '>=0.40.0,<0.47.0'
     typing-extensions: '>=4.8.0'
   url: https://files.pythonhosted.org/packages/b3/5d/4d8bbb94f0dbc22732350c06965e40740f4a92ca560e90bb566f4f73af41/fastapi-0.115.11-py3-none-any.whl
   hash:
@@ -25369,9 +24320,9 @@ package:
   manager: pip
   platform: osx-arm64
   dependencies:
-    starlette: '>=0.40.0,<0.47.0'
     pydantic: '>=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0
       || >2.1.0,<3.0.0'
+    starlette: '>=0.40.0,<0.47.0'
     typing-extensions: '>=4.8.0'
   url: https://files.pythonhosted.org/packages/b3/5d/4d8bbb94f0dbc22732350c06965e40740f4a92ca560e90bb566f4f73af41/fastapi-0.115.11-py3-none-any.whl
   hash:
@@ -25383,9 +24334,9 @@ package:
   manager: pip
   platform: win-64
   dependencies:
-    starlette: '>=0.40.0,<0.47.0'
     pydantic: '>=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0
       || >2.1.0,<3.0.0'
+    starlette: '>=0.40.0,<0.47.0'
     typing-extensions: '>=4.8.0'
   url: https://files.pythonhosted.org/packages/b3/5d/4d8bbb94f0dbc22732350c06965e40740f4a92ca560e90bb566f4f73af41/fastapi-0.115.11-py3-none-any.whl
   hash:
@@ -25430,6 +24381,46 @@ package:
   url: https://files.pythonhosted.org/packages/d3/50/7b7a3e10ed82c760c1fd8d3167a7c95508e9fdfc0b0604f05ed1a9a9efdc/greenlet-3.1.1-cp38-cp38-win_amd64.whl
   hash:
     sha256: 7017b2be767b9d43cc31416aba48aab0d2309ee31b4dbf10a1d38fb7972bdf9d
+  category: main
+  optional: false
+- name: h3
+  version: 4.2.2
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/e0/e4/50ca07182061d461d4d4051ab4975500eaed3df830686267660db7cac3ac/h3-4.2.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  hash:
+    sha256: ecd448725c7c36c59edf831e4666ea950060e99afdfc38e384da3cbab21453da
+  category: main
+  optional: false
+- name: h3
+  version: 4.2.2
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/2c/d4/a7bf463c37509645fe77baefaaaabb890cc63856c1a4e51a5036beb447a9/h3-4.2.2-cp38-cp38-macosx_10_9_x86_64.whl
+  hash:
+    sha256: 4c7320ea6551b21275e14cde684ff060b2a7ee1cfd7c4232cccc8922ead5820c
+  category: main
+  optional: false
+- name: h3
+  version: 4.2.2
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/d2/de/90708e0a04b83803d0c5f6e31651a5f73382be44787f6d0c9478449ce39b/h3-4.2.2-cp38-cp38-macosx_11_0_arm64.whl
+  hash:
+    sha256: 0e8e6ba11dba11b130fced35e553b2813f4ab0ff5d34d570443e7e9d454845d6
+  category: main
+  optional: false
+- name: h3
+  version: 4.2.2
+  manager: pip
+  platform: win-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/c1/8b/d819d95ed01288c6b1876b6064ac9276c6124765a7cecc6839657f062d0e/h3-4.2.2-cp38-cp38-win_amd64.whl
+  hash:
+    sha256: 7fc37373148b2c5626da1a580db4d686dac3243e1cb1c29b20aab281c640a129
   category: main
   optional: false
 - name: lxml
@@ -25512,105 +24503,365 @@ package:
     sha256: a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c
   category: main
   optional: false
+- name: multiprocess
+  version: 0.70.18
+  manager: pip
+  platform: linux-64
+  dependencies:
+    dill: '>=0.4.0'
+  url: https://files.pythonhosted.org/packages/3b/c3/ca84c19bd14cdfc21c388fdcebf08b86a7a470ebc9f5c3c084fc2dbc50f7/multiprocess-0.70.18-py38-none-any.whl
+  hash:
+    sha256: dbf705e52a154fe5e90fb17b38f02556169557c2dd8bb084f2e06c2784d8279b
+  category: main
+  optional: false
+- name: multiprocess
+  version: 0.70.18
+  manager: pip
+  platform: osx-64
+  dependencies:
+    dill: '>=0.4.0'
+  url: https://files.pythonhosted.org/packages/3b/c3/ca84c19bd14cdfc21c388fdcebf08b86a7a470ebc9f5c3c084fc2dbc50f7/multiprocess-0.70.18-py38-none-any.whl
+  hash:
+    sha256: dbf705e52a154fe5e90fb17b38f02556169557c2dd8bb084f2e06c2784d8279b
+  category: main
+  optional: false
+- name: multiprocess
+  version: 0.70.18
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    dill: '>=0.4.0'
+  url: https://files.pythonhosted.org/packages/3b/c3/ca84c19bd14cdfc21c388fdcebf08b86a7a470ebc9f5c3c084fc2dbc50f7/multiprocess-0.70.18-py38-none-any.whl
+  hash:
+    sha256: dbf705e52a154fe5e90fb17b38f02556169557c2dd8bb084f2e06c2784d8279b
+  category: main
+  optional: false
+- name: multiprocess
+  version: 0.70.18
+  manager: pip
+  platform: win-64
+  dependencies:
+    dill: '>=0.4.0'
+  url: https://files.pythonhosted.org/packages/3b/c3/ca84c19bd14cdfc21c388fdcebf08b86a7a470ebc9f5c3c084fc2dbc50f7/multiprocess-0.70.18-py38-none-any.whl
+  hash:
+    sha256: dbf705e52a154fe5e90fb17b38f02556169557c2dd8bb084f2e06c2784d8279b
+  category: main
+  optional: false
+- name: narwhals
+  version: 1.42.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/8d/0f/f9ae7c8c55f9078c852b13ea4a6e92e5f4d6d4c8fc0781ec2882957006bb/narwhals-1.42.0-py3-none-any.whl
+  hash:
+    sha256: ef6cedf7700dc22c09d17973b9ede11b53e25331e238b24ac73884a8c5e27c19
+  category: main
+  optional: false
+- name: narwhals
+  version: 1.42.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/8d/0f/f9ae7c8c55f9078c852b13ea4a6e92e5f4d6d4c8fc0781ec2882957006bb/narwhals-1.42.0-py3-none-any.whl
+  hash:
+    sha256: ef6cedf7700dc22c09d17973b9ede11b53e25331e238b24ac73884a8c5e27c19
+  category: main
+  optional: false
+- name: narwhals
+  version: 1.42.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/8d/0f/f9ae7c8c55f9078c852b13ea4a6e92e5f4d6d4c8fc0781ec2882957006bb/narwhals-1.42.0-py3-none-any.whl
+  hash:
+    sha256: ef6cedf7700dc22c09d17973b9ede11b53e25331e238b24ac73884a8c5e27c19
+  category: main
+  optional: false
+- name: narwhals
+  version: 1.42.0
+  manager: pip
+  platform: win-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/8d/0f/f9ae7c8c55f9078c852b13ea4a6e92e5f4d6d4c8fc0781ec2882957006bb/narwhals-1.42.0-py3-none-any.whl
+  hash:
+    sha256: ef6cedf7700dc22c09d17973b9ede11b53e25331e238b24ac73884a8c5e27c19
+  category: main
+  optional: false
+- name: networkx
+  version: '2.8'
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/df/04/416751fe793a10a9b1c786d8dd93b80190ae745b3c9cb847c8f84fd119c2/networkx-2.8-py3-none-any.whl
+  hash:
+    sha256: 1a1e8fe052cc1b4e0339b998f6795099562a264a13a5af7a32cad45ab9d4e126
+  category: main
+  optional: false
+- name: networkx
+  version: '2.8'
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/df/04/416751fe793a10a9b1c786d8dd93b80190ae745b3c9cb847c8f84fd119c2/networkx-2.8-py3-none-any.whl
+  hash:
+    sha256: 1a1e8fe052cc1b4e0339b998f6795099562a264a13a5af7a32cad45ab9d4e126
+  category: main
+  optional: false
+- name: networkx
+  version: '2.8'
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/df/04/416751fe793a10a9b1c786d8dd93b80190ae745b3c9cb847c8f84fd119c2/networkx-2.8-py3-none-any.whl
+  hash:
+    sha256: 1a1e8fe052cc1b4e0339b998f6795099562a264a13a5af7a32cad45ab9d4e126
+  category: main
+  optional: false
+- name: networkx
+  version: '2.8'
+  manager: pip
+  platform: win-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/df/04/416751fe793a10a9b1c786d8dd93b80190ae745b3c9cb847c8f84fd119c2/networkx-2.8-py3-none-any.whl
+  hash:
+    sha256: 1a1e8fe052cc1b4e0339b998f6795099562a264a13a5af7a32cad45ab9d4e126
+  category: main
+  optional: false
+- name: numpy-financial
+  version: 1.0.0
+  manager: pip
+  platform: linux-64
+  dependencies:
+    numpy: '>=1.15'
+  url: https://files.pythonhosted.org/packages/6a/be/d07585e440d58835bad8f1c9ca7823b5252ffeda4c797e653a20215fca65/numpy_financial-1.0.0-py3-none-any.whl
+  hash:
+    sha256: bae534b357516f12258862d1f0181d911032d0467f215bfcd1c264b4da579047
+  category: main
+  optional: false
+- name: numpy-financial
+  version: 1.0.0
+  manager: pip
+  platform: osx-64
+  dependencies:
+    numpy: '>=1.15'
+  url: https://files.pythonhosted.org/packages/6a/be/d07585e440d58835bad8f1c9ca7823b5252ffeda4c797e653a20215fca65/numpy_financial-1.0.0-py3-none-any.whl
+  hash:
+    sha256: bae534b357516f12258862d1f0181d911032d0467f215bfcd1c264b4da579047
+  category: main
+  optional: false
+- name: numpy-financial
+  version: 1.0.0
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    numpy: '>=1.15'
+  url: https://files.pythonhosted.org/packages/6a/be/d07585e440d58835bad8f1c9ca7823b5252ffeda4c797e653a20215fca65/numpy_financial-1.0.0-py3-none-any.whl
+  hash:
+    sha256: bae534b357516f12258862d1f0181d911032d0467f215bfcd1c264b4da579047
+  category: main
+  optional: false
+- name: numpy-financial
+  version: 1.0.0
+  manager: pip
+  platform: win-64
+  dependencies:
+    numpy: '>=1.15'
+  url: https://files.pythonhosted.org/packages/6a/be/d07585e440d58835bad8f1c9ca7823b5252ffeda4c797e653a20215fca65/numpy_financial-1.0.0-py3-none-any.whl
+  hash:
+    sha256: bae534b357516f12258862d1f0181d911032d0467f215bfcd1c264b4da579047
+  category: main
+  optional: false
+- name: openpyxl
+  version: 3.1.5
+  manager: pip
+  platform: linux-64
+  dependencies:
+    et-xmlfile: '*'
+  url: https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl
+  hash:
+    sha256: 5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2
+  category: main
+  optional: false
+- name: openpyxl
+  version: 3.1.5
+  manager: pip
+  platform: osx-64
+  dependencies:
+    et-xmlfile: '*'
+  url: https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl
+  hash:
+    sha256: 5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2
+  category: main
+  optional: false
+- name: openpyxl
+  version: 3.1.5
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    et-xmlfile: '*'
+  url: https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl
+  hash:
+    sha256: 5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2
+  category: main
+  optional: false
+- name: openpyxl
+  version: 3.1.5
+  manager: pip
+  platform: win-64
+  dependencies:
+    et-xmlfile: '*'
+  url: https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl
+  hash:
+    sha256: 5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2
+  category: main
+  optional: false
+- name: plotly
+  version: 6.1.2
+  manager: pip
+  platform: linux-64
+  dependencies:
+    narwhals: '>=1.15.1'
+    packaging: '*'
+  url: https://files.pythonhosted.org/packages/bf/6f/759d5da0517547a5d38aabf05d04d9f8adf83391d2c7fc33f904417d3ba2/plotly-6.1.2-py3-none-any.whl
+  hash:
+    sha256: f1548a8ed9158d59e03d7fed548c7db5549f3130d9ae19293c8638c202648f6d
+  category: main
+  optional: false
+- name: plotly
+  version: 6.1.2
+  manager: pip
+  platform: osx-64
+  dependencies:
+    narwhals: '>=1.15.1'
+    packaging: '*'
+  url: https://files.pythonhosted.org/packages/bf/6f/759d5da0517547a5d38aabf05d04d9f8adf83391d2c7fc33f904417d3ba2/plotly-6.1.2-py3-none-any.whl
+  hash:
+    sha256: f1548a8ed9158d59e03d7fed548c7db5549f3130d9ae19293c8638c202648f6d
+  category: main
+  optional: false
+- name: plotly
+  version: 6.1.2
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    narwhals: '>=1.15.1'
+    packaging: '*'
+  url: https://files.pythonhosted.org/packages/bf/6f/759d5da0517547a5d38aabf05d04d9f8adf83391d2c7fc33f904417d3ba2/plotly-6.1.2-py3-none-any.whl
+  hash:
+    sha256: f1548a8ed9158d59e03d7fed548c7db5549f3130d9ae19293c8638c202648f6d
+  category: main
+  optional: false
+- name: plotly
+  version: 6.1.2
+  manager: pip
+  platform: win-64
+  dependencies:
+    narwhals: '>=1.15.1'
+    packaging: '*'
+  url: https://files.pythonhosted.org/packages/bf/6f/759d5da0517547a5d38aabf05d04d9f8adf83391d2c7fc33f904417d3ba2/plotly-6.1.2-py3-none-any.whl
+  hash:
+    sha256: f1548a8ed9158d59e03d7fed548c7db5549f3130d9ae19293c8638c202648f6d
+  category: main
+  optional: false
 - name: py4design
   version: '0.32'
   manager: pip
   platform: linux-64
   dependencies:
+    cvxopt: '*'
     lxml: '*'
-    pyshp: '*'
+    matplotlib: '*'
+    networkx: '*'
     numpy: '*'
+    pycollada: '*'
+    pyshp: '*'
+    scikit-learn: '*'
     scipy: '*'
     sympy: '*'
-    pycollada: '*'
-    networkx: '*'
-    scikit-learn: '*'
-    cvxopt: '*'
-    matplotlib: '*'
   url: git+https://github.com/reyery/py4design.git@3323b1a3209a38fc08fad0d28dba176d0b99d3e2
   hash:
     sha256: 3323b1a3209a38fc08fad0d28dba176d0b99d3e2
-  category: main
   source:
     type: url
     url: git+https://github.com/reyery/py4design.git@3323b1a3209a38fc08fad0d28dba176d0b99d3e2
+  category: main
   optional: false
 - name: py4design
   version: '0.32'
   manager: pip
   platform: osx-64
   dependencies:
+    cvxopt: '*'
     lxml: '*'
-    pyshp: '*'
+    matplotlib: '*'
+    networkx: '*'
     numpy: '*'
+    pycollada: '*'
+    pyshp: '*'
+    scikit-learn: '*'
     scipy: '*'
     sympy: '*'
-    pycollada: '*'
-    networkx: '*'
-    scikit-learn: '*'
-    cvxopt: '*'
-    matplotlib: '*'
   url: git+https://github.com/reyery/py4design.git@3323b1a3209a38fc08fad0d28dba176d0b99d3e2
   hash:
     sha256: 3323b1a3209a38fc08fad0d28dba176d0b99d3e2
-  category: main
   source:
     type: url
     url: git+https://github.com/reyery/py4design.git@3323b1a3209a38fc08fad0d28dba176d0b99d3e2
+  category: main
   optional: false
 - name: py4design
   version: '0.32'
   manager: pip
   platform: osx-arm64
   dependencies:
+    cvxopt: '*'
     lxml: '*'
-    pyshp: '*'
+    matplotlib: '*'
+    networkx: '*'
     numpy: '*'
+    pycollada: '*'
+    pyshp: '*'
+    scikit-learn: '*'
     scipy: '*'
     sympy: '*'
-    pycollada: '*'
-    networkx: '*'
-    scikit-learn: '*'
-    cvxopt: '*'
-    matplotlib: '*'
   url: git+https://github.com/reyery/py4design.git@3323b1a3209a38fc08fad0d28dba176d0b99d3e2
   hash:
     sha256: 3323b1a3209a38fc08fad0d28dba176d0b99d3e2
-  category: main
   source:
     type: url
     url: git+https://github.com/reyery/py4design.git@3323b1a3209a38fc08fad0d28dba176d0b99d3e2
+  category: main
   optional: false
 - name: py4design
   version: '0.32'
   manager: pip
   platform: win-64
   dependencies:
+    cvxopt: '*'
     lxml: '*'
-    pyshp: '*'
+    matplotlib: '*'
+    networkx: '*'
     numpy: '*'
+    pycollada: '*'
+    pyshp: '*'
+    scikit-learn: '*'
     scipy: '*'
     sympy: '*'
-    pycollada: '*'
-    networkx: '*'
-    scikit-learn: '*'
-    cvxopt: '*'
-    matplotlib: '*'
   url: git+https://github.com/reyery/py4design.git@3323b1a3209a38fc08fad0d28dba176d0b99d3e2
   hash:
     sha256: 3323b1a3209a38fc08fad0d28dba176d0b99d3e2
-  category: main
   source:
     type: url
     url: git+https://github.com/reyery/py4design.git@3323b1a3209a38fc08fad0d28dba176d0b99d3e2
+  category: main
   optional: false
 - name: pycollada
   version: '0.8'
   manager: pip
   platform: linux-64
   dependencies:
-    python-dateutil: '>=2.2'
     numpy: '*'
+    python-dateutil: '>=2.2'
   url: https://files.pythonhosted.org/packages/dc/f1/5e81108414287278a01f1642271d7885e2aebc2bd10e7cf744d8c4cf0955/pycollada-0.8.tar.gz
   hash:
     sha256: f3a3759cc4cec1d59e932aad74399dbcf541d18862aad903c770040da42af20e
@@ -25621,8 +24872,8 @@ package:
   manager: pip
   platform: osx-64
   dependencies:
-    python-dateutil: '>=2.2'
     numpy: '*'
+    python-dateutil: '>=2.2'
   url: https://files.pythonhosted.org/packages/dc/f1/5e81108414287278a01f1642271d7885e2aebc2bd10e7cf744d8c4cf0955/pycollada-0.8.tar.gz
   hash:
     sha256: f3a3759cc4cec1d59e932aad74399dbcf541d18862aad903c770040da42af20e
@@ -25633,8 +24884,8 @@ package:
   manager: pip
   platform: osx-arm64
   dependencies:
-    python-dateutil: '>=2.2'
     numpy: '*'
+    python-dateutil: '>=2.2'
   url: https://files.pythonhosted.org/packages/dc/f1/5e81108414287278a01f1642271d7885e2aebc2bd10e7cf744d8c4cf0955/pycollada-0.8.tar.gz
   hash:
     sha256: f3a3759cc4cec1d59e932aad74399dbcf541d18862aad903c770040da42af20e
@@ -25645,8 +24896,8 @@ package:
   manager: pip
   platform: win-64
   dependencies:
-    python-dateutil: '>=2.2'
     numpy: '*'
+    python-dateutil: '>=2.2'
   url: https://files.pythonhosted.org/packages/dc/f1/5e81108414287278a01f1642271d7885e2aebc2bd10e7cf744d8c4cf0955/pycollada-0.8.tar.gz
   hash:
     sha256: f3a3759cc4cec1d59e932aad74399dbcf541d18862aad903c770040da42af20e
@@ -25964,6 +25215,54 @@ package:
     sha256: f0971ac4c65accc489154fe12efd88f53ca8caf04754c46a66e85f5102ef22ad
   category: main
   optional: false
+- name: python-louvain
+  version: '0.16'
+  manager: pip
+  platform: linux-64
+  dependencies:
+    networkx: '*'
+    numpy: '*'
+  url: https://files.pythonhosted.org/packages/7c/0d/8787b021d52eb8764c0bb18ab95f720cf554902044c6a5cb1865daf45763/python-louvain-0.16.tar.gz
+  hash:
+    sha256: b7ba2df5002fd28d3ee789a49532baad11fe648e4f2117cf0798e7520a1da56b
+  category: main
+  optional: false
+- name: python-louvain
+  version: '0.16'
+  manager: pip
+  platform: osx-64
+  dependencies:
+    networkx: '*'
+    numpy: '*'
+  url: https://files.pythonhosted.org/packages/7c/0d/8787b021d52eb8764c0bb18ab95f720cf554902044c6a5cb1865daf45763/python-louvain-0.16.tar.gz
+  hash:
+    sha256: b7ba2df5002fd28d3ee789a49532baad11fe648e4f2117cf0798e7520a1da56b
+  category: main
+  optional: false
+- name: python-louvain
+  version: '0.16'
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    networkx: '*'
+    numpy: '*'
+  url: https://files.pythonhosted.org/packages/7c/0d/8787b021d52eb8764c0bb18ab95f720cf554902044c6a5cb1865daf45763/python-louvain-0.16.tar.gz
+  hash:
+    sha256: b7ba2df5002fd28d3ee789a49532baad11fe648e4f2117cf0798e7520a1da56b
+  category: main
+  optional: false
+- name: python-louvain
+  version: '0.16'
+  manager: pip
+  platform: win-64
+  dependencies:
+    networkx: '*'
+    numpy: '*'
+  url: https://files.pythonhosted.org/packages/7c/0d/8787b021d52eb8764c0bb18ab95f720cf554902044c6a5cb1865daf45763/python-louvain-0.16.tar.gz
+  hash:
+    sha256: b7ba2df5002fd28d3ee789a49532baad11fe648e4f2117cf0798e7520a1da56b
+  category: main
+  optional: false
 - name: python-multipart
   version: 0.0.20
   manager: pip
@@ -26096,56 +25395,64 @@ package:
     sha256: ee7e1056b9aea0f04c6c2ed59452947f34c4940ee025f5dd83e6a6418b6989e4
   category: main
   optional: false
-- name: setuptools-scm
-  version: 8.0.4
+- name: salib
+  version: 1.4.8
   manager: pip
   platform: linux-64
   dependencies:
-    packaging: '>=20'
-    typing-extensions: '*'
-    tomli: '>=1'
-  url: https://files.pythonhosted.org/packages/0e/a3/b9a8b0adfe672bf0df5901707aa929d30a97ee390ba651910186776746d2/setuptools_scm-8.0.4-py3-none-any.whl
+    matplotlib: '>=3.2.2'
+    multiprocess: '*'
+    numpy: '>=1.20.3'
+    pandas: '>=1.2'
+    scipy: '>=1.7.3'
+  url: https://files.pythonhosted.org/packages/c3/ea/600e4122a3f063882d7509aed97554ab6e95e874a6bf67e553cdff07e499/salib-1.4.8-py3-none-any.whl
   hash:
-    sha256: b47844cd2a84b83b3187a5782c71128c28b4c94cad8bfb871da2784a5cb54c4f
+    sha256: fef0f0637a97f1adca35a435e41274add6275ea42428f04d3e83deb720cc0234
   category: main
   optional: false
-- name: setuptools-scm
-  version: 8.0.4
+- name: salib
+  version: 1.4.8
   manager: pip
   platform: osx-64
   dependencies:
-    packaging: '>=20'
-    typing-extensions: '*'
-    tomli: '>=1'
-  url: https://files.pythonhosted.org/packages/0e/a3/b9a8b0adfe672bf0df5901707aa929d30a97ee390ba651910186776746d2/setuptools_scm-8.0.4-py3-none-any.whl
+    matplotlib: '>=3.2.2'
+    multiprocess: '*'
+    numpy: '>=1.20.3'
+    pandas: '>=1.2'
+    scipy: '>=1.7.3'
+  url: https://files.pythonhosted.org/packages/c3/ea/600e4122a3f063882d7509aed97554ab6e95e874a6bf67e553cdff07e499/salib-1.4.8-py3-none-any.whl
   hash:
-    sha256: b47844cd2a84b83b3187a5782c71128c28b4c94cad8bfb871da2784a5cb54c4f
+    sha256: fef0f0637a97f1adca35a435e41274add6275ea42428f04d3e83deb720cc0234
   category: main
   optional: false
-- name: setuptools-scm
-  version: 8.0.4
+- name: salib
+  version: 1.4.8
   manager: pip
   platform: osx-arm64
   dependencies:
-    packaging: '>=20'
-    typing-extensions: '*'
-    tomli: '>=1'
-  url: https://files.pythonhosted.org/packages/0e/a3/b9a8b0adfe672bf0df5901707aa929d30a97ee390ba651910186776746d2/setuptools_scm-8.0.4-py3-none-any.whl
+    matplotlib: '>=3.2.2'
+    multiprocess: '*'
+    numpy: '>=1.20.3'
+    pandas: '>=1.2'
+    scipy: '>=1.7.3'
+  url: https://files.pythonhosted.org/packages/c3/ea/600e4122a3f063882d7509aed97554ab6e95e874a6bf67e553cdff07e499/salib-1.4.8-py3-none-any.whl
   hash:
-    sha256: b47844cd2a84b83b3187a5782c71128c28b4c94cad8bfb871da2784a5cb54c4f
+    sha256: fef0f0637a97f1adca35a435e41274add6275ea42428f04d3e83deb720cc0234
   category: main
   optional: false
-- name: setuptools-scm
-  version: 8.0.4
+- name: salib
+  version: 1.4.8
   manager: pip
   platform: win-64
   dependencies:
-    packaging: '>=20'
-    typing-extensions: '*'
-    tomli: '>=1'
-  url: https://files.pythonhosted.org/packages/0e/a3/b9a8b0adfe672bf0df5901707aa929d30a97ee390ba651910186776746d2/setuptools_scm-8.0.4-py3-none-any.whl
+    matplotlib: '>=3.2.2'
+    multiprocess: '*'
+    numpy: '>=1.20.3'
+    pandas: '>=1.2'
+    scipy: '>=1.7.3'
+  url: https://files.pythonhosted.org/packages/c3/ea/600e4122a3f063882d7509aed97554ab6e95e874a6bf67e553cdff07e499/salib-1.4.8-py3-none-any.whl
   hash:
-    sha256: b47844cd2a84b83b3187a5782c71128c28b4c94cad8bfb871da2784a5cb54c4f
+    sha256: fef0f0637a97f1adca35a435e41274add6275ea42428f04d3e83deb720cc0234
   category: main
   optional: false
 - name: simple-websocket
@@ -26245,8 +25552,8 @@ package:
   manager: pip
   platform: linux-64
   dependencies:
-    sqlalchemy: '>=2.0.14,<2.1.0'
     pydantic: '>=1.10.13,<3.0.0'
+    sqlalchemy: '>=2.0.14,<2.1.0'
   url: https://files.pythonhosted.org/packages/16/91/484cd2d05569892b7fef7f5ceab3bc89fb0f8a8c0cde1030d383dbc5449c/sqlmodel-0.0.24-py3-none-any.whl
   hash:
     sha256: 6778852f09370908985b667d6a3ab92910d0d5ec88adcaf23dbc242715ff7193
@@ -26257,8 +25564,8 @@ package:
   manager: pip
   platform: osx-64
   dependencies:
-    sqlalchemy: '>=2.0.14,<2.1.0'
     pydantic: '>=1.10.13,<3.0.0'
+    sqlalchemy: '>=2.0.14,<2.1.0'
   url: https://files.pythonhosted.org/packages/16/91/484cd2d05569892b7fef7f5ceab3bc89fb0f8a8c0cde1030d383dbc5449c/sqlmodel-0.0.24-py3-none-any.whl
   hash:
     sha256: 6778852f09370908985b667d6a3ab92910d0d5ec88adcaf23dbc242715ff7193
@@ -26269,8 +25576,8 @@ package:
   manager: pip
   platform: osx-arm64
   dependencies:
-    sqlalchemy: '>=2.0.14,<2.1.0'
     pydantic: '>=1.10.13,<3.0.0'
+    sqlalchemy: '>=2.0.14,<2.1.0'
   url: https://files.pythonhosted.org/packages/16/91/484cd2d05569892b7fef7f5ceab3bc89fb0f8a8c0cde1030d383dbc5449c/sqlmodel-0.0.24-py3-none-any.whl
   hash:
     sha256: 6778852f09370908985b667d6a3ab92910d0d5ec88adcaf23dbc242715ff7193
@@ -26281,8 +25588,8 @@ package:
   manager: pip
   platform: win-64
   dependencies:
-    sqlalchemy: '>=2.0.14,<2.1.0'
     pydantic: '>=1.10.13,<3.0.0'
+    sqlalchemy: '>=2.0.14,<2.1.0'
   url: https://files.pythonhosted.org/packages/16/91/484cd2d05569892b7fef7f5ceab3bc89fb0f8a8c0cde1030d383dbc5449c/sqlmodel-0.0.24-py3-none-any.whl
   hash:
     sha256: 6778852f09370908985b667d6a3ab92910d0d5ec88adcaf23dbc242715ff7193
@@ -26380,6 +25687,98 @@ package:
     sha256: c3588cd4295d0c0f603d0f2ae780587e64e2efeedb3521e46b9bb1d08d184fa5
   category: main
   optional: false
+- name: timezonefinder
+  version: 6.5.9
+  manager: pip
+  platform: linux-64
+  dependencies:
+    cffi: '>=1.15.1,<2'
+    h3: '>4'
+    numpy: '>=1.21,<3'
+  url: https://files.pythonhosted.org/packages/9e/ca/e36f8c2f970077facbc7d57f60fd4cf8cb2f50bda529758cdbcb4d7730ae/timezonefinder-6.5.9-cp38-cp38-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl
+  hash:
+    sha256: f7af80ceac094932c07750d384539f6c4397c7b1bcbbb51dc9d5a90a65ad1df4
+  category: main
+  optional: false
+- name: timezonefinder
+  version: 6.5.9
+  manager: pip
+  platform: osx-64
+  dependencies:
+    cffi: '>=1.15.1,<2'
+    h3: '>4'
+    numpy: '>=1.21,<3'
+  url: https://files.pythonhosted.org/packages/5e/4d/8694391d6b014bc49f8fd2eb8c05c94526b36fba8dc76d439f3d51948e46/timezonefinder-6.5.9.tar.gz
+  hash:
+    sha256: 0d84c792a499fd098a35c701c3e3293423ba8d45c81b3eecd7c7cb72c7f1f415
+  category: main
+  optional: false
+- name: timezonefinder
+  version: 6.5.9
+  manager: pip
+  platform: osx-arm64
+  dependencies:
+    cffi: '>=1.15.1,<2'
+    h3: '>4'
+    numpy: '>=1.21,<3'
+  url: https://files.pythonhosted.org/packages/5e/4d/8694391d6b014bc49f8fd2eb8c05c94526b36fba8dc76d439f3d51948e46/timezonefinder-6.5.9.tar.gz
+  hash:
+    sha256: 0d84c792a499fd098a35c701c3e3293423ba8d45c81b3eecd7c7cb72c7f1f415
+  category: main
+  optional: false
+- name: timezonefinder
+  version: 6.5.9
+  manager: pip
+  platform: win-64
+  dependencies:
+    cffi: '>=1.15.1,<2'
+    h3: '>4'
+    numpy: '>=1.21,<3'
+  url: https://files.pythonhosted.org/packages/5e/4d/8694391d6b014bc49f8fd2eb8c05c94526b36fba8dc76d439f3d51948e46/timezonefinder-6.5.9.tar.gz
+  hash:
+    sha256: 0d84c792a499fd098a35c701c3e3293423ba8d45c81b3eecd7c7cb72c7f1f415
+  category: main
+  optional: false
+- name: utm
+  version: 0.8.1
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/3b/a4/0698f3e5c397442ec9323a537e48cc63b846288b6878d38efd04e91005e3/utm-0.8.1-py3-none-any.whl
+  hash:
+    sha256: e3d5e224082af138e40851dcaad08d7f99da1cc4b5c413a7de34eabee35f434a
+  category: main
+  optional: false
+- name: utm
+  version: 0.8.1
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/3b/a4/0698f3e5c397442ec9323a537e48cc63b846288b6878d38efd04e91005e3/utm-0.8.1-py3-none-any.whl
+  hash:
+    sha256: e3d5e224082af138e40851dcaad08d7f99da1cc4b5c413a7de34eabee35f434a
+  category: main
+  optional: false
+- name: utm
+  version: 0.8.1
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/3b/a4/0698f3e5c397442ec9323a537e48cc63b846288b6878d38efd04e91005e3/utm-0.8.1-py3-none-any.whl
+  hash:
+    sha256: e3d5e224082af138e40851dcaad08d7f99da1cc4b5c413a7de34eabee35f434a
+  category: main
+  optional: false
+- name: utm
+  version: 0.8.1
+  manager: pip
+  platform: win-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/3b/a4/0698f3e5c397442ec9323a537e48cc63b846288b6878d38efd04e91005e3/utm-0.8.1-py3-none-any.whl
+  hash:
+    sha256: e3d5e224082af138e40851dcaad08d7f99da1cc4b5c413a7de34eabee35f434a
+  category: main
+  optional: false
 - name: uvicorn
   version: 0.33.0
   manager: pip
@@ -26437,11 +25836,11 @@ package:
   manager: pip
   platform: linux-64
   dependencies:
-    numpy: '*'
-    scipy: '*'
-    networkx: '*'
-    pandas: '*'
     matplotlib: '*'
+    networkx: '*'
+    numpy: '*'
+    pandas: '*'
+    scipy: '*'
   url: https://files.pythonhosted.org/packages/75/9f/d27ade1ca2ac73064913aaca653d768174049e5f9ad8c07f85036463df69/wntr-0.2.3-py3-none-any.whl
   hash:
     sha256: 5f16fb016cb70c519b2f86e70646c624c618ed38de90f110fd3dbd55591d15d5
@@ -26452,11 +25851,11 @@ package:
   manager: pip
   platform: osx-64
   dependencies:
-    numpy: '*'
-    scipy: '*'
-    networkx: '*'
-    pandas: '*'
     matplotlib: '*'
+    networkx: '*'
+    numpy: '*'
+    pandas: '*'
+    scipy: '*'
   url: https://files.pythonhosted.org/packages/75/9f/d27ade1ca2ac73064913aaca653d768174049e5f9ad8c07f85036463df69/wntr-0.2.3-py3-none-any.whl
   hash:
     sha256: 5f16fb016cb70c519b2f86e70646c624c618ed38de90f110fd3dbd55591d15d5
@@ -26467,11 +25866,11 @@ package:
   manager: pip
   platform: osx-arm64
   dependencies:
-    numpy: '*'
-    scipy: '*'
-    networkx: '*'
-    pandas: '*'
     matplotlib: '*'
+    networkx: '*'
+    numpy: '*'
+    pandas: '*'
+    scipy: '*'
   url: https://files.pythonhosted.org/packages/75/9f/d27ade1ca2ac73064913aaca653d768174049e5f9ad8c07f85036463df69/wntr-0.2.3-py3-none-any.whl
   hash:
     sha256: 5f16fb016cb70c519b2f86e70646c624c618ed38de90f110fd3dbd55591d15d5
@@ -26482,11 +25881,11 @@ package:
   manager: pip
   platform: win-64
   dependencies:
-    numpy: '*'
-    scipy: '*'
-    networkx: '*'
-    pandas: '*'
     matplotlib: '*'
+    networkx: '*'
+    numpy: '*'
+    pandas: '*'
+    scipy: '*'
   url: https://files.pythonhosted.org/packages/75/9f/d27ade1ca2ac73064913aaca653d768174049e5f9ad8c07f85036463df69/wntr-0.2.3-py3-none-any.whl
   hash:
     sha256: 5f16fb016cb70c519b2f86e70646c624c618ed38de90f110fd3dbd55591d15d5
@@ -26534,6 +25933,86 @@ package:
   url: https://files.pythonhosted.org/packages/78/58/e860788190eba3bcce367f74d29c4675466ce8dddfba85f7827588416f01/wsproto-1.2.0-py3-none-any.whl
   hash:
     sha256: b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736
+  category: main
+  optional: false
+- name: xlrd
+  version: 2.0.1
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/a6/0c/c2a72d51fe56e08a08acc85d13013558a2d793028ae7385448a6ccdfae64/xlrd-2.0.1-py2.py3-none-any.whl
+  hash:
+    sha256: 6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd
+  category: main
+  optional: false
+- name: xlrd
+  version: 2.0.1
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/a6/0c/c2a72d51fe56e08a08acc85d13013558a2d793028ae7385448a6ccdfae64/xlrd-2.0.1-py2.py3-none-any.whl
+  hash:
+    sha256: 6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd
+  category: main
+  optional: false
+- name: xlrd
+  version: 2.0.1
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/a6/0c/c2a72d51fe56e08a08acc85d13013558a2d793028ae7385448a6ccdfae64/xlrd-2.0.1-py2.py3-none-any.whl
+  hash:
+    sha256: 6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd
+  category: main
+  optional: false
+- name: xlrd
+  version: 2.0.1
+  manager: pip
+  platform: win-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/a6/0c/c2a72d51fe56e08a08acc85d13013558a2d793028ae7385448a6ccdfae64/xlrd-2.0.1-py2.py3-none-any.whl
+  hash:
+    sha256: 6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd
+  category: main
+  optional: false
+- name: xlwt
+  version: 1.3.0
+  manager: pip
+  platform: linux-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/44/48/def306413b25c3d01753603b1a222a011b8621aed27cd7f89cbc27e6b0f4/xlwt-1.3.0-py2.py3-none-any.whl
+  hash:
+    sha256: a082260524678ba48a297d922cc385f58278b8aa68741596a87de01a9c628b2e
+  category: main
+  optional: false
+- name: xlwt
+  version: 1.3.0
+  manager: pip
+  platform: osx-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/44/48/def306413b25c3d01753603b1a222a011b8621aed27cd7f89cbc27e6b0f4/xlwt-1.3.0-py2.py3-none-any.whl
+  hash:
+    sha256: a082260524678ba48a297d922cc385f58278b8aa68741596a87de01a9c628b2e
+  category: main
+  optional: false
+- name: xlwt
+  version: 1.3.0
+  manager: pip
+  platform: osx-arm64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/44/48/def306413b25c3d01753603b1a222a011b8621aed27cd7f89cbc27e6b0f4/xlwt-1.3.0-py2.py3-none-any.whl
+  hash:
+    sha256: a082260524678ba48a297d922cc385f58278b8aa68741596a87de01a9c628b2e
+  category: main
+  optional: false
+- name: xlwt
+  version: 1.3.0
+  manager: pip
+  platform: win-64
+  dependencies: {}
+  url: https://files.pythonhosted.org/packages/44/48/def306413b25c3d01753603b1a222a011b8621aed27cd7f89cbc27e6b0f4/xlwt-1.3.0-py2.py3-none-any.whl
+  hash:
+    sha256: a082260524678ba48a297d922cc385f58278b8aa68741596a87de01a9c628b2e
   category: main
   optional: false
 - name: zipp

--- a/environment.yml
+++ b/environment.yml
@@ -3,40 +3,27 @@ channels:
 - conda-forge
 dependencies:
 - cvxopt # For wntr
-- deap
-- ephem
 - fiona
 - geopandas=0.13 # Due to python3.8 support
 - libpysal
-- networkx=2.8
 - numba=0.57
 - numpy=1.24 # Due to python3.8 support
-- numpy-financial
 - osmnx=1.8
 - pip
 - psutil
-- pvlib-python
+- pvlib
 - python=3.8 # Held back by wntr version
-- python-louvain
 - pythonocc-core==7.7.0 # Avoid deprecation warnings
-- pytz # Not required from 3.9
 - pyyaml
-- salib
 - scikit-learn=1.3.2
 - scipy=1.10 # Due to python3.8 support
 - shapely=2
-- timezonefinder
 - matplotlib
 - notebook
-- openpyxl
-- plotly
-- utm
-- xlrd
-- xlwt
 - pyarrow
 - git
-- yarn=4 # Use latest version of yarn
 - pip:
+  # Web
   - aiocache[redis]
   - fastapi
   - pydantic-settings
@@ -48,5 +35,19 @@ dependencies:
   - asyncpg # Required by sqlmodel for postgres
   - aiosqlite # Required for async sqlite adapter
   - pyjwt[crypto] # Required by fastapi for JWT authentication
+  # Python packages
+  - deap
+  - ephem
+  - networkx==2.8
+  - numpy-financial
+  - python-louvain
+  - pytz # Not required from 3.9
+  - salib
+  - timezonefinder
+  - openpyxl
+  - plotly
+  - utm
+  - xlrd
+  - xlwt
   - wntr==0.2.3
   - git+https://github.com/reyery/py4design.git@ignore-display # modified p4design to remove deprecated functions


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the environment setup by moving several Python package dependencies from conda to pip installation.
  - Removed "yarn" from the environment dependencies.
  - Improved organization of package listings for easier management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->