### PR TITLE
Suppress warnings for cea worker job outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,13 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
     branches: [master, release-**]
-    paths: ['cea/**', 'pyproject.toml', 'pixi.lock']
-  
+    # Ignore changes in the interfaces directory since they do not have tests
+    # TODO: Add tests for interfaces module
+    paths: ['cea/**', 'pyproject.toml', 'pixi.lock', '!cea/interfaces/**']
+
   push:
     branches: [master]
-    paths: ['cea/**', 'pyproject.toml', 'pixi.lock']
+    paths: ['cea/**', 'pyproject.toml', 'pixi.lock', '!cea/interfaces/**']
 
 concurrency:
   # Use head_ref for PRs, fall back to ref for pushes

--- a/cea/interfaces/dashboard/server/jobs.py
+++ b/cea/interfaces/dashboard/server/jobs.py
@@ -180,7 +180,7 @@ async def start_job(session: SessionDep, worker_processes: CEAWorkerProcesses, s
         raise HTTPException(status_code=404, detail="Job not found")
     
     # Use validated parameters in command
-    command = [sys.executable, "-m", "cea.worker", job_id, str(server_url)]
+    command = [sys.executable, "-m", "cea.worker", "--suppress-warnings", job_id, str(server_url)]
     logger.debug(f"command: {command}")
     process = subprocess.Popen(command)
 

--- a/cea/worker.py
+++ b/cea/worker.py
@@ -118,7 +118,8 @@ def run_job(job: JobInfo, suppress_warnings: bool = False):
     script = read_script(job)
     if suppress_warnings:
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
+            # Suppress warnings from external libraries but keep CEA warnings
+            warnings.filterwarnings("ignore", module=r"^(?!cea).*")
             output = script(**parameters)
     else:
         output = script(**parameters)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional suppression of non-core library warnings during job runs.
  * New CLI option to enable this suppression; jobs launched from the dashboard respect the setting.

* **Chores**
  * CI workflow updated to ignore interface-only changes for push and PR triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->