### PR TITLE
Emission timeline for individual building and district

### DIFF
--- a/cea/analysis/lca/emission_timeline.py
+++ b/cea/analysis/lca/emission_timeline.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+import pandas as pd
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cea.inputlocator import InputLocator
+    from cea.demand.building_properties import BuildingProperties
+
+
+class BuildingEmissionTimeline:
+    def __init__(
+        self,
+        building_properties: BuildingProperties,
+        building_name: str,
+        locator: InputLocator,
+    ):
+        self.name = building_name
+        self.locator = locator
+        self.building_properties = building_properties
+        self.geometry = self.building_properties.geometry[self.name]
+        self.envelope = self.building_properties.envelope[self.name]
+        self.generate_timeline()
+
+    def generate_timeline(self, end_year: int) -> None:
+        self.initialize_timeline(end_year)
+        self.get_component_db()
+        self.get_component_quantity()
+        self.fill_embodied_emissions()
+        self.fill_operational_emissions()
+
+    def initialize_timeline(self, end_year: int) -> pd.DataFrame:
+        # Placeholder for the actual implementation
+        # timeline should have the following columns:
+        # year,
+        # embodied_(
+        #           wall_ag, wall_bg, wall_int, win_ag,
+        #           roof, upperside, underside, ceiling, base,
+        #           others,
+        #           ),
+        # operational
+
+        # 0. read the year-of-built of building
+        # 1. initialize the dataframe
+        start_year = self.geometry["year"]
+        if start_year >= end_year:
+            raise ValueError("The starting year must be less than the ending year.")
+        # initialize the dataframe with years
+        self.timeline = pd.DataFrame(
+            {
+                "year": range(start_year, end_year + 1),
+                "embodied_wall_ag": 0.0,
+                "embodied_wall_bg": 0.0,
+                "embodied_wall_int": 0.0,
+                "embodied_win_ag": 0.0,
+                "embodied_roof": 0.0,
+                "embodied_upperside": 0.0,
+                "embodied_underside": 0.0,
+                "embodied_ceiling": 0.0,
+                "embodied_base": 0.0,
+                "embodied_others": 0.0,
+                "operational": 0.0,
+            }
+        )
+        self.timeline.set_index("year", inplace=True)
+
+    def log_emission_in_timeline(
+        self, emission: float, year: int | list[int], col: str
+    ) -> None:
+        self.timeline.loc[year, col] += emission
+
+    def get_component_db(self) -> None:
+        self.wall_db = pd.read_csv(self.locator.get_database_assemblies_envelope_wall())
+        self.roof_db = pd.read_csv(self.locator.get_database_assemblies_envelope_roof())
+        self.floor_db = pd.read_csv(
+            self.locator.get_database_assemblies_envelope_floor()
+        )
+        self.window_db = pd.read_csv(
+            self.locator.get_database_assemblies_envelope_window()
+        )
+
+    def get_component_quantity(self) -> None:
+        # fields = ['Atot', 'Awin_ag', 'Am', 'Aef', 'Af', 'Cm', 'Htr_is', 'Htr_em', 'Htr_ms', 'Htr_op', 'Hg', 'HD',
+        #           'Aroof', 'Aunderside', 'U_wall', 'U_roof', 'U_win', 'U_base', 'Htr_w', 'GFA_m2', 'Aocc', 'Aop_bg',
+        #           'Awall_ag', 'footprint', 'Hs_ag']
+        # useful fields for LCA calculation:
+        # GFA_m2:       total floor area of building
+        # Awin_ag:      total area of windows
+        # Aroof:        total area of roof
+        # Aunderside:   total area of bottom surface, if the bottom surface is above ground level.
+        #               In case where building touches the ground, this value is zero.
+        # Awall_ag:     total area of walls
+        # footprint:    the area of the building footprint
+        self.rc_model_props = self.building_properties.rc_model[self.name]
+
+        # select only useful fields
+        useful_fields = [
+            "GFA_m2",
+            "Awin_ag",
+            "Aroof",
+            "Aunderside",
+            "Awall_ag",
+            "footprint",
+        ]
+        self.rc_model_props = self.rc_model_props[useful_fields]
+
+        # also add floor_ag, floor_bg and void_deck to the dict from geometry
+        self.rc_model_props["floor_ag"] = self.geometry.loc[self.name, "floors_ag"]
+        self.rc_model_props["floor_bg"] = self.geometry.loc[self.name, "floors_bg"]
+        self.rc_model_props["void_deck"] = self.geometry.loc[self.name, "void_deck"]
+
+        # calculate the area of each component
+        # horizontal: roof, ceiling, underside, upperside (not implemented), base
+        # vertical: wall_ag, wall_bg, wall_int (not implemented), win_ag
+        self.rc_model_props["Aupperside"] = 0.0  # not implemented
+        self.rc_model_props["Abase"] = self.rc_model_props["footprint"]
+        # internal floors that are not base, not upperside and not underside
+        self.rc_model_props["Aceiling"] = (
+            self.rc_model_props[
+                "GFA_m2"
+            ]  # GFA = footprint * (floor_ag + floor_bg - void_deck)
+            - self.rc_model_props["Aunderside"]
+            - self.rc_model_props["Aupperside"]
+            - self.rc_model_props["Abase"]
+        )
+        self.rc_model_props["Awall_bg"] = (
+            self.geometry["perimeter"] * self.geometry["height_bg"]
+        )

--- a/cea/analysis/lca/emission_timeline.py
+++ b/cea/analysis/lca/emission_timeline.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
+import os
 import pandas as pd
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from cea.inputlocator import InputLocator
+    from cea.utilities.assemblies_db_reader import EnvelopeDBReader
     from cea.demand.building_properties import BuildingProperties
 
 
@@ -11,22 +13,63 @@ class BuildingEmissionTimeline:
     def __init__(
         self,
         building_properties: BuildingProperties,
+        envelope_db: EnvelopeDBReader,
         building_name: str,
         locator: InputLocator,
     ):
         self.name = building_name
         self.locator = locator
         self.building_properties = building_properties
+        self.envelope_db = envelope_db
         self.geometry = self.building_properties.geometry[self.name]
         self.envelope = self.building_properties.envelope[self.name]
-        self.generate_timeline()
 
     def generate_timeline(self, end_year: int) -> None:
         self.initialize_timeline(end_year)
-        self.get_component_db()
         self.get_component_quantity()
         self.fill_embodied_emissions()
         self.fill_operational_emissions()
+
+    def save_timeline(self):
+        # first, check if timeline folder exist, if not create it
+        if not os.path.exists(self.locator.get_lca_timeline_folder()):
+            os.makedirs(self.locator.get_lca_timeline_folder())
+
+        self.timeline.to_csv(self.locator.get_lca_timeline_building(self.name))
+
+    def fill_embodied_emissions(self) -> None:
+        mapping_dict = {
+            "wall_ag": "wall",
+            "wall_bg": "base",
+            "wall_int": "part",
+            "win_ag": "win",
+            "roof": "roof",
+            "upperside": "roof",
+            "underside": "base",
+            "floor": "floor",
+            "base": "base",
+        }
+        for key, value in mapping_dict.items():
+            type_str = f"type_{value}"
+            lifetime: int = self.envelope_db.get_item_value(
+                code=self.envelope[type_str], col="Service_Life"
+            )
+            ghg: float = self.envelope_db.get_item_value(
+                code=self.envelope[type_str], col="GHG_kgCO2m2"
+            )
+            biogenic: float = self.envelope_db.get_item_value(
+                code=self.envelope[type_str], col="GHG_biogenic_kgCO2m2"
+            )
+            area: float = self.surface_area[f"A{key}"]
+            self.log_emission_with_lifetime(
+                emission=ghg * area, lifetime=lifetime, col=f"embodied_{key}"
+            )
+            self.log_emission_with_lifetime(
+                emission=-biogenic * area, lifetime=lifetime, col=f"biogenic_{key}"
+            )
+
+    def fill_operational_emissions(self) -> None:
+        pass
 
     def initialize_timeline(self, end_year: int) -> pd.DataFrame:
         # Placeholder for the actual implementation
@@ -34,7 +77,7 @@ class BuildingEmissionTimeline:
         # year,
         # embodied_(
         #           wall_ag, wall_bg, wall_int, win_ag,
-        #           roof, upperside, underside, ceiling, base,
+        #           roof, upperside, underside, floor, base,
         #           others,
         #           ),
         # operational
@@ -55,28 +98,49 @@ class BuildingEmissionTimeline:
                 "embodied_roof": 0.0,
                 "embodied_upperside": 0.0,
                 "embodied_underside": 0.0,
-                "embodied_ceiling": 0.0,
+                "embodied_floor": 0.0,
                 "embodied_base": 0.0,
+                "embodied_deconstruction": 0.0,
                 "embodied_others": 0.0,
+                "biogenic_wall_ag": 0.0,
+                "biogenic_wall_bg": 0.0,
+                "biogenic_wall_int": 0.0,
+                "biogenic_win_ag": 0.0,
+                "biogenic_roof": 0.0,
+                "biogenic_upperside": 0.0,
+                "biogenic_underside": 0.0,
+                "biogenic_floor": 0.0,
+                "biogenic_base": 0.0,
+                "biogenic_deconstruction": 0.0,
                 "operational": 0.0,
             }
         )
         self.timeline.set_index("year", inplace=True)
 
+    def log_emission_with_lifetime(
+        self, emission: float, lifetime: int, col: str
+    ) -> None:
+        """The function logs emission once every "lifetime" years in the desired column.
+
+        :param emission: The amount of emission to log.
+        :type emission: float
+        :param lifetime: The lifetime of the component in years. Minimum 1.
+        :type lifetime: int
+        :param col: The column to log the emission in.
+        :type col: str
+        """
+        if lifetime < 1:
+            raise ValueError("Lifetime must be at least 1 year.")
+
+        years = list(
+            range(self.geometry["year"], self.timeline.index.max() + 1, lifetime)
+        )
+        self.log_emission_in_timeline(emission, years, col)
+
     def log_emission_in_timeline(
         self, emission: float, year: int | list[int], col: str
     ) -> None:
         self.timeline.loc[year, col] += emission
-
-    def get_component_db(self) -> None:
-        self.wall_db = pd.read_csv(self.locator.get_database_assemblies_envelope_wall())
-        self.roof_db = pd.read_csv(self.locator.get_database_assemblies_envelope_roof())
-        self.floor_db = pd.read_csv(
-            self.locator.get_database_assemblies_envelope_floor()
-        )
-        self.window_db = pd.read_csv(
-            self.locator.get_database_assemblies_envelope_window()
-        )
 
     def get_component_quantity(self) -> None:
         # fields = ['Atot', 'Awin_ag', 'Am', 'Aef', 'Af', 'Cm', 'Htr_is', 'Htr_em', 'Htr_ms', 'Htr_op', 'Hg', 'HD',
@@ -90,38 +154,27 @@ class BuildingEmissionTimeline:
         #               In case where building touches the ground, this value is zero.
         # Awall_ag:     total area of walls
         # footprint:    the area of the building footprint
-        self.rc_model_props = self.building_properties.rc_model[self.name]
+        rc_model_props = self.building_properties.rc_model[self.name]
 
-        # select only useful fields
-        useful_fields = [
-            "GFA_m2",
-            "Awin_ag",
-            "Aroof",
-            "Aunderside",
-            "Awall_ag",
-            "footprint",
-        ]
-        self.rc_model_props = self.rc_model_props[useful_fields]
-
-        # also add floor_ag, floor_bg and void_deck to the dict from geometry
-        self.rc_model_props["floor_ag"] = self.geometry.loc[self.name, "floors_ag"]
-        self.rc_model_props["floor_bg"] = self.geometry.loc[self.name, "floors_bg"]
-        self.rc_model_props["void_deck"] = self.geometry.loc[self.name, "void_deck"]
-
-        # calculate the area of each component
-        # horizontal: roof, ceiling, underside, upperside (not implemented), base
-        # vertical: wall_ag, wall_bg, wall_int (not implemented), win_ag
-        self.rc_model_props["Aupperside"] = 0.0  # not implemented
-        self.rc_model_props["Abase"] = self.rc_model_props["footprint"]
-        # internal floors that are not base, not upperside and not underside
-        self.rc_model_props["Aceiling"] = (
-            self.rc_model_props[
-                "GFA_m2"
-            ]  # GFA = footprint * (floor_ag + floor_bg - void_deck)
-            - self.rc_model_props["Aunderside"]
-            - self.rc_model_props["Aupperside"]
-            - self.rc_model_props["Abase"]
-        )
-        self.rc_model_props["Awall_bg"] = (
+        self.surface_area = {}
+        self.surface_area["Awall_ag"] = rc_model_props["Awall_ag"]
+        self.surface_area["Awall_bg"] = (
             self.geometry["perimeter"] * self.geometry["height_bg"]
         )
+        self.surface_area["Awall_int"] = 0.0  # not implemented
+        self.surface_area["Awin_ag"] = rc_model_props["Awin_ag"]
+
+        # calculate the area of each component
+        # horizontal: roof, floor, underside, upperside (not implemented), base
+        # vertical: wall_ag, wall_bg, wall_int (not implemented), win_ag
+        self.surface_area["Aroof"] = rc_model_props["Aroof"]
+        self.surface_area["Aupperside"] = 0.0  # not implemented
+        self.surface_area["Aunderside"] = rc_model_props["Aunderside"]
+        # internal floors that are not base, not upperside and not underside
+        self.surface_area["Afloor"] = (
+            rc_model_props["GFA_m2"]  # GFA = footprint * (floor_ag + floor_bg - void_deck)
+            - self.surface_area["Aunderside"]
+            - self.surface_area["Aupperside"]
+            - rc_model_props["footprint"]
+        )
+        self.surface_area["Abase"] = rc_model_props["footprint"]

--- a/cea/analysis/lca/timeline_generator.py
+++ b/cea/analysis/lca/timeline_generator.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from cea.config import Configuration
+from cea.inputlocator import InputLocator
+from cea.demand.building_properties import BuildingProperties
+from cea.utilities import epwreader
+from cea.utilities.assemblies_db_reader import EnvelopeDBReader
+from cea.analysis.lca.emission_timeline import BuildingEmissionTimeline
+
+
+def main(config: Configuration) -> None:
+    locator = InputLocator(scenario=config.scenario)
+    buildings: list[str] = config.emission_timeline.buildings
+    end_year: int = config.emission_timeline.end_year
+
+    envelope_db = EnvelopeDBReader(locator)
+    weather_path = locator.get_weather_file()
+    weather_data = epwreader.epw_reader(weather_path)[
+        ["year", "drybulb_C", "wetbulb_C", "relhum_percent", "windspd_ms", "skytemp_C"]
+    ]
+    building_properties = BuildingProperties(locator, weather_data, buildings)
+
+    for building in buildings:
+        timeline = BuildingEmissionTimeline(
+            building_properties=building_properties,
+            envelope_db=envelope_db,
+            building_name=building,
+            locator=locator,
+        )
+        timeline.generate_timeline(end_year)
+        timeline.save_timeline()
+
+
+if __name__ == "__main__":
+    main(Configuration())

--- a/cea/default.config
+++ b/cea/default.config
@@ -433,6 +433,15 @@ operational = true
 operational.type = BooleanParameter
 operational.help = Estimate emissions due to supply systems operation (allocated according to the supply-systems input database)
 
+[emission-timeline]
+buildings = 
+buildings.type = BuildingsParameter
+buildings.help = List of buildings considered in the emission timeline generation.
+
+end-year = 2100
+end-year.type = IntegerParameter
+end-year.help = The last year that will be included into the timeline.
+
 [extract-reference-case]
 destination = {general:scenario}/../..
 destination.type = PathParameter

--- a/cea/inputlocator.py
+++ b/cea/inputlocator.py
@@ -1433,6 +1433,14 @@ class InputLocator(object):
     def get_lca_mobility(self):
         """scenario/outputs/data/emissions/Total_LCA_mobility.csv"""
         return os.path.join(self.get_lca_emissions_results_folder(), 'Total_LCA_mobility.csv')
+    
+    def get_lca_timeline_folder(self):
+        """scenario/outputs/data/emissions/timeline"""
+        return os.path.join(self.get_lca_emissions_results_folder(), "timeline")
+    
+    def get_lca_timeline_building(self, building: str):
+        """scenario/outputs/data/emissions/timeline/{building}_timeline.csv"""
+        return os.path.join(self.get_lca_timeline_folder(), f"{building}_timeline.csv")
 
     # COSTS
     def get_costs_folder(self):

--- a/cea/schemas.yml
+++ b/cea/schemas.yml
@@ -14167,6 +14167,13 @@ get_lca_operation:
         values: '{0.0...n}'
         min: 0.0
   used_by: []
+get_lca_timeline_building:
+  created_by:
+  - emission-timeline
+  file_path: outputs/data/emissions/timeline/{building}_timeline.csv
+  file_type: csv
+  schema: 
+  used_by: []
 get_multi_criteria_analysis:
   created_by:
   - multi_criteria_analysis

--- a/cea/scripts.yml
+++ b/cea/scripts.yml
@@ -273,6 +273,40 @@ Life Cycle Analysis:
       - [get_zone_geometry]
       - [get_building_supply]
 
+  - name: emission-timeline
+    label: Emission Timeline
+    short_description: Generate a timeline of embodied and operational emissions per building.
+    description: This Feature accounts for all possible emissions since the building's initial construction, 
+      including construction, renovation, deconstruction, biogenic carbon storage and operational emissions. 
+      The timeline records all activities every year, assuming all components are renovated or replaced 
+      according to its lifetime. For operational emissions, the current demand is used.
+    interfaces: [cli, dashboard]
+    module: cea.analysis.lca.timeline_generator
+    parameters: ['general:scenario', emission-timeline]
+    input-files:
+      - [get_total_demand]
+      - [get_building_architecture]
+      - [get_zone_geometry]
+      - [get_building_supply]
+      - [get_weather_file]
+      # - [get_database_assemblies_envelope_mass]
+      # - [get_database_assemblies_envelope_tightness]
+      - [get_database_assemblies_envelope_floor]
+      - [get_database_assemblies_envelope_wall]
+      - [get_database_assemblies_envelope_window]
+      # - [get_database_assemblies_envelope_shading]
+      - [get_database_assemblies_envelope_roof]
+      # - [get_database_assemblies_hvac_controller]
+      # - [get_database_assemblies_hvac_cooling]
+      # - [get_database_assemblies_hvac_heating]
+      # - [get_database_assemblies_hvac_hot_water]
+      # - [get_building_internal]
+      # - [get_building_air_conditioning]
+      # - [get_building_weekly_schedules, building_name]
+      - [get_radiation_metadata, building_name]
+      - [get_radiation_building, building_name]
+      # - [get_occupancy_model_file, building_name]
+
   - name: system-costs
     label: Energy Supply System Costs
     short_description: Calculate costs for energy supply systems

--- a/cea/utilities/assemblies_db_reader.py
+++ b/cea/utilities/assemblies_db_reader.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+import pandas as pd
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cea.inputlocator import InputLocator
+
+
+class EnvelopeDBReader:
+    def __init__(self, locator: InputLocator):
+        self.locator = locator
+        self.wall_db = pd.read_csv(self.locator.get_database_assemblies_envelope_wall())
+        self.roof_db = pd.read_csv(self.locator.get_database_assemblies_envelope_roof())
+        self.floor_db = pd.read_csv(self.locator.get_database_assemblies_envelope_floor())
+        self.window_db = pd.read_csv(self.locator.get_database_assemblies_envelope_window())
+
+    def get_item_value(self, code: str, col: str) -> float | int:
+        """Get the value of a specific item from the envelope database.
+
+        :param code: The code of the item to retrieve.
+        :type code: str
+        :param col: The column to retrieve the value from. Allowed values are (in string):
+
+            - `U`
+            - `GHG_kgCO2m2`
+            - `GHG_biogenic_kgCO2m2`
+            - `Service_Life`
+
+        :type col: str
+        :raises ValueError: _description_
+        :return: _description_
+        :rtype: float | int
+        """
+        # search code in all four databases
+        allowed_cols = ["U", "GHG_kgCO2m2", "GHG_biogenic_kgCO2m2", "Service_Life"]
+        if code in self.wall_db['code'].values:
+            mapping_dict = {
+                allowed_cols[0]: "U_wall",
+                allowed_cols[1]: "GHG_wall_kgCO2m2", 
+                allowed_cols[2]: "GHG_biogenic_wall_kgCO2m2",
+                allowed_cols[3]: "Service_Life_wall",
+            }
+            value = self.wall_db.loc[self.wall_db['code'] == code, mapping_dict[col]].values[0]
+        elif code in self.roof_db['code'].values:
+            mapping_dict = {
+                allowed_cols[0]: "U_roof",
+                allowed_cols[1]: "GHG_roof_kgCO2m2",
+                allowed_cols[2]: "GHG_biogenic_roof_kgCO2m2",
+                allowed_cols[3]: "Service_Life_roof",
+            }
+            value = self.roof_db.loc[self.roof_db['code'] == code, mapping_dict[col]].values[0]
+        elif code in self.floor_db['code'].values:
+            mapping_dict = {
+                allowed_cols[0]: "U_floor",
+                allowed_cols[1]: "GHG_floor_kgCO2m2",
+                allowed_cols[2]: "GHG_biogenic_floor_kgCO2m2",
+                allowed_cols[3]: "Service_Life_floor",
+            }
+            value = self.floor_db.loc[self.floor_db['code'] == code, mapping_dict[col]].values[0]
+        elif code in self.window_db['code'].values:
+            mapping_dict = {
+                allowed_cols[0]: "U_win",
+                allowed_cols[1]: "GHG_win_kgCO2m2",
+                allowed_cols[2]: "GHG_biogenic_win_kgCO2m2",
+                allowed_cols[3]: "Service_Life_win",
+            }
+            value = self.window_db.loc[self.window_db['code'] == code, mapping_dict[col]].values[0]
+        else:
+            raise ValueError(f"Code '{code}' not found in any database.")
+
+        if col == "Service_Life":
+            return int(value) if value is not None else None
+        return float(value) if value is not None else None


### PR DESCRIPTION
With the commits now, a preliminary emission timeline generator is available from cea dashboard, under Life Cycle Analysis. 
## Dashboard preview:
<img width="2860" height="1826" alt="image" src="https://github.com/user-attachments/assets/29f9ed38-ea12-4ad0-b38a-e8a2a970320e" />


## result example (total and total_accumulated needs to be calculated within excel, because these are not primary results):
<img width="2880" height="1836" alt="image" src="https://github.com/user-attachments/assets/44a6bddc-ddf7-4d3f-ac09-65a5fefae19d" />

## to do:
- [ ] revise the BuildingEmissionTimeline for more modular and pythonic implementation.
- [ ] include demolition information, after which the timeline should not be updated anymore.
- [ ] add functional operational emission calculation to timeline.
- [ ] reconsider the framework to track building modifications, so that partial addition/renovation/demolition is doable.
- [ ] expand framework to enable layer-level modifications, like adding insulation layers.
- [ ] add demolition's contribution to emission.