### PR TITLE
Enable plugin support in tool routes

### DIFF
--- a/cea/interfaces/dashboard/api/tools.py
+++ b/cea/interfaces/dashboard/api/tools.py
@@ -27,9 +27,9 @@ class ToolProperties(ToolDescription):
 
 
 @router.get('/')
-async def get_tool_list() -> Dict[str, List[ToolDescription]]:
+async def get_tool_list(config: CEAConfig) -> Dict[str, List[ToolDescription]]:
     # TODO: Add plugin support
-    tools = cea.scripts.for_interface('dashboard', plugins=[])
+    tools = cea.scripts.for_interface('dashboard', plugins=config.plugins)
     result = dict()
     for category, group in groupby(tools, lambda t: t.category):
         result[category] = [
@@ -41,7 +41,7 @@ async def get_tool_list() -> Dict[str, List[ToolDescription]]:
 @router.get('/{tool_name}')
 async def get_tool_properties(config: CEAConfig, tool_name: str) -> ToolProperties:
     # TODO: Add plugin support
-    script = cea.scripts.by_name(tool_name, plugins=[])
+    script = cea.scripts.by_name(tool_name, plugins=config.plugins)
 
     parameters = []
     categories = defaultdict(list)
@@ -119,7 +119,7 @@ async def check_tool_inputs(config: CEAConfig, tool_name: str, payload: Dict[str
             parameter.set(value)
 
     # TODO: Add plugin support
-    script = cea.scripts.by_name(tool_name, plugins=[])
+    script = cea.scripts.by_name(tool_name, plugins=config.plugins)
     schema_data = schemas(config.plugins)
 
     script_suggestions = set()


### PR DESCRIPTION
Updated API endpoints in tools.py to pass config.plugins to cea.scripts methods, enabling plugin support for tool listing, properties, and input checking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for plugins in tool-related API endpoints, allowing dynamic handling of plugins based on user configuration. 

* **Bug Fixes**
  * Enhanced reliability in retrieving and displaying tools and their properties when plugins are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->