### PR TITLE
Add user limit settings

### DIFF
--- a/cea/interfaces/dashboard/api/contents.py
+++ b/cea/interfaces/dashboard/api/contents.py
@@ -195,13 +195,13 @@ async def upload_scenario(form: Annotated[UploadScenario, Form()], project_root:
     if form.type == "new" and limit_settings.num_projects is not None and limit_settings.num_projects <= num_projects:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Maximum number of projects reached ({limit_settings.num_projects}). Number of projects found: {num_projects}",
+            detail=f"Maximum number of projects reached ({limit_settings.num_projects}). Number of projects found: {num_projects}",
         )
     num_scenarios = len(cea.config.get_scenarios_list(str(project_path)))
     if limit_settings.num_scenarios is not None and limit_settings.num_scenarios <= num_scenarios:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Maximum number of scenarios reached ({limit_settings.num_scenarios}). Number of scenarios found: {num_scenarios}",
+            detail=f"Maximum number of scenarios reached ({limit_settings.num_scenarios}). Number of scenarios found: {num_scenarios}",
             )
 
     # Check for existing projects
@@ -303,7 +303,7 @@ async def upload_scenario(form: Annotated[UploadScenario, Form()], project_root:
             if limit_settings.num_scenarios is not None and limit_settings.num_scenarios <= num_scenarios:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Maximum number of scenarios reached ({limit_settings.num_scenarios}). Number of scenarios found: {num_scenarios}",
+                    detail=f"Maximum number of scenarios reached ({limit_settings.num_scenarios}). Number of scenarios found: {num_scenarios}",
                     )
 
 

--- a/cea/interfaces/dashboard/api/project.py
+++ b/cea/interfaces/dashboard/api/project.py
@@ -27,6 +27,7 @@ from cea.interfaces.dashboard.dependencies import CEAConfig, CEADatabaseConfig, 
     CEASeverDemoAuthCheck
 from cea.interfaces.dashboard.lib.database.session import SessionDep
 from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
+from cea.interfaces.dashboard.settings import LimitSettings
 from cea.interfaces.dashboard.utils import secure_path, OutsideProjectRootError
 from cea.utilities.dbf import dbf_to_dataframe
 from cea.utilities.standardize_coordinates import get_geographic_coordinate_system, raster_to_WSG_and_UTM
@@ -169,7 +170,7 @@ async def get_project_choices(project_root):
                 # Optionally: Add validation that this is a valid project directory
                 projects.append(_path)
         if not projects:
-            return {"projects": [], "warning": "No valid projects found in directory"}
+            logger.warning("No valid projects found in directory")
     except PermissionError:
         raise HTTPException(
             status_code=403,
@@ -248,6 +249,13 @@ async def create_new_project(project_root: CEAProjectRoot, new_project: NewProje
     """
     Create new project folder
     """
+    limit_settings = LimitSettings()
+    if limit_settings.num_projects is not None and limit_settings.num_projects <= len(await get_project_choices(project_root)):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Maximum number of projects reached",
+        )
+
     if new_project.project_root is None and project_root is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -339,6 +347,13 @@ async def create_new_scenario_v2(project_root: CEAProjectRoot, scenario_form: An
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
+        )
+    
+    limit_settings = LimitSettings()
+    if limit_settings.num_scenarios is not None and limit_settings.num_scenarios <= len(cea.config.get_scenarios_list(cea_project)):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Maximum number of scenarios reached",
         )
 
     scenario_name = os.path.normpath(scenario_form.scenario_name)

--- a/cea/interfaces/dashboard/api/project.py
+++ b/cea/interfaces/dashboard/api/project.py
@@ -250,10 +250,11 @@ async def create_new_project(project_root: CEAProjectRoot, new_project: NewProje
     Create new project folder
     """
     limit_settings = LimitSettings()
-    if limit_settings.num_projects is not None and limit_settings.num_projects <= len(await get_project_choices(project_root)):
+    num_projects = len(await get_project_choices(project_root))
+    if limit_settings.num_projects is not None and limit_settings.num_projects <= num_projects:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Maximum number of projects reached",
+            detail=f"Maximum number of projects reached ({limit_settings.num_projects}). Number of projects found: {num_projects}",
         )
 
     if new_project.project_root is None and project_root is None:
@@ -350,10 +351,11 @@ async def create_new_scenario_v2(project_root: CEAProjectRoot, scenario_form: An
         )
     
     limit_settings = LimitSettings()
-    if limit_settings.num_scenarios is not None and limit_settings.num_scenarios <= len(cea.config.get_scenarios_list(cea_project)):
+    num_scenarios = len(cea.config.get_scenarios_list(cea_project))
+    if limit_settings.num_scenarios is not None and limit_settings.num_scenarios <= num_scenarios:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Maximum number of scenarios reached",
+            detail=f"Maximum number of scenarios reached ({limit_settings.num_scenarios}). Number of scenarios found: {num_scenarios}",
         )
 
     scenario_name = os.path.normpath(scenario_form.scenario_name)
@@ -387,10 +389,11 @@ async def create_new_scenario_v2(project_root: CEAProjectRoot, scenario_form: An
             zone_df = geopandas.read_file(locator.get_zone_geometry())
 
             limit_settings = LimitSettings()
-            if limit_settings.num_buildings is not None and limit_settings.num_buildings <= len(zone_df):
+            num_buildings = len(zone_df)
+            if limit_settings.num_buildings is not None and limit_settings.num_buildings <= num_buildings:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Maximum number of buildings reached ({limit_settings.num_buildings}). Number of buildings found: {len(zone_df)}",
+                    detail=f"Maximum number of buildings reached ({limit_settings.num_buildings}). Number of buildings found: {num_buildings}",
                 )
 
         # Copy zone from user-input

--- a/cea/interfaces/dashboard/api/project.py
+++ b/cea/interfaces/dashboard/api/project.py
@@ -386,6 +386,13 @@ async def create_new_scenario_v2(project_root: CEAProjectRoot, scenario_form: An
             # Ensure that zone exists
             zone_df = geopandas.read_file(locator.get_zone_geometry())
 
+            limit_settings = LimitSettings()
+            if limit_settings.num_buildings is not None and limit_settings.num_buildings <= len(zone_df):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Maximum number of buildings reached ({limit_settings.num_buildings}). Number of buildings found: {len(zone_df)}",
+                )
+
         # Copy zone from user-input
         else:
             # Copy zone using path

--- a/cea/interfaces/dashboard/server/__init__.py
+++ b/cea/interfaces/dashboard/server/__init__.py
@@ -4,6 +4,7 @@ import cea
 import cea.interfaces.dashboard.server.jobs as jobs
 import cea.interfaces.dashboard.server.streams as streams
 from cea.interfaces.dashboard.dependencies import get_worker_processes, CEAServerSettings
+from cea.interfaces.dashboard.settings import LimitSettings
 
 router = APIRouter()
 
@@ -30,4 +31,6 @@ async def get_version():
 
 @router.get("/settings")
 async def get_settings(settings: CEAServerSettings):
-    return {'allow_path_transversal': settings.allow_path_transversal()}
+    # TODO: Shift limits to user properties
+    limits = LimitSettings()
+    return {'limits': limits}

--- a/cea/interfaces/dashboard/settings.py
+++ b/cea/interfaces/dashboard/settings.py
@@ -21,6 +21,14 @@ class StackAuthSettings(BaseSettings):
     publishable_client_key: Optional[str] = None
 
 
+class LimitSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix=ENV_VAR_PREFIX + "limit_",
+                                      env_file=('.env', '.env.local'), extra="ignore")
+    num_projects: Optional[int] = None
+    num_scenarios: Optional[int] = None
+    num_buildings: Optional[int] = None
+
+
 class Settings(BaseSettings):
     # Use "cea_" as prefix for env vars
     model_config = SettingsConfigDict(env_prefix=ENV_VAR_PREFIX,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for the number of projects, scenarios, and buildings that can be created or uploaded.
  * Users will now receive clear error messages if they attempt to exceed these limits during project or scenario creation and uploads.

* **API Changes**
  * The settings endpoint now returns current limit configurations for projects, scenarios, and buildings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->