### PR TITLE
Fix SH-only existing DH network staying at `PLANT_hs` when DHW is added

### DIFF
--- a/cea/technologies/network_layout/AGENTS.md
+++ b/cea/technologies/network_layout/AGENTS.md
@@ -213,6 +213,9 @@ connected-buildings: B1001, B1002, B1003
 **Key properties:**
 - **User's disk files never modified**: Only in-memory GeoDataFrames are changed
 - Augmentation: New buildings connect at optimal entry points (existing nodes)
+- When reusing an existing DH network, copied plant nodes must be reconciled with the
+  current `itemised-dh-services` before saving `DH/layout/nodes.shp`; otherwise
+  `thermal-network` infers the old service mix from the stale plant type
 - Filtering: Uses graph-based cleanup to remove orphaned infrastructure
 - Both use `connection_candidates` parameter (default: 3) for Steiner optimisation
 - Coordinate precision: SHAPEFILE_TOLERANCE (6 decimal places)

--- a/cea/technologies/network_layout/main.py
+++ b/cea/technologies/network_layout/main.py
@@ -1071,6 +1071,12 @@ def auto_create_plant_nodes(nodes_gdf, edges_gdf, zone_gdf, plant_building_names
                 "  1. Remove plant building specifications from config (cooling-plant-building/heating-plant-building), OR\n"
                 "  2. Remove PLANT nodes from your network layout shapefile"
             )
+        if network_type == 'DH' and itemised_dh_services:
+            desired_plant_type = get_plant_type_from_services(itemised_dh_services, network_type)
+            current_plant_types = set(nodes_gdf.loc[existing_plants.index, 'type'].dropna().tolist())
+            if current_plant_types != {desired_plant_type}:
+                nodes_gdf.loc[existing_plants.index, 'type'] = desired_plant_type
+                print(f"    - Updated existing DH plant node(s) to {desired_plant_type}")
         print("  Plants already exist, skipping auto-creation")
         return nodes_gdf, edges_gdf, []
 


### PR DESCRIPTION
## What

Make reused DH networks respect the current DH service configuration in `network-layout`.

This includes:
- filtering DH buildings by the selected `itemised-dh-services`
- updating reused DH plant node types to match the current service mix before saving

## Why

This fixes a bug in the reused-DH-network path when the DH service mix changes between states.

Concrete example:
- state 2050 created a DH network with service configuration `space_heating` only
- the saved DH plant node type was therefore `PLANT_hs`
- state 2060 then reused that older network with `existing-network = thermal_network_2050`
- but state 2060 now required `space_heating -> domestic_hot_water`

Before this change, the copied plant node type was not updated. So even though `network-layout` received `itemised-dh-services = ['space_heating', 'domestic_hot_water']`, the saved reused network still contained `PLANT_hs`.

`thermal-network` reads DH service configuration from the saved plant node type. As a result, the 2060 network was still interpreted as `space_heating` only instead of `space_heating + domestic_hot_water`.

In other words:
- reusing an old SH-only DH network
- then adding WW in a later state
- produced a reused network whose saved plant metadata still described SH only

That made the saved network inconsistent with the current state configuration.

## How

- use service-specific DH demand fields in `network-layout`
  - `space_heating` → `Qhs_sys_MWhyr`
  - `domestic_hot_water` → `Qww_sys_MWhyr`
- pass `itemised-dh-services` through the relevant filtering paths
- apply the same demand filtering in the user-defined / `existing-network` path
- when reusing an existing DH network, rewrite copied plant node types to the current
  service-specific DH plant type before saving
- add focused regressions for service-specific filtering and copied-plant updates
