### PR TITLE
Remove ensure_folder from locator methods

### DIFF
--- a/cea/analysis/costs/system_costs.py
+++ b/cea/analysis/costs/system_costs.py
@@ -96,6 +96,7 @@ def costs_main(locator, config):
     result_out = pd.DataFrame(result)
 
     # save dataframe
+    locator.ensure_parent_folder_exists(locator.get_costs_operation_file())
     result_out.to_csv(locator.get_costs_operation_file(), index=False, float_format='%.2f',  na_rep='nan')
 
 

--- a/cea/analysis/lca/embodied.py
+++ b/cea/analysis/lca/embodied.py
@@ -209,6 +209,7 @@ def lca_embodied(year_to_calculate, locator):
 
     # export the results for embodied emissions (E_ghg_) and non-renewable primary energy (E_nre_pen_) for each
     # building, both total (in t CO2-eq. and GJ) and per square meter (in kg CO2-eq./m2 and MJ/m2)
+    locator.ensure_parent_folder_exists(locator.get_lca_embodied())
     result_emissions.to_csv(locator.get_lca_embodied(),
                             index=False,
                             float_format='%.2f', na_rep='nan')

--- a/cea/analysis/lca/operation.py
+++ b/cea/analysis/lca/operation.py
@@ -164,6 +164,7 @@ def lca_operation(locator):
     # export the total operational non-renewable energy demand and emissions for each building
     fields_to_plot = ['name', 'GFA_m2', 'GHG_sys_tonCO2', 'GHG_sys_building_scale_tonCO2',
                       'GHG_sys_district_scale_tonCO2'] + fields_to_plot
+    locator.ensure_parent_folder_exists(locator.get_lca_operation())
     result[fields_to_plot].to_csv(locator.get_lca_operation(), index=False, float_format='%.2f', na_rep='nan')
 
 

--- a/cea/analysis/multicriteria/main.py
+++ b/cea/analysis/multicriteria/main.py
@@ -38,6 +38,7 @@ def multi_criteria_main(locator,
                                             weight_total_capital_costs,
                                             weight_annual_operation_costs,
                                             weight_annual_emissions)
+    locator.ensure_parent_folder_exists(locator.get_multi_criteria_analysis(generation))
     compiled_data_df.to_csv(locator.get_multi_criteria_analysis(generation), index=False)
     return
 

--- a/cea/datamanagement/archetypes_mapper.py
+++ b/cea/datamanagement/archetypes_mapper.py
@@ -101,7 +101,6 @@ def archetypes_mapper(locator,
 
 
 def indoor_comfort_mapper(list_uses, locator, occupant_densities, building_typology_df):
-    locator.ensure_parent_folder_exists(locator.get_building_comfort())
     comfort_DB = pd.read_csv(locator.get_database_archetypes_use_type())
     # define comfort
     prop_comfort_df = building_typology_df.merge(comfort_DB, left_on='use_type1', right_on='use_type')
@@ -119,10 +118,10 @@ def indoor_comfort_mapper(list_uses, locator, occupant_densities, building_typol
                                                         occupant_densities,
                                                         list_uses,
                                                         comfort_DB)
+    locator.ensure_parent_folder_exists(locator.get_building_comfort())
     prop_comfort_df_merged[fields].to_csv(locator.get_building_comfort(), index=False)
 
 def internal_loads_mapper(list_uses, locator, occupant_densities, building_typology_df):
-    locator.ensure_parent_folder_exists(locator.get_building_internal())
     internal_DB = pd.read_csv(locator.get_database_archetypes_use_type())
     # define comfort
     prop_internal_df = building_typology_df.merge(internal_DB, left_on='use_type1', right_on='use_type')
@@ -146,11 +145,11 @@ def internal_loads_mapper(list_uses, locator, occupant_densities, building_typol
                                                          occupant_densities,
                                                          list_uses,
                                                          internal_DB)
+    locator.ensure_parent_folder_exists(locator.get_building_internal())
     prop_internal_df_merged[fields].to_csv(locator.get_building_internal(), index=False)
 
 
 def supply_mapper(locator, building_typology_df):
-    locator.ensure_parent_folder_exists(locator.get_building_supply())
     supply_DB = pd.read_csv(locator.get_database_archetypes_construction_type())
     prop_supply_df = building_typology_df.merge(supply_DB, left_on='const_type', right_on='const_type')
     fields = ['name',
@@ -158,10 +157,10 @@ def supply_mapper(locator, building_typology_df):
               'supply_type_hs',
               'supply_type_dhw',
               'supply_type_el']
+    locator.ensure_parent_folder_exists(locator.get_building_supply())
     prop_supply_df[fields].to_csv(locator.get_building_supply(), index=False)
 
 def aircon_mapper(locator, typology_df):
-    locator.ensure_parent_folder_exists(locator.get_building_air_conditioning())
     air_conditioning_DB = pd.read_csv(locator.get_database_archetypes_construction_type())
     # define HVAC systems types
     prop_HVAC_df = typology_df.merge(air_conditioning_DB, left_on='const_type', right_on='const_type')
@@ -176,11 +175,11 @@ def aircon_mapper(locator, typology_df):
               'hvac_heat_ends',
               'hvac_cool_starts',
               'hvac_cool_ends']
+    locator.ensure_parent_folder_exists(locator.get_building_air_conditioning())
     prop_HVAC_df[fields].to_csv(locator.get_building_air_conditioning(), index=False)
 
 
 def architecture_mapper(locator, typology_df):
-    locator.ensure_parent_folder_exists(locator.get_building_architecture())
     architecture_DB = pd.read_csv(locator.get_database_archetypes_construction_type())
     prop_architecture_df = typology_df.merge(architecture_DB, left_on='const_type', right_on='const_type')
     fields = ['name',
@@ -202,6 +201,7 @@ def architecture_mapper(locator, typology_df):
               'type_wall',
               'type_win',
               'type_shade']
+    locator.ensure_parent_folder_exists(locator.get_building_architecture())
     prop_architecture_df[fields].to_csv(locator.get_building_architecture(), index=False)
 
 def calc_code(code1, code2, code3, code4):

--- a/cea/demand/demand_writers.py
+++ b/cea/demand/demand_writers.py
@@ -100,12 +100,14 @@ class HourlyDemandWriter(DemandWriter):
         super(HourlyDemandWriter, self).__init__(loads, massflows, temperatures)
 
     def write_to_csv(self, building_name, columns, hourly_data, locator):
+        locator.ensure_parent_folder_exists(locator.get_demand_results_file(building_name, 'csv'))
         hourly_data.to_csv(locator.get_demand_results_file(building_name, 'csv'), columns=columns,
                            float_format=FLOAT_FORMAT, na_rep='nan')
 
     def write_to_hdf5(self, building_name, columns, hourly_data, locator):
         # fixing columns with strings
         hourly_data.drop('name', inplace=True, axis=1)
+        locator.ensure_parent_folder_exists(locator.get_demand_results_file(building_name, 'hdf'))
         hourly_data.to_hdf(locator.get_demand_results_file(building_name, 'hdf'), key='dataset')
 
 
@@ -120,6 +122,7 @@ class MonthlyDemandWriter(DemandWriter):
     def write_to_csv(self, building_name, columns, hourly_data, locator):
         # get monthly totals and rename to MWhyr
         monthly_data_new = self.calc_monthly_dataframe(building_name, hourly_data)
+        locator.ensure_parent_folder_exists(locator.get_demand_results_file(building_name, 'csv'))
         monthly_data_new.to_csv(locator.get_demand_results_file(building_name, 'csv'), index=False,
                                 float_format=FLOAT_FORMAT, na_rep='nan')
 
@@ -173,7 +176,10 @@ class YearlyDemandWriter:
                 df = pd.read_csv(temporary_file)
             else:
                 df = pd.concat([df, pd.read_csv(temporary_file)], ignore_index=True)
-        df.to_csv(locator.get_total_demand('csv'), index=False, float_format='%.3f', na_rep='nan')
+        
+        if df is not None:
+            locator.ensure_parent_folder_exists(locator.get_total_demand('csv'))
+            df.to_csv(locator.get_total_demand('csv'), index=False, float_format='%.3f', na_rep='nan')
 
     @staticmethod
     def write_aggregate_hourly(locator, building_names):
@@ -190,6 +196,7 @@ class YearlyDemandWriter:
         aggregated_hourly_results_df = aggregated_hourly_results_df.drop(columns=['name', 'x_int'])
 
         # save hourly results
+        locator.ensure_parent_folder_exists(locator.get_total_demand_hourly('csv'))
         aggregated_hourly_results_df.to_csv(locator.get_total_demand_hourly('csv'),
                                             index=True, float_format='%.3f', na_rep='nan')
 

--- a/cea/demand/occupancy_helper.py
+++ b/cea/demand/occupancy_helper.py
@@ -274,6 +274,7 @@ def calc_schedules(locator,
     }
 
     yearly_occupancy_schedules = pd.DataFrame(final_dict)
+    locator.ensure_parent_folder_exists(locator.get_occupancy_model_file(building))
     yearly_occupancy_schedules.to_csv(locator.get_occupancy_model_file(building), index=False, na_rep='OFF',
                                       float_format='%.3f')
 

--- a/cea/inputlocator.py
+++ b/cea/inputlocator.py
@@ -1329,11 +1329,6 @@ class InputLocator(object):
     def get_radiation_metadata(self, building):
         """scenario/outputs/data/solar-radiation/{building}_geometrgy.csv"""
         return os.path.join(self.get_solar_radiation_folder(), '%s_geometry.csv' % building)
- 
-    def get_radiation_metadata_usr(self, building):
-        base_folder = os.path.join(self.get_solar_radiation_folder(), "input_files_USR", "BuildingSensorGeometry")
-        os.makedirs(base_folder, exist_ok=True)
-        return os.path.join(base_folder, '%s_geometry.csv' % building)
 
     def get_radiation_materials(self):
         """scenario/outputs/data/solar-radiation/{building}_geometry.csv"""

--- a/cea/inputlocator.py
+++ b/cea/inputlocator.py
@@ -88,6 +88,9 @@ class InputLocator(object):
     @staticmethod
     def _clear_folder(folder):
         """Delete all files in a folder"""
+        if not os.path.exists(folder):
+            return
+
         for filename in os.listdir(folder):
             file_path = os.path.join(folder, filename)
             try:

--- a/cea/inputlocator.py
+++ b/cea/inputlocator.py
@@ -324,24 +324,24 @@ class InputLocator(object):
 
     def get_optimization_results_folder(self):
         """Returns the folder containing the scenario's optimization results"""
-        return self._ensure_folder(self.scenario, 'outputs', 'data', 'optimization')
+        return os.path.join(self.scenario, 'outputs', 'data', 'optimization')
 
 
     def get_electrical_and_thermal_network_optimization_results_folder(self):
         """scenario/outputs/data/optimization"""
-        return self._ensure_folder(self.get_optimization_results_folder(), 'electrical_and_thermal_network')
+        return os.path.join(self.get_optimization_results_folder(), 'electrical_and_thermal_network')
 
     def get_optimization_master_results_folder(self):
         """Returns the folder containing the scenario's optimization Master Checkpoints"""
-        return self._ensure_folder(self.get_optimization_results_folder(), "master")
+        return os.path.join(self.get_optimization_results_folder(), "master")
 
     def get_optimization_slave_results_folder(self):
         """Returns the folder containing the scenario's optimization Slave results (storage + operation pattern)"""
-        return self._ensure_folder(self.get_optimization_results_folder(), "slave")
+        return os.path.join(self.get_optimization_results_folder(), "slave")
 
     def get_optimization_slave_generation_results_folder(self, gen_num):
         """Returns the folder containing the scenario's optimization Slave results (storage + operation pattern)"""
-        return self._ensure_folder(
+        return os.path.join(
             os.path.join(self.get_optimization_slave_results_folder(), "gen_%(gen_num)s" % locals()))
 
     def get_optimization_individuals_in_generation(self, gen_num):
@@ -467,13 +467,13 @@ class InputLocator(object):
         """scenario/outputs/data/optimization/network
         Network summary results
         """
-        return self._ensure_folder(self.get_optimization_results_folder(), "network")
+        return os.path.join(self.get_optimization_results_folder(), "network")
 
     def get_optimization_network_layout_folder(self):
         """scenario/outputs/data/optimization/network/layout
         Network layout files
         """
-        return self._ensure_folder(self.get_optimization_network_results_folder(), "layout")
+        return os.path.join(self.get_optimization_network_results_folder(), "layout")
 
     def get_optimization_network_layout_costs_file(self, network_type):
         """scenario/outputs/data/optimization/network/layout/DC_costs.csv
@@ -506,7 +506,7 @@ class InputLocator(object):
     def get_optimization_decentralized_folder(self):
         """scenario/outputs/data/optimization/decentralized
         Operation pattern for decentralized buildings"""
-        return self._ensure_folder(self.get_optimization_results_folder(), "decentralized")
+        return os.path.join(self.get_optimization_results_folder(), "decentralized")
 
     def get_optimization_checkpoint(self, generation):
         """scenario/outputs/data/optimization/master/..."""
@@ -516,7 +516,7 @@ class InputLocator(object):
     def get_optimization_substations_folder(self):
         """scenario/outputs/data/optimization/substations
         Substation results for decentralized buildings"""
-        return self._ensure_folder(self.get_optimization_results_folder(), "decentralized", "substations")
+        return os.path.join(self.get_optimization_results_folder(), "decentralized", "substations")
 
     def get_optimization_substations_results_file(self, building, network_type, district_network_barcode):
         """scenario/outputs/data/optimization/substations/${building}_result.csv"""
@@ -540,7 +540,7 @@ class InputLocator(object):
         if self.optimization_run:
             return os.path.join(self.get_optimization_results_folder(), f'centralized_run_{self.optimization_run}')
         else:
-            return self._ensure_folder(self.get_optimization_results_folder(), 'centralized')
+            return os.path.join(self.get_optimization_results_folder(), 'centralized')
 
     def register_centralized_optimization_run_id(self):
         """Registers the run_id of the centralized optimization run"""
@@ -558,17 +558,17 @@ class InputLocator(object):
 
     def get_new_optimization_base_case_folder(self, network_type):
         """Returns the folder containing the base-case energy systems against which optimal systems are compared"""
-        return self._ensure_folder(self.get_centralized_optimization_results_folder(), f'base_{network_type}S')
+        return os.path.join(self.get_centralized_optimization_results_folder(), f'base_{network_type}S')
 
     def get_new_optimization_optimal_district_energy_system_folder(self, district_energy_system_id='DES_000'):
         """Returns the results-folder for the n-th near pareto-optimal district energy system"""
-        return self._ensure_folder(self.get_centralized_optimization_results_folder(),
+        return os.path.join(self.get_centralized_optimization_results_folder(),
                                    f'{district_energy_system_id}')
 
     def get_new_optimization_optimal_networks_folder(self, district_energy_system_id='DES_000'):
         """Returns the results-folder for the i-th network of the n-th near-pareto-optimal DES"""
         des_folder = self.get_new_optimization_optimal_district_energy_system_folder(district_energy_system_id)
-        return self._ensure_folder(des_folder, 'networks')
+        return os.path.join(des_folder, 'networks')
 
     def get_new_optimization_optimal_network_layout_file(self, district_energy_system_id='DES_000',
                                                          network_id='N0000'):
@@ -579,7 +579,7 @@ class InputLocator(object):
     def get_new_optimization_optimal_supply_systems_folder(self, district_energy_system_id='DES_000'):
         """Returns the results-file for the general supply systems results of the n-th near-pareto-optimal DES"""
         des_folder = self.get_new_optimization_optimal_district_energy_system_folder(district_energy_system_id)
-        return self._ensure_folder(des_folder, 'Supply_systems')
+        return os.path.join(des_folder, 'Supply_systems')
 
     def get_new_optimization_optimal_supply_system_file(self, district_energy_system_id='DES_000',
                                                         supply_system_id='N0000_or_B0000'):
@@ -595,7 +595,7 @@ class InputLocator(object):
     def get_new_optimization_supply_system_details_folder(self, district_energy_system_id='DES_000'):
         """Returns the results-folder for the detailed supply system information of the n-th near-pareto-optimal DES"""
         des_folder = self.get_new_optimization_optimal_district_energy_system_folder(district_energy_system_id)
-        return self._ensure_folder(des_folder, 'Supply_system_operation_details')
+        return os.path.join(des_folder, 'Supply_system_operation_details')
 
     def get_new_optimization_detailed_network_performance_file(self, district_energy_system_id='DES_000'):
         """Returns the results-file for the detailed performance of the n-th near-pareto-optimal DES's networks"""
@@ -617,7 +617,7 @@ class InputLocator(object):
 
     def get_new_optimization_debugging_folder(self):
         """Returns the debugging-folder, used to store information gathered by the optimisation tracker"""
-        return self._ensure_folder(self.get_centralized_optimization_results_folder(), 'debugging')
+        return os.path.join(self.get_centralized_optimization_results_folder(), 'debugging')
 
     def get_new_optimization_debugging_network_tracker_file(self):
         """Returns the debugging-file, used to store information gathered by the optimisation tracker"""
@@ -634,7 +634,7 @@ class InputLocator(object):
     # POTENTIAL
     def get_potentials_folder(self):
         """scenario/outputs/data/potentials"""
-        return self._ensure_folder(self.scenario, 'outputs', 'data', 'potentials')
+        return os.path.join(self.scenario, 'outputs', 'data', 'potentials')
 
     def get_sewage_heat_potential(self):
         return os.path.join(self.get_potentials_folder(), "Sewage_heat_potential.csv")
@@ -679,7 +679,7 @@ class InputLocator(object):
         return weather_names
 
     def get_weather_folder(self):
-        return self._ensure_folder(self.get_input_folder(), 'weather')
+        return os.path.join(self.get_input_folder(), 'weather')
 
     def get_db4_folder(self):
         """scenario/inputs/database/"""
@@ -930,7 +930,7 @@ class InputLocator(object):
 
     def get_building_weekly_schedules_folder(self):
         """scenario/inputs/building-properties/schedules/"""
-        return self._ensure_folder(self.get_building_properties_folder(), 'schedules')
+        return os.path.join(self.get_building_properties_folder(), 'schedules')
 
     def get_building_weekly_schedules_monthly_multiplier_csv(self):
         """
@@ -962,7 +962,7 @@ class InputLocator(object):
         """scenario/outputs/data/occupancy
         Folder to store occupancy to.
         """
-        return self._ensure_folder(self.scenario, 'outputs', 'data', 'occupancy')
+        return os.path.join(self.scenario, 'outputs', 'data', 'occupancy')
 
     def get_occupancy_model_file(self, building):
         """
@@ -981,9 +981,9 @@ class InputLocator(object):
 
     def get_output_thermal_network_type_folder(self, network_type, network_name=""):
         if network_name == '':  # in case there is no specific network name (default case)
-            return self._ensure_folder(self.get_thermal_network_folder(), network_type)
+            return os.path.join(self.get_thermal_network_folder(), network_type)
         else:
-            return self._ensure_folder(self.get_thermal_network_folder(), network_type, network_name)
+            return os.path.join(self.get_thermal_network_folder(), network_type, network_name)
 
     def get_network_layout_edges_shapefile(self, network_type, network_name=""):
         """scenario/outputs/thermal-network/DH or DC/edges.shp"""
@@ -999,7 +999,7 @@ class InputLocator(object):
 
     # THERMAL NETWORK OUTPUTS
     def get_thermal_network_folder(self):
-        return self._ensure_folder(self.scenario, 'outputs', 'data', 'thermal-network')
+        return os.path.join(self.scenario, 'outputs', 'data', 'thermal-network')
 
     def get_nominal_edge_mass_flow_csv_file(self, network_type, network_name=""):
         """scenario/outputs/data/optimization/network/layout/DH_NodesData.csv or DC_NodesData.csv
@@ -1068,7 +1068,7 @@ class InputLocator(object):
         """scenario/outputs/data/optimization/network/layout
         Network layout files
         """
-        return self._ensure_folder(self.get_thermal_network_folder(), "reduced_timesteps")
+        return os.path.join(self.get_thermal_network_folder(), "reduced_timesteps")
 
     def get_thermal_network_layout_massflow_edges_file(self, network_type, network_name, representative_week=False):
         """scenario/outputs/data/optimization/network/layout/DH_MassFlow.csv or DC_MassFlow.csv
@@ -1304,7 +1304,7 @@ class InputLocator(object):
         return os.path.join(folder, file_name)
 
     def get_networks_folder(self):
-        return self._ensure_folder(self.scenario, 'inputs', 'networks')
+        return os.path.join(self.scenario, 'inputs', 'networks')
 
     def get_street_network(self):
         shapefile_path = os.path.join(self.get_networks_folder(), "streets.shp")
@@ -1316,7 +1316,7 @@ class InputLocator(object):
     # SOLAR-RADIATION
     def get_solar_radiation_folder(self):
         """scenario/outputs/data/solar-radiation"""
-        return self._ensure_folder(self.scenario, 'outputs', 'data', 'solar-radiation')
+        return os.path.join(self.scenario, 'outputs', 'data', 'solar-radiation')
 
     def get_radiation_building(self, building):
         """scenario/outputs/data/solar-radiation/${building}_radiation.csv"""
@@ -1340,22 +1340,22 @@ class InputLocator(object):
         return os.path.join(self.get_solar_radiation_folder(), 'buidling_materials.csv')
 
     def solar_potential_folder(self):
-        return self._ensure_folder(self.scenario, 'outputs', 'data', 'potentials', 'solar')
+        return os.path.join(self.scenario, 'outputs', 'data', 'potentials', 'solar')
 
     def solar_potential_folder_PV(self):
         """scenario/outputs/data/potentials/solar/PV"""
-        return self._ensure_folder(self.scenario, 'outputs', 'data', 'potentials', 'solar', 'PV')
+        return os.path.join(self.scenario, 'outputs', 'data', 'potentials', 'solar', 'PV')
 
     def solar_potential_folder_SC(self):
         """scenario/outputs/data/potentials/solar/SC"""
-        return self._ensure_folder(self.scenario, 'outputs', 'data', 'potentials', 'solar', 'SC')
+        return os.path.join(self.scenario, 'outputs', 'data', 'potentials', 'solar', 'SC')
 
     def solar_potential_folder_PVT(self):
         """scenario/outputs/data/potentials/solar/PVT"""
-        return self._ensure_folder(self.scenario, 'outputs', 'data', 'potentials', 'solar', 'PVT')
+        return os.path.join(self.scenario, 'outputs', 'data', 'potentials', 'solar', 'PVT')
 
     def solar_potential_folder_sensors(self):
-        return self._ensure_folder(self.scenario, 'outputs', 'data', 'potentials', 'solar', 'sensors')
+        return os.path.join(self.scenario, 'outputs', 'data', 'potentials', 'solar', 'sensors')
 
     def PV_results(self, building, panel_type):
         """scenario/outputs/data/potentials/solar/PV/{building}_{panel_type}.csv"""
@@ -1408,7 +1408,7 @@ class InputLocator(object):
 
     def get_demand_results_folder(self):
         """scenario/outputs/data/demand"""
-        return self._ensure_folder(self.scenario, 'outputs', 'data', 'demand')
+        return os.path.join(self.scenario, 'outputs', 'data', 'demand')
 
     def get_total_demand(self, format='csv'):
         """scenario/outputs/data/demand/Total_demand.csv"""
@@ -1425,10 +1425,7 @@ class InputLocator(object):
     # EMISSIONS
     def get_lca_emissions_results_folder(self):
         """scenario/outputs/data/emissions"""
-        lca_emissions_results_folder = os.path.join(self.scenario, 'outputs', 'data', 'emissions')
-        if not os.path.exists(lca_emissions_results_folder):
-            os.makedirs(lca_emissions_results_folder)
-        return lca_emissions_results_folder
+        return os.path.join(self.scenario, 'outputs', 'data', 'emissions')
 
     def get_lca_embodied(self):
         """scenario/outputs/data/emissions/Total_LCA_embodied.csv"""
@@ -1445,14 +1442,11 @@ class InputLocator(object):
     # COSTS
     def get_costs_folder(self):
         """scenario/outputs/data/costs"""
-        return self._ensure_folder(self.scenario, 'outputs', 'data', 'costs')
+        return os.path.join(self.scenario, 'outputs', 'data', 'costs')
 
     def get_multi_criteria_results_folder(self):
         """scenario/outputs/data/multi-criteria"""
-        multi_criteria_results_folder = os.path.join(self.scenario, 'outputs', 'data', 'multicriteria')
-        if not os.path.exists(multi_criteria_results_folder):
-            os.makedirs(multi_criteria_results_folder)
-        return multi_criteria_results_folder
+        return os.path.join(self.scenario, 'outputs', 'data', 'multicriteria')
 
     def get_multi_criteria_analysis(self, generation):
         return os.path.join(self.get_multi_criteria_results_folder(),
@@ -1467,7 +1461,7 @@ class InputLocator(object):
     # GRAPHS
     def get_plots_folder(self, category):
         """scenario/outputs/plots/timeseries"""
-        return self._ensure_folder(self.scenario, 'outputs', 'plots', category)
+        return os.path.join(self.scenario, 'outputs', 'plots', category)
 
     def get_timeseries_plots_file(self, building, category=''):
         """scenario/outputs/plots/timeseries/{building}.html

--- a/cea/optimization/master/data_saver.py
+++ b/cea/optimization/master/data_saver.py
@@ -29,6 +29,8 @@ def save_results(locator,
                  buildings_building_scale_heating_capacities,
                  buildings_building_scale_cooling_capacities
                  ):
+    locator.ensure_parent_folder_exists(locator.get_optimization_slave_generation_results_folder(generation_number))
+
     # SAVE INDIVIDUAL DISTRICT HEATING INSTALLED CAPACITIES
     pd.DataFrame(district_heating_capacity_installed_dict, index=[0]).to_csv(
         locator.get_optimization_district_scale_heating_capacity(individual_number,

--- a/cea/optimization/master/master_main.py
+++ b/cea/optimization/master/master_main.py
@@ -596,6 +596,7 @@ def save_final_generation_pareto_individuals(toolbox,
     performance_totals_pareto['individual'] = individual_number_list
     performance_totals_pareto['individual_name'] = systems_name_list
     performance_totals_pareto['generation'] = generation_number_list
+    locator.ensure_parent_folder_exists(locator.get_optimization_generation_total_performance_pareto(generation))
     performance_totals_pareto.to_csv(locator.get_optimization_generation_total_performance_pareto(generation),
                                      index=False)
 
@@ -624,6 +625,7 @@ def save_generation_pareto_individuals(locator, generation, record_individuals_t
     performance_totals_pareto['individual'] = individual_list
     performance_totals_pareto['individual_name'] = systems_name_list
     performance_totals_pareto['generation'] = generation_list
+    locator.ensure_parent_folder_exists(locator.get_optimization_generation_total_performance_pareto(generation))
     performance_totals_pareto.to_csv(locator.get_optimization_generation_total_performance_pareto(generation),
                                      index=False)
 
@@ -665,6 +667,7 @@ def save_generation_dataframes(generation,
     performance_totals['generation'] = generation
 
     # save all results to disk
+    locator.ensure_parent_folder_exists(locator.get_optimization_slave_generation_results_folder(generation))
     performance_disconnected.to_csv(locator.get_optimization_generation_building_scale_performance(generation),
                                     index=False)
     performance_connected.to_csv(locator.get_optimization_generation_district_scale_performance(generation),
@@ -682,6 +685,7 @@ def save_generation_individuals(columns_of_saved_files, generation, invalid_ind,
 
     individuals_info['individual'] = individual_list
     individuals_info['generation'] = generation
+    locator.ensure_parent_folder_exists(locator.get_optimization_individuals_in_generation(generation))
     individuals_info.to_csv(locator.get_optimization_individuals_in_generation(generation), index=False)
 
 

--- a/cea/optimization/master/summarize_network.py
+++ b/cea/optimization/master/summarize_network.py
@@ -250,7 +250,7 @@ def network_main(locator, buildings_in_this_network, ground_temp, num_tot_buildi
                                 "Q_DC_space_cooling_and_refrigeration_losses_W": Q_DC_space_cooling_and_refrigeration_losses_W,
                                 "Q_DC_space_cooling_data_center_and_refrigeration_losses_W": Q_DC_space_cooling_data_center_and_refrigeration_losses_W})
 
-
+    locator.ensure_parent_folder_exists(locator.get_optimization_network_results_summary(network_type, key))
     results.to_csv(locator.get_optimization_network_results_summary(network_type, key), index=False, float_format='%.3f')
 
     print(round(time.perf_counter() - t0), "seconds process time for Network summary for configuration", key)

--- a/cea/optimization_new/domain.py
+++ b/cea/optimization_new/domain.py
@@ -52,7 +52,7 @@ from cea.optimization_new.helperclasses.multiprocessing.memoryPreserver import M
 
 
 class Domain(object):
-    def __init__(self, config, locator):
+    def __init__(self, config, locator: InputLocator):
         self.config = config
         self.locator = locator
         self.weather = self._load_weather(locator)
@@ -341,6 +341,7 @@ class Domain(object):
                                                                                                 network.identifier)
             network_layout = pd.concat([network.network_nodes, network.network_edges]).drop(['coordinates'], axis=1)
             network_layout = network_layout.to_crs(get_geographic_coordinate_system())
+            self.locator.ensure_parent_folder_exists(network_layout_file)
             network_layout.to_file(network_layout_file, driver='GeoJSON')
 
         return

--- a/cea/optimization_new/domain.py
+++ b/cea/optimization_new/domain.py
@@ -374,6 +374,7 @@ class Domain(object):
 
             # Summarise structure of the supply system & print to file
             building_file = self.locator.get_new_optimization_optimal_supply_system_file(system_name, supply_system_id)
+            self.locator.ensure_parent_folder_exists(building_file)
             Domain._write_system_structure(building_file, supply_system)
 
             # Calculate supply system fitness-values and add them to the summary of all supply systems

--- a/cea/resources/radiation/daysim.py
+++ b/cea/resources/radiation/daysim.py
@@ -262,6 +262,7 @@ def calc_sensors_zone(building_names, locator, grid_size: GridSize, geometry_pic
         names_zone.append(building_name)
 
         # save sensors geometry result to disk
+        locator.ensure_parent_folder_exists(locator.get_radiation_metadata(building_name))
         pd.DataFrame({'BUILDING': building_name,
                       'SURFACE': sensors_code,
                       'orientation': sensor_orientation_building,
@@ -390,4 +391,5 @@ def write_aggregated_results(building_name, sensor_values, locator, date):
     data["Date"] = date
     data.set_index("Date", inplace=True)
 
+    locator.ensure_parent_folder_exists(locator.get_radiation_building(building_name))
     data.to_csv(locator.get_radiation_building(building_name))

--- a/cea/resources/radiation/main.py
+++ b/cea/resources/radiation/main.py
@@ -164,6 +164,7 @@ def main(config):
     # import material properties of buildings
     print("Getting geometry materials")
     building_surface_properties = read_surface_properties(locator)
+    locator.ensure_parent_folder_exists(locator.get_radiation_materials())
     building_surface_properties.to_csv(locator.get_radiation_materials())
 
     geometry_staging_location = os.path.join(locator.get_solar_radiation_folder(), "radiance_geometry_pickle")

--- a/cea/resources/radiation/simplified/main.py
+++ b/cea/resources/radiation/simplified/main.py
@@ -111,6 +111,7 @@ def main(config):
     # import material properties of buildings
     print("Getting geometry materials")
     building_surface_properties = read_surface_properties(locator)
+    locator.ensure_parent_folder_exists(locator.get_radiation_materials())
     building_surface_properties.to_csv(locator.get_radiation_materials())
 
     geometry_staging_location = os.path.join(locator.get_solar_radiation_folder(), "radiance_geometry_pickle")

--- a/cea/resources/radiationCRAX/main.py
+++ b/cea/resources/radiationCRAX/main.py
@@ -292,6 +292,7 @@ def calc_sensors_zone_crax(building_names, locator, grid_size: GridSize, geometr
         names_zone.append(building_name)
 
         # save sensors geometry result to disk
+        locator.ensure_parent_folder_exists(locator.get_radiation_metadata(building_name))
         pd.DataFrame({'BUILDING': building_name,
                       'SURFACE': sensors_code,
                       'orientation': sensor_orientation_building,

--- a/cea/resources/sewage_heat_exchanger.py
+++ b/cea/resources/sewage_heat_exchanger.py
@@ -67,6 +67,7 @@ def calc_sewage_heat_exchanger(locator, config):
                                                                               heat_exchanger_length, T_MIN, AT_MIN_K, V_lps_external)
 
     #save to disk
+    locator.ensure_parent_folder_exists(locator.get_sewage_heat_potential())
     pd.DataFrame({"date": pd.to_datetime(date_range), "Qsw_kW" : Q_source, "Ts_C" : t_source, "T_out_sw_C" : t_out, "T_in_sw_C" : twaste_zone,
                   "mww_zone_kWperC":mcpwaste_total,
                     "T_out_HP_C" : tout_e, "T_in_HP_C" : tin_e}).to_csv(locator.get_sewage_heat_potential(),

--- a/cea/technologies/solar/photovoltaic.py
+++ b/cea/technologies/solar/photovoltaic.py
@@ -120,9 +120,10 @@ def calc_PV(locator, config, type_PVpanel, latitude, longitude, weather_data, da
 
         final = calc_pv_generation(sensor_groups, weather_data, datetime_local, solar_properties, latitude, longitude,
                                    panel_properties_PV)
-
+        locator.ensure_parent_folder_exists(locator.PV_results(building=building_name, panel_type=type_PVpanel))
         final.to_csv(locator.PV_results(building=building_name, panel_type=type_PVpanel), index=True,
                      float_format='%.2f')  # print PV generation potential
+        locator.ensure_parent_folder_exists(locator.PV_metadata_results(building=building_name))
         sensors_metadata_cat.to_csv(locator.PV_metadata_results(building=building_name), index=True,
                                     index_label='SURFACE',
                                     float_format='%.2f',
@@ -136,12 +137,14 @@ def calc_PV(locator, config, type_PVpanel, latitude, longitude, weather_data, da
              'PV_walls_east_E_kWh': 0, 'PV_walls_east_m2': 0, 'PV_walls_west_E_kWh': 0, 'PV_walls_west_m2': 0,
              'PV_roofs_top_E_kWh': 0, 'PV_roofs_top_m2': 0,
              'E_PV_gen_kWh': 0, 'area_PV_m2': 0, 'radiation_kWh': 0}, index=range(HOURS_IN_YEAR))
+        locator.ensure_parent_folder_exists(locator.PV_results(building=building_name, panel_type=type_PVpanel))
         final.to_csv(locator.PV_results(building=building_name, panel_type=type_PVpanel), index=False, float_format='%.2f', na_rep='nan')
         sensors_metadata_cat = pd.DataFrame(
             {'SURFACE': 0, 'AREA_m2': 0, 'BUILDING': 0, 'TYPE': 0, 'Xcoor': 0, 'Xdir': 0, 'Ycoor': 0, 'Ydir': 0,
              'Zcoor': 0, 'Zdir': 0, 'orientation': 0, 'total_rad_Whm2': 0, 'tilt_deg': 0, 'B_deg': 0,
              'array_spacing_m': 0, 'surface_azimuth_deg': 0, 'area_installed_module_m2': 0,
              'CATteta_z': 0, 'CATB': 0, 'CATGB': 0, 'type_orientation': 0}, index=range(2))
+        locator.ensure_parent_folder_exists(locator.PV_metadata_results(building=building_name))
         sensors_metadata_cat.to_csv(locator.PV_metadata_results(building=building_name), index=False,
                                     float_format='%.2f', na_rep='nan')
 
@@ -802,9 +805,11 @@ def write_aggregate_results(locator, type_PVpanel, building_names):
                 aggregated_annual_results = pd.concat([aggregated_annual_results, annual_results], axis=1, sort=False)
 
     # save hourly results
+    locator.ensure_parent_folder_exists(locator.PV_totals(panel_type=type_PVpanel))
     aggregated_hourly_results_df.to_csv(locator.PV_totals(panel_type=type_PVpanel), index=True, float_format='%.2f', na_rep='nan')
     # save annual results
     aggregated_annual_results_df = pd.DataFrame(aggregated_annual_results).T
+    locator.ensure_parent_folder_exists(locator.PV_total_buildings(type_PVpanel))
     aggregated_annual_results_df.to_csv(locator.PV_total_buildings(type_PVpanel), index=True, index_label="name",
                                         float_format='%.2f', na_rep='nan')
 

--- a/cea/technologies/solar/photovoltaic_thermal.py
+++ b/cea/technologies/solar/photovoltaic_thermal.py
@@ -113,8 +113,10 @@ def calc_PVT(locator, config, type_pvpanel, type_scpanel,latitude, longitude, we
 
         Final = calc_PVT_generation(sensor_groups, weather_data, date_local, solar_properties, latitude, longitude,
                                     tot_bui_height_m, panel_properties_SC, panel_properties_PV, config, type_scpanel)
-
+        
+        locator.ensure_parent_folder_exists(locator.PVT_results(building_name, type_pvpanel, type_scpanel))
         Final.to_csv(locator.PVT_results(building_name, type_pvpanel, type_scpanel), index=True, float_format='%.2f',  na_rep='nan')
+        locator.ensure_parent_folder_exists(locator.PVT_metadata_results(building=building_name))
         sensors_metadata_cat.to_csv(locator.PVT_metadata_results(building=building_name), index=True,
                                     index_label='SURFACE',
                                     float_format='%.2f',  na_rep='nan')  # print selected metadata of the selected sensors
@@ -138,12 +140,14 @@ def calc_PVT(locator, config, type_pvpanel, type_scpanel,latitude, longitude, we
              'mcp_PVT_kWperC': 0.0, 'Eaux_PVT_kWh': 0.0,
              'Q_PVT_l_kWh': 0.0, 'E_PVT_gen_kWh': 0.0, 'area_PVT_m2': 0.0,
              'radiation_kWh': 0.0}, index=range(HOURS_IN_YEAR))
+        locator.ensure_parent_folder_exists(locator.PVT_results(building_name, type_pvpanel, type_scpanel))
         Final.to_csv(locator.PVT_results(building_name, type_pvpanel, type_scpanel), index=False, float_format='%.2f', na_rep='nan')
         sensors_metadata_cat = pd.DataFrame(
             {'SURFACE': 0, 'AREA_m2': 0, 'BUILDING': 0, 'TYPE': 0, 'Xcoor': 0, 'Xdir': 0, 'Ycoor': 0, 'Ydir': 0,
              'Zcoor': 0, 'Zdir': 0, 'orientation': 0, 'total_rad_Whm2': 0, 'tilt_deg': 0, 'B_deg': 0,
              'array_spacing_m': 0, 'surface_azimuth_deg': 0, 'area_installed_module_m2': 0,
              'CATteta_z': 0, 'CATB': 0, 'CATGB': 0, 'type_orientation': 0}, index=range(2))
+        locator.ensure_parent_folder_exists(locator.PV_metadata_results(building=building_name))
         sensors_metadata_cat.to_csv(locator.PVT_metadata_results(building=building_name), index=False,
                                     float_format='%.2f', na_rep='nan')
 

--- a/cea/technologies/solar/solar_collector.py
+++ b/cea/technologies/solar/solar_collector.py
@@ -109,7 +109,9 @@ def calc_SC(locator, config, type_panel, latitude, longitude, weather_data, date
 
         # save SC generation potential and metadata of the selected sensors
         panel_type = panel_properties_SC['type']
+        locator.ensure_parent_folder_exists(locator.SC_results(building_name, panel_type))
         Final.to_csv(locator.SC_results(building_name, panel_type), index=True, float_format='%.2f', na_rep='nan')
+        locator.ensure_parent_folder_exists(locator.SC_metadata_results(building_name, panel_type))
         sensors_metadata_cat.to_csv(locator.SC_metadata_results(building_name, panel_type), index=True,
                                     index_label='SURFACE',
                                     float_format='%.2f', na_rep='nan')  # print selected metadata of the selected sensors
@@ -133,12 +135,14 @@ def calc_SC(locator, config, type_panel, latitude, longitude, weather_data, date
              'date':date_local},
             index=np.zeros(HOURS_IN_YEAR))
         Final.set_index('date', inplace=True)
+        locator.ensure_parent_folder_exists(locator.SC_results(building_name, panel_type))
         Final.to_csv(locator.SC_results(building_name, panel_type), index=True, float_format='%.2f', na_rep='nan')
         sensors_metadata_cat = pd.DataFrame(
             {'SURFACE': 0, 'AREA_m2': 0, 'BUILDING': 0, 'TYPE': 0, 'Xcoor': 0, 'Xdir': 0, 'Ycoor': 0, 'Ydir': 0,
              'Zcoor': 0, 'Zdir': 0, 'orientation': 0, 'total_rad_Whm2': 0, 'tilt_deg': 0, 'B_deg': 0,
              'array_spacing_m': 0, 'surface_azimuth_deg': 0, 'area_installed_module_m2': 0,
              'CATteta_z': 0, 'CATB': 0, 'CATGB': 0, 'type_orientation': 0}, index=range(2))
+        locator.ensure_parent_folder_exists(locator.SC_metadata_results(building_name, panel_type))
         sensors_metadata_cat.to_csv(locator.SC_metadata_results(building_name, panel_type), index=True,
                                     float_format='%.2f', na_rep="nan")
 

--- a/cea/technologies/substation.py
+++ b/cea/technologies/substation.py
@@ -47,6 +47,7 @@ def substation_main_heating(locator, total_demand, buildings_name_with_heating, 
 
         for name in buildings_name_with_heating:
             substation_demand = total_demand[(total_demand.Name == name)]
+            locator.ensure_parent_folder_exists(locator.get_optimization_substations_total_file(DHN_barcode, 'DH'))
             substation_demand.to_csv(locator.get_optimization_substations_total_file(DHN_barcode, 'DH'), sep=',',
                                      index=False, float_format='%.3f')
 
@@ -127,6 +128,7 @@ def substation_main_cooling(locator, total_demand, buildings_name_with_cooling,
 
         for name in buildings_name_with_cooling:
             substation_demand = total_demand[(total_demand.Name == name)]
+            locator.ensure_parent_folder_exists(locator.get_optimization_substations_total_file(DCN_barcode, 'DC'))
             substation_demand.to_csv(locator.get_optimization_substations_total_file(DCN_barcode, 'DC'), sep=',',
                                      index=False, float_format='%.3f')
             # calculate substation parameters per building
@@ -368,7 +370,8 @@ def substation_model_cooling(name, building, T_DC_supply_to_cs_ref_C, T_DC_suppl
          "Q_space_cooling_and_refrigeration_W": Qcs_sys_W + Qcre_sys_W,
          "Q_space_cooling_data_center_and_refrigeration_W": Qcs_sys_W + Qcdata_sys_W + Qcre_sys_W,
          })
-
+    
+    locator.ensure_parent_folder_exists(locator.get_optimization_substations_results_file(name, "DC", DCN_barcode))
     results.to_csv(locator.get_optimization_substations_results_file(name, "DC", DCN_barcode), sep=',', index=False,
                    float_format='%.3f')
     return results
@@ -548,6 +551,7 @@ def substation_model_heating(building_name, building_demand_df, T_DH_supply_C, T
                                           "Q_heating_W": Qhs_sys_W,
                                           "Q_dhw_W": Qww_sys_W})
 
+    locator.ensure_parent_folder_exists(locator.get_optimization_substations_results_file(building_name, "DH", DHN_barcode))
     substation_activation.to_csv(locator.get_optimization_substations_results_file(building_name, "DH", DHN_barcode),
                                  sep=',',
                                  index=False,

--- a/cea/technologies/thermal_network/simplified_thermal_network.py
+++ b/cea/technologies/thermal_network/simplified_thermal_network.py
@@ -418,6 +418,7 @@ def thermal_network_simplified(locator, config, network_name=''):
                                                                      k_kWperK,
                                                                      )
     # WRITE TO DISK
+    locator.ensure_parent_folder_exists(locator.get_thermal_network_folder())
 
     # LINEAR PRESSURE LOSSES (EDGES)
     linear_pressure_loss_Paperm.to_csv(locator.get_network_linear_pressure_drop_edges(network_type, network_name),

--- a/cea/technologies/thermal_network/thermal_network_costs.py
+++ b/cea/technologies/thermal_network/thermal_network_costs.py
@@ -623,6 +623,7 @@ def main(config):
     cost_output['avg_diam_m'] = average_diameter_m
     cost_output['network_length_m'] = length_m
     cost_output = pd.DataFrame.from_dict(cost_output, orient='index').T
+    locator.ensure_parent_folder_exists(locator.get_optimization_network_layout_costs_file(config.thermal_network.network_type))
     cost_output.to_csv(locator.get_optimization_network_layout_costs_file(config.thermal_network.network_type))
     return
 

--- a/cea/technologies/thermal_network/thermal_network_optimization.py
+++ b/cea/technologies/thermal_network/thermal_network_optimization.py
@@ -209,6 +209,7 @@ def output_results_of_all_individuals(config, locator, network_info):
     all_individuals_df = pd.DataFrame(all_individuals_array).drop(columns=[0])
     all_individuals_df.columns = network_info.generation_info + network_info.cost_info
     all_individuals_df = all_individuals_df.sort_values(by=['total'])
+    locator.ensure_parent_folder_exists(locator.get_optimization_network_all_individuals_results_file(network_info.network_type))
     all_individuals_df.to_csv(locator.get_optimization_network_all_individuals_results_file(network_info.network_type),
                               index=False)
     return np.nan


### PR DESCRIPTION
Users should be responsible for ensuring that the folders exist. Locator methods should only return the path of the required resource/file. This also prevents unexpected behaviour where empty folders are created when the config file is being initialised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced reliability of file saving by automatically creating necessary output directories before writing files across multiple modules, preventing errors due to missing folders.
  - Improved folder management to avoid errors when clearing or accessing non-existent directories.
- **Chores**
  - Refined internal handling of directory checks to improve robustness without affecting user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->