### PR TITLE
Allow server settings to read from .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ setup/Dependencies/Python/*
 setup/win-unpacked/*
 setup/CityEnergyAnalyst-GUI-win32-x64/*
 setup/Dependencies/cityenergyanalyst.tar.gz
+
+*.local

--- a/cea/interfaces/dashboard/app.py
+++ b/cea/interfaces/dashboard/app.py
@@ -56,7 +56,8 @@ app.include_router(server.router, prefix='/server')
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     logger.error("Found validation errors:", exc.errors())
-    logger.error("url", request.url)
+    if request:
+        logger.error("request", request)
 
     return JSONResponse(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/cea/interfaces/dashboard/lib/database/settings.py
+++ b/cea/interfaces/dashboard/lib/database/settings.py
@@ -6,7 +6,8 @@ from cea.interfaces.dashboard.constants import ENV_VAR_PREFIX
 
 
 class DatabaseSettings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix=ENV_VAR_PREFIX + "db_")
+    model_config = SettingsConfigDict(env_prefix=ENV_VAR_PREFIX + "db_",
+                                      env_file=('.env', '.env.local'), extra="ignore")
 
     path: Optional[str] = None
     # TODO: Parse url using sqlalchemy

--- a/cea/interfaces/dashboard/settings.py
+++ b/cea/interfaces/dashboard/settings.py
@@ -14,7 +14,8 @@ logger = getCEAServerLogger("cea-server-settings")
 
 
 class StackAuthSettings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix=ENV_VAR_PREFIX + "auth_")
+    model_config = SettingsConfigDict(env_prefix=ENV_VAR_PREFIX + "auth_",
+                                      env_file=('.env', '.env.local'), extra="ignore")
 
     project_id: Optional[str] = None
     publishable_client_key: Optional[str] = None
@@ -22,7 +23,8 @@ class StackAuthSettings(BaseSettings):
 
 class Settings(BaseSettings):
     # Use "cea_" as prefix for env vars
-    model_config = SettingsConfigDict(env_prefix=ENV_VAR_PREFIX)
+    model_config = SettingsConfigDict(env_prefix=ENV_VAR_PREFIX,
+                                      env_file=('.env', '.env.local'), extra="ignore")
 
     # Settings from cea.config
     host: Optional[str] = None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration to load environment variables from both `.env` and `.env.local` files and to ignore unspecified fields.
	- Modified `.gitignore` to exclude files with the `.local` extension.
- **Bug Fixes**
	- Improved error handling by refining request logging in validation error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->