### PR TITLE
Add ubuntu-24.04-arm to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "ubuntu-24.04-arm", "macos-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Expanded the CI job matrix to include ubuntu-24.04-arm, enabling builds and tests on ARM architecture for Ubuntu 24.04.