### PR TITLE
Fix phasing network part2

### DIFF
--- a/cea/optimization_new/user_network_loader.py
+++ b/cea/optimization_new/user_network_loader.py
@@ -28,7 +28,7 @@ import pandas as pd
 import geopandas as gpd
 import networkx as nx
 from shapely.geometry import Point
-from typing import Tuple, Dict, List, Set
+from typing import Tuple, Dict, List, Optional, Set
 
 from cea import CEAException
 from cea.constants import SHAPEFILE_TOLERANCE
@@ -970,6 +970,25 @@ def augment_user_network_with_buildings(
     print(f"    - Buildings to add: {', '.join(sorted(missing_building_names)[:10])}" +
           (f" and {len(missing_building_names) - 10} more" if len(missing_building_names) > 10 else ""))
 
+    # Build a GeoDataFrame of existing PLANT nodes so the potential graph
+    # (and the Steiner terminal set) both reach the plant, even when the
+    # filter step pruned the plant's pipes away.
+    plant_mask = (
+        user_nodes_gdf['type'].fillna('').astype(str).str.upper().str.startswith('PLANT')
+    )
+    existing_plant_nodes = user_nodes_gdf[plant_mask].copy()
+    plant_terminals = (
+        gpd.GeoDataFrame(
+            {
+                'name': existing_plant_nodes['name'].values,
+                'geometry': existing_plant_nodes['geometry'].values,
+            },
+            crs=existing_plant_nodes.crs,
+        )
+        if not existing_plant_nodes.empty
+        else None
+    )
+
     # Step 1: Create potential network combining user network + streets for routing
     print("  Step 1/3: Creating potential network graph...")
     potential_graph, building_terminals = _create_terminal_connections_for_buildings(
@@ -979,7 +998,8 @@ def augment_user_network_with_buildings(
         missing_building_names=missing_building_names,
         street_network_gdf=street_network_gdf,
         snap_tolerance=snap_tolerance,
-        connection_candidates=connection_candidates
+        connection_candidates=connection_candidates,
+        extra_terminal_points=plant_terminals,
     )
 
     # Step 2: Use Steiner tree to find optimal subset of edges connecting missing buildings to existing network
@@ -1012,16 +1032,32 @@ def augment_user_network_with_buildings(
         crs=existing_building_nodes.crs
     )
 
-    # Combine missing buildings + existing user buildings as terminals
+    # Combine missing buildings + existing user buildings (+ plants) as terminals.
+    # Plants were extracted above and fed into the potential graph so Steiner
+    # has a reachable node at every plant coord — including the case where the
+    # filter step pruned the plant's original pipes. Treating plants as
+    # mandatory terminals guarantees the augmented network is one connected
+    # component containing plant + all consumers.
     # Steiner tree will find optimal path connecting ALL terminals
+    terminal_frames = [
+        missing_buildings_centroids[['name', 'geometry']].reset_index(drop=True),
+        existing_terminals[['name', 'geometry']].reset_index(drop=True),
+    ]
+    if plant_terminals is not None:
+        terminal_frames.append(plant_terminals[['name', 'geometry']].reset_index(drop=True))
     all_terminals = gpd.GeoDataFrame(
-        pd.concat([missing_buildings_centroids[['name', 'geometry']].reset_index(drop=True),
-                   existing_terminals[['name', 'geometry']].reset_index(drop=True)],
-                  ignore_index=True),
+        pd.concat(terminal_frames, ignore_index=True),
         crs=missing_buildings_centroids.crs
     )
 
-    print(f"    - Terminals: {len(missing_buildings_centroids)} new + {len(existing_terminals)} existing = {len(all_terminals)} total")
+    plant_count = 0 if plant_terminals is None else len(plant_terminals)
+    if plant_count > 0:
+        print(f"    - Terminals: {len(missing_buildings_centroids)} new + "
+              f"{len(existing_terminals)} existing + {plant_count} plant = "
+              f"{len(all_terminals)} total")
+    else:
+        print(f"    - Terminals: {len(missing_buildings_centroids)} new + "
+              f"{len(existing_terminals)} existing = {len(all_terminals)} total")
 
     # Create temporary output paths for Steiner tree results
     temp_dir = tempfile.mkdtemp()
@@ -1387,11 +1423,19 @@ def _create_terminal_connections_for_buildings(
     missing_building_names: List[str],
     street_network_gdf: gpd.GeoDataFrame,
     snap_tolerance: float,
-    connection_candidates: int
+    connection_candidates: int,
+    extra_terminal_points: Optional[gpd.GeoDataFrame] = None,
 ) -> Tuple[nx.Graph, dict]:
     """
     Create potential network graph combining user edges + street network with terminal connections
     to missing buildings.
+
+    :param extra_terminal_points: Optional GeoDataFrame with ``name`` + ``geometry``
+        (Point) rows for non-building terminals (e.g. plant nodes) whose
+        coordinates must be present in the potential graph. They get the same
+        nearest-street connection treatment as missing buildings — necessary
+        when a plant's pipes were pruned by the filter step and its coord is
+        no longer reachable via user edges.
 
     Returns:
     - NetworkX graph with all potential edges (user + streets + terminals)
@@ -1407,16 +1451,32 @@ def _create_terminal_connections_for_buildings(
     missing_buildings_centroids_gdf = missing_buildings_gdf.copy()
     missing_buildings_centroids_gdf['geometry'] = missing_buildings_gdf.geometry.centroid
 
+    # Attach non-building terminals (e.g. plants) so ``create_terminals`` gives
+    # each one a connection to the nearest street. Without this, a plant whose
+    # pipes were pruned by the filter step has no coord in the potential graph
+    # and Steiner can't route through it.
+    if extra_terminal_points is not None and not extra_terminal_points.empty:
+        extra = extra_terminal_points[['name', 'geometry']].copy()
+        combined_centroids_gdf = gpd.GeoDataFrame(
+            pd.concat(
+                [missing_buildings_centroids_gdf[['name', 'geometry']], extra],
+                ignore_index=True,
+            ),
+            crs=missing_buildings_centroids_gdf.crs,
+        )
+    else:
+        combined_centroids_gdf = missing_buildings_centroids_gdf
+
     # Combine user edges + street network (both are potential routing options)
     combined_network_gdf = gpd.GeoDataFrame(
         pd.concat([user_edges_gdf, street_network_gdf], ignore_index=True),
         crs=user_edges_gdf.crs
     )
 
-    # Create terminal connections for missing buildings to combined network
-    # This connects each building to k-nearest street/edge points
+    # Create terminal connections for missing buildings (and extra points) to combined network
+    # This connects each terminal to k-nearest street/edge points
     network_with_terminals_gdf = create_terminals(
-        building_centroids=missing_buildings_centroids_gdf,
+        building_centroids=combined_centroids_gdf,
         street_network=combined_network_gdf,
         connection_candidates=connection_candidates
     )

--- a/cea/optimization_new/user_network_loader.py
+++ b/cea/optimization_new/user_network_loader.py
@@ -937,7 +937,8 @@ def augment_user_network_with_buildings(
     street_network_gdf: gpd.GeoDataFrame,
     locator,
     snap_tolerance: float = 0.5,
-    connection_candidates: int = 3
+    connection_candidates: int = 3,
+    existing_max_pipe_number: Optional[int] = None,
 ) -> Tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]:
     """
     Augment user-provided network with additional buildings using Steiner tree optimisation.
@@ -959,6 +960,12 @@ def augment_user_network_with_buildings(
     :param locator: InputLocator for file paths
     :param snap_tolerance: Tolerance for snapping terminal connections (metres)
     :param connection_candidates: Number of nearest streets to consider per building (1-5)
+    :param existing_max_pipe_number: Highest ``PIPE{N}`` number already in use in the
+        parent network (before any filter step). Steiner-added edges are renumbered
+        to start at ``N + 1`` so chained networks
+        (``existing-network`` workflows) never reuse a parent pipe name for a
+        different physical pipe — even names that were dropped from the parent by
+        the filter step. ``None`` or ``-1`` disables the offset.
     :return: Tuple of (augmented_nodes_gdf, augmented_edges_gdf) with new buildings added
     """
     from cea.technologies.network_layout.steiner_spanning_tree import calc_steiner_spanning_tree
@@ -1090,6 +1097,29 @@ def augment_user_network_with_buildings(
     finally:
         # Clean up temp files regardless of success or failure
         shutil.rmtree(temp_dir)
+
+    # Shift Steiner-assigned ``PIPE{N}`` numbers above the parent's namespace
+    # so new pipes never reuse a name that was in the parent — even ones the
+    # filter step dropped. ``calc_steiner_spanning_tree`` writes names
+    # starting at ``PIPE0``; without this shift, an inherited ``sub1`` PIPE
+    # whose building was decommissioned could be silently overwritten by a
+    # completely unrelated new ``sub2`` pipe with the same name, and
+    # downstream tools that cross-reference by name (multi-phase sizing,
+    # per-phase edges.shp with idle pipes, mass-flow CSVs) would misalign.
+    if existing_max_pipe_number is not None and existing_max_pipe_number >= 0:
+        offset = existing_max_pipe_number + 1
+
+        def _shift_pipe_name(name):
+            if (
+                isinstance(name, str)
+                and name.startswith('PIPE')
+                and name[4:].isdigit()
+            ):
+                return f'PIPE{int(name[4:]) + offset}'
+            return name
+
+        if 'name' in steiner_edges_gdf.columns:
+            steiner_edges_gdf['name'] = steiner_edges_gdf['name'].map(_shift_pipe_name)
 
     # Step 3: Merge optimised subnetwork with user's original network
     print("  Step 3/3: Merging augmented edges/nodes with user network...")

--- a/cea/technologies/network_layout/main.py
+++ b/cea/technologies/network_layout/main.py
@@ -341,6 +341,28 @@ def prune_disconnected_subnetwork(nodes_gdf, edges_gdf, target_buildings):
     return nodes_gdf, edges_gdf
 
 
+def _max_pipe_number(edges_gdf) -> int:
+    """Return the highest N across all ``PIPE{N}`` names in the given edges.
+
+    Returns ``-1`` when the GeoDataFrame has no ``PIPE{N}``-shaped names.
+    Used by ``apply_network_mode_to_user_network`` to reserve the parent
+    network's full pipe-name pool when chaining via ``existing-network``
+    so new Steiner-added edges never reuse a name that referred to a
+    different physical pipe in the parent — even names that were dropped
+    by the filter step. Without this, ``sub1``'s ``PIPE2`` (dropped when
+    its building was decommissioned) can be silently reused by ``sub2``'s
+    Steiner output for an unrelated pipe, breaking cross-phase alignment.
+    """
+    if 'name' not in edges_gdf.columns or len(edges_gdf) == 0:
+        return -1
+    nums = [
+        int(n[4:])
+        for n in edges_gdf['name']
+        if isinstance(n, str) and n.startswith('PIPE') and n[4:].isdigit()
+    ]
+    return max(nums) if nums else -1
+
+
 def apply_network_mode_to_user_network(nodes_gdf, edges_gdf, buildings_to_validate, zone_gdf,
                                        network_types_to_generate, config, locator, snap_tolerance):
     """
@@ -380,6 +402,12 @@ def apply_network_mode_to_user_network(nodes_gdf, edges_gdf, buildings_to_valida
             f"Expected one of: {', '.join(m.value for m in NetworkLayoutMode)}."
         )
     auto_modify = config.network_layout.auto_modify_network
+
+    # Snapshot the input edges' pipe-name pool BEFORE any filter/augment
+    # mutates it. New Steiner-added edges must skip these numbers so
+    # chained networks (existing-network workflows, multi-phase sizing)
+    # agree on pipe identity across phases. See ``_max_pipe_number``.
+    input_max_pipe_number = _max_pipe_number(edges_gdf)
 
     # Check for extra buildings in network (buildings not in parameter)
     network_buildings = set(nodes_gdf[
@@ -444,7 +472,8 @@ def apply_network_mode_to_user_network(nodes_gdf, edges_gdf, buildings_to_valida
                 street_network_gdf=street_network_gdf,
                 locator=locator,
                 snap_tolerance=snap_tolerance,
-                connection_candidates=config.network_layout.connection_candidates
+                connection_candidates=config.network_layout.connection_candidates,
+                existing_max_pipe_number=input_max_pipe_number,
             )
 
             print("  Augmentation successful - all buildings now in network")
@@ -496,7 +525,8 @@ def apply_network_mode_to_user_network(nodes_gdf, edges_gdf, buildings_to_valida
                     street_network_gdf=street_network_gdf,
                     locator=locator,
                     snap_tolerance=snap_tolerance,
-                    connection_candidates=config.network_layout.connection_candidates
+                    connection_candidates=config.network_layout.connection_candidates,
+                    existing_max_pipe_number=input_max_pipe_number,
                 )
 
             print("  Filter complete - network now matches parameter exactly")

--- a/cea/technologies/thermal_network/common/phasing.py
+++ b/cea/technologies/thermal_network/common/phasing.py
@@ -1482,6 +1482,9 @@ def save_phase_layout_shapefiles(locator, phases: List[Dict], phase_results: Lis
         # the current phase's local name / geometry (so the output matches
         # what Part 1 drew for this phase); fall back to the first phase
         # that contained the edge for idle edges not in this phase's layout.
+        # Name-pool preservation in ``network-layout`` guarantees that
+        # inherited idle-edge names don't collide with this phase's local
+        # names when the phase chain uses ``existing-network``.
         edge_rows = []
         for cid, decision in sizing_decisions.items():
             phase_decision = decision.get(phase_key, {})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network augmentation now preserves existing pipe numbering when extending district networks, preventing naming conflicts in chained workflows.
  * Plant nodes are now designated as mandatory terminals during network augmentation, ensuring connection to existing infrastructure.

* **Documentation**
  * Enhanced documentation clarifying how name-pool preservation prevents edge-name collisions in multi-phase network layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->