### PR TITLE
fix `.save()` method of `BaseDatabase` class

### DIFF
--- a/cea/datamanagement/database/__init__.py
+++ b/cea/datamanagement/database/__init__.py
@@ -160,11 +160,9 @@ class BaseDatabase(Base):
                 if columns and isinstance(columns, dict):
                     config['columns'] = list(columns.keys())
                 
-                os.makedirs(os.path.dirname(path), exist_ok=True)
                 if value.index.name in config.get('columns', []):
-                    value.reset_index().to_csv(path, **config, index=False)
-                else:
-                    value.to_csv(path, **config)
+                    config['columns'].remove(value.index.name)
+                value.to_csv(path, **config)
             elif isinstance(value, dict):
                 # Assume is _library with special index handling
                 # e.g., Schedules and Feedstocks classes


### PR DESCRIPTION
## Column names to save
in line 159 of cea.datamanagement.database.__init__.py, the current approach tries to get columns from the field.name subdict. 
```python
columns = self.schema().get(field.name, {}).get('columns', None)
```
However, there's one more branch between field.name and columns, which is `schema`.
The overview of `self.schema()` (from example of `ConstructionType`):
```python
{
    "construction_types": {
        "created_by": ["database_helper"],
        "file_path": "inputs/database/ARCHETYPES/CONSTRUCTION/CONSTRUCTION_TYPES.csv",
        "file_type": "csv",
        "schema": {
            "columns": {
                "Es": {
                    "description": "Fraction of gross floor area with electrical demands.",
                    "max": 1.0,
                    "min": 0.0,
                    "type": "float",
                    "unit": "[m2/m2]",
                    "values": "{0.0...1}",
                },
            },
            "constraints": {"year": "year_start < year_end"},
        },
        "used_by": ["archetypes_mapper"],
    }
}
```
To get the column names, the correct way is:
```python
columns = self.schema().get(field.name, {}).get('schema', {}).get('columns', None)
```
## save with index column
current apprach:
```python
value.to_csv(path, **config)
```
Currently, all database dataframes have specified an index column, which no long counts as an item of `df.columns`, but a separate `df.index.name`. Therefore, `**config` will pass the name of the index to `columns=` argument of `.to_csv()` method, and cause an error. 
To solve, I removed the index from `config['columns']` before saving:
```python
if value.index.name in config.get('columns', []):
    config['columns'].remove(value.index.name)
value.to_csv(path, **config)
```

## Minimal test run
```python
from cea.config import Configuration
from cea.inputlocator import InputLocator
from cea.datamanagement.database.archetypes import ConstructionType, Schedules, UseType
from cea.datamanagement.database.assemblies import HVAC, Envelope, Supply
from cea.datamanagement.database.components import Conversion, Distribution, Feedstocks

config = Configuration()
locator = InputLocator(config.scenario)
for Class in [ConstructionType, Schedules, UseType, Envelope, HVAC, Supply, Conversion, Distribution, Feedstocks]:
    obj = Class.from_locator(locator)
    obj.save(locator)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema handling for data exports to support nested configuration structures.
  * Refined file and configuration management during data persistence operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->