### PR TITLE
Incorrect format in typology import in schedule_helper

### DIFF
--- a/cea/datamanagement/schedule_helper.py
+++ b/cea/datamanagement/schedule_helper.py
@@ -287,7 +287,7 @@ def main(config):
     locator = cea.inputlocator.InputLocator(scenario=config.scenario)
 
     # get typology data
-    building_typology_df = gpd.read_file(locator.get_zone_geometry()).drop('geometry', axis=1)[COLUMNS_ZONE_TYPOLOGY]
+    building_typology_df = gpd.read_file(locator.get_zone_geometry())[COLUMNS_ZONE_TYPOLOGY]
 
     # validate list of uses in case study
     get_list_of_uses_in_case_study(building_typology_df)

--- a/cea/datamanagement/schedule_helper.py
+++ b/cea/datamanagement/schedule_helper.py
@@ -4,6 +4,7 @@ This script creates schedules per building in CEA
 
 import os
 
+import geopandas as gpd
 import numpy as np
 import pandas as pd
 
@@ -285,8 +286,8 @@ class ScheduleData(object):
 def main(config):
     locator = cea.inputlocator.InputLocator(scenario=config.scenario)
 
-    # get occupancy and age files
-    building_typology_df = pd.read_csv(locator.get_zone_geometry())[COLUMNS_ZONE_TYPOLOGY]
+    # get typology data
+    building_typology_df = gpd.read_file(locator.get_zone_geometry()).drop('geometry', axis=1)[COLUMNS_ZONE_TYPOLOGY]
 
     # validate list of uses in case study
     get_list_of_uses_in_case_study(building_typology_df)


### PR DESCRIPTION
The following line was in the `schedule_helper`:
```
building_typology_df = pd.read_csv(locator.get_zone_geometry())[COLUMNS_ZONE_TYPOLOGY]
```
However, `locator.get_zone_geometry()` points to a shapefile, not a csv file. So I've made the following fix:
```
building_typology_df = gpd.read_file(locator.get_zone_geometry())[COLUMNS_ZONE_TYPOLOGY]
```
...which solves the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated typology data loading to a geospatial-aware backend, improving compatibility with spatial file formats (e.g., shapefiles, GeoJSON) while preserving existing behavior and outputs. No changes to user workflows or configuration.
* **Documentation**
  * Clarified comments to reflect typology data loading via a geospatial data source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->