### PR TITLE
Remove statefull config from routes

### DIFF
--- a/.github/codeql/extensions/cea-path-sanitizers.yml
+++ b/.github/codeql/extensions/cea-path-sanitizers.yml
@@ -9,3 +9,6 @@ extensions:
       # through it into downstream filesystem operations.
       - ["cea.interfaces.dashboard.utils", "Member[secure_path].ReturnValue", "path-injection"]
       - ["cea.interfaces.dashboard.utils", "Member[secure_join_under_root].ReturnValue", "path-injection"]
+      # validate_path_within_root resolves to realpath and verifies the result
+      # stays within the given root — its return value is a canonical safe path.
+      - ["cea.utilities", "Member[validate_path_within_root].ReturnValue", "path-injection"]

--- a/.github/codeql/extensions/cea-path-sanitizers.yml
+++ b/.github/codeql/extensions/cea-path-sanitizers.yml
@@ -1,10 +1,11 @@
 extensions:
   - addsTo:
-      pack: codeql/python-queries
-      extensible: neutralModel
+      pack: codeql/python-all
+      extensible: barrierModel
     data:
       # secure_path resolves a canonical path via os.path.realpath and enforces
-      # project-root boundary checks (validate_path_within_root).  Declaring it
-      # neutral prevents CodeQL from propagating taint through its return value:
-      # any path that has passed through secure_path is considered sanitised.
-      - ["cea.interfaces.dashboard.utils", "", false, "secure_path", "()", "", "summary", "manual"]
+      # project-root boundary checks (validate_path_within_root). Declaring its
+      # return value as a path-injection barrier stops CodeQL from tracing taint
+      # through it into downstream filesystem operations.
+      - ["cea.interfaces.dashboard.utils", "Member[secure_path].ReturnValue", "path-injection"]
+      - ["cea.interfaces.dashboard.utils", "Member[secure_join_under_root].ReturnValue", "path-injection"]

--- a/.github/codeql/extensions/cea-path-sanitizers.yml
+++ b/.github/codeql/extensions/cea-path-sanitizers.yml
@@ -1,0 +1,10 @@
+extensions:
+  - addsTo:
+      pack: codeql/python-queries
+      extensible: neutralModel
+    data:
+      # secure_path resolves a canonical path via os.path.realpath and enforces
+      # project-root boundary checks (validate_path_within_root).  Declaring it
+      # neutral prevents CodeQL from propagating taint through its return value:
+      # any path that has passed through secure_path is considered sanitised.
+      - ["cea.interfaces.dashboard.utils", "", false, "secure_path", "()", "", "summary", "manual"]

--- a/cea/interfaces/dashboard/AGENTS.md
+++ b/cea/interfaces/dashboard/AGENTS.md
@@ -68,6 +68,17 @@ All transitions are auth-checked and row-locked (TOCTOU protection).
 - Keep FastAPI responses as Python objects; JSON-safe conversion too early breaks computed fields like `duration`
 - Prefer FastAPI `status.HTTP_*` constants over numeric status codes in `HTTPException` and response constructors
 
+## Logging
+
+Use `getCEAServerLogger` from `cea.interfaces.dashboard.lib.logs` — never `logging.getLogger(__name__)`.
+
+```python
+from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
+logger = getCEAServerLogger("cea-server-<module>")
+```
+
+Use a descriptive name matching the module (e.g. `"cea-server-utils"`, `"cea-server-inputs"`).
+
 ## Caching (`dependencies.py`)
 
 - `worker_processes`: `job_id → PID` (TTL-based)

--- a/cea/interfaces/dashboard/AGENTS.md
+++ b/cea/interfaces/dashboard/AGENTS.md
@@ -106,6 +106,10 @@ Treat the dashboard server as stateless. Do not persist request-scoped selection
 
 Both dependencies read scenario context from `X-CEA-*` headers first; if absent they fall back to query params. They enforce `project_root` boundaries in both cases; in non-local mode, absolute `X-CEA-Project` / `project` values are rejected.
 
+**Route path safety helpers** (`utils.py`):
+- Use `InputLocator(scenario)` directly in all route handlers — `CEAScenario` / `CEAScenarioLenient` already sanitise the path, and `resolve_scenario_path` applies `secure_path` to the final joined path for cross-scenario routes.
+- Use `secure_join_under_root(base, user_segment)` when appending user-provided path segments before filesystem checks.
+
 **`save()` behaviour**: `CEALocalConfig.save()` writes `~/cea.config`; `CEAStatelessConfig.save()` is a no-op. Call `config.save()` unconditionally where appropriate — it does the right thing in both modes.
 
 ## Scenario Context — Header Contract

--- a/cea/interfaces/dashboard/AGENTS.md
+++ b/cea/interfaces/dashboard/AGENTS.md
@@ -108,6 +108,24 @@ Both dependencies enforce `project_root` boundaries when present; in non-local m
 
 **`save()` behaviour**: `CEALocalConfig.save()` writes `~/cea.config`; `CEAStatelessConfig.save()` is a no-op. Call `config.save()` unconditionally where appropriate — it does the right thing in both modes.
 
+## Architectural Debt: Query-Param Scenario Passing
+
+**Current API pattern** (temporary):
+```
+PUT /tools/{tool}/save-config?scenario=MyScenario&project=project
+```
+
+**Planned refactor** (blocked by projects table):
+```
+PUT /projects/{project_id}/scenarios/{scenario_name}/tools/{tool}/config
+```
+
+**Why query params exist**: Scenarios are filesystem paths (contain `/`); cannot be safely embedded in URL paths. Refactor requires a projects table mapping `project_id → project_path` (both local and non-local modes).
+
+**Pathway child scenarios**: Use dedicated `?child_scenario=subpath` parameter (e.g., `pathway_output/year_2050/scenario`), validated to prevent directory escaping.
+
+**See also**: TODO comments in `cea/interfaces/dashboard/api/utils.py` and `api/tools.py` for refactor details.
+
 ## Docker
 
 Server runs as PID 1 with a `SIGCHLD` handler (`setup_sigchld_handler` in `app.py`) that reaps zombie workers via `os.waitpid(-1, WNOHANG)`. Tini not required but easy to re-enable.

--- a/cea/interfaces/dashboard/AGENTS.md
+++ b/cea/interfaces/dashboard/AGENTS.md
@@ -96,7 +96,7 @@ Not every user action should become a background job. Keep fast synchronous API 
 
 ## Statelessness (important for container scaling)
 
-Treat the dashboard server as stateless. Do not persist request-scoped selections (e.g. scenario) to `config` or any server-side store. Pass context per request via `X-CEA-*` headers (preferred) or query params (deprecated compat); never call `save()` on it.
+Treat the dashboard server as stateless. Do not persist request-scoped selections (e.g. scenario) to `config` or any server-side store. Pass context per request via `X-CEA-*` headers (preferred) or query params (deprecated compat); do not use `config.save()` to persist request-scoped scenario selection.
 
 **Config is per-request**: `get_cea_config()` creates a fresh instance on every request (local: `CEALocalConfig` from disk, non-local: `CEAStatelessConfig` from `DEFAULT_CONFIG`). There is no shared config singleton — mutations are request-scoped and need no snapshot/restore.
 

--- a/cea/interfaces/dashboard/AGENTS.md
+++ b/cea/interfaces/dashboard/AGENTS.md
@@ -96,7 +96,7 @@ Not every user action should become a background job. Keep fast synchronous API 
 
 ## Statelessness (important for container scaling)
 
-Treat the dashboard server as stateless. Do not persist request-scoped selections (e.g. scenario) to `config` or any server-side store. Pass context per request — accept it as a query parameter and apply it in memory for that request only; never call `save()` on it.
+Treat the dashboard server as stateless. Do not persist request-scoped selections (e.g. scenario) to `config` or any server-side store. Pass context per request via `X-CEA-*` headers (preferred) or query params (deprecated compat); never call `save()` on it.
 
 **Config is per-request**: `get_cea_config()` creates a fresh instance on every request (local: `CEALocalConfig` from disk, non-local: `CEAStatelessConfig` from `DEFAULT_CONFIG`). There is no shared config singleton — mutations are request-scoped and need no snapshot/restore.
 
@@ -104,27 +104,27 @@ Treat the dashboard server as stateless. Do not persist request-scoped selection
 - `CEAScenario` enforces that the resolved scenario directory exists (use for endpoints that read/write scenario files).
 - `CEAScenarioLenient` resolves and validates path boundaries but does not require directory existence (use for metadata/config endpoints).
 
-Both dependencies enforce `project_root` boundaries when present; in non-local mode, absolute `project` query values are rejected.
+Both dependencies read scenario context from `X-CEA-*` headers first; if absent they fall back to query params. They enforce `project_root` boundaries in both cases; in non-local mode, absolute `X-CEA-Project` / `project` values are rejected.
 
 **`save()` behaviour**: `CEALocalConfig.save()` writes `~/cea.config`; `CEAStatelessConfig.save()` is a no-op. Call `config.save()` unconditionally where appropriate — it does the right thing in both modes.
 
-## Architectural Debt: Query-Param Scenario Passing
+## Scenario Context — Header Contract
 
-**Current API pattern** (temporary):
-```
-PUT /tools/{tool}/save-config?scenario=MyScenario&project=project
-```
+Scenario context travels as HTTP request headers. Query params (`project`, `scenario_name`, `scenario_path`) are deprecated compat, accepted during frontend migration.
 
-**Planned refactor** (blocked by projects table):
-```
-PUT /projects/{project_id}/scenarios/{scenario_name}/tools/{tool}/config
-```
+| Header | Purpose |
+|---|---|
+| `X-CEA-Project` | Project directory (relative under `project_root` in non-local mode) |
+| `X-CEA-Scenario-Name` | Bare scenario name — always the parent scenario |
+| `X-CEA-Child-Scenario` | Logical pathway child token `<pathway_name>/<year>`; requires the two above |
 
-**Why query params exist**: Scenarios are filesystem paths (contain `/`); cannot be safely embedded in URL paths. Refactor requires a projects table mapping `project_id → project_path` (both local and non-local modes).
+**Resolution priority**: header values (if any header present) > query params > `config.scenario`.
 
-**Pathway child scenarios**: Use dedicated `?child_scenario=subpath` parameter (e.g., `pathway_output/year_2050/scenario`), validated to prevent directory escaping.
+**Child scenario**: `X-CEA-Child-Scenario: <pathway_name>/<year>` is a logical token — the backend resolves it to a filesystem path via `InputLocator.get_state_in_time_scenario_folder(pathway_name, year)`. No filesystem path is sent by the client; the physical layout (`outputs/pathways/<name>/state_<year>`) stays an implementation detail.
 
-**See also**: TODO comments in `cea/interfaces/dashboard/api/utils.py` and `api/tools.py` for refactor details.
+**Canvas compare mode**: send per-request `headers` on each Axios call to target different scenarios concurrently — one global header/cookie cannot express this, which is why headers (not cookies) were chosen.
+
+**Future phase (separate plan)**: URL path hierarchy `PUT /projects/{id}/scenarios/{name}/...` requires a `project_id → project_path` mapping table (works for local and non-local modes). Deferred: no `project_id` migration needed until online multi-user requires stable IDs.
 
 ## Docker
 

--- a/cea/interfaces/dashboard/AGENTS.md
+++ b/cea/interfaces/dashboard/AGENTS.md
@@ -100,7 +100,11 @@ Treat the dashboard server as stateless. Do not persist request-scoped selection
 
 **Config is per-request**: `get_cea_config()` creates a fresh instance on every request (local: `CEALocalConfig` from disk, non-local: `CEAStatelessConfig` from `DEFAULT_CONFIG`). There is no shared config singleton — mutations are request-scoped and need no snapshot/restore.
 
-**`CEAScenario`** (`api/utils.py`) is the standard dependency for resolving the effective scenario. Routes set `config.scenario = scenario` directly; no `finally` restore is needed.
+**Scenario dependencies** (`api/utils.py`):
+- `CEAScenario` enforces that the resolved scenario directory exists (use for endpoints that read/write scenario files).
+- `CEAScenarioLenient` resolves and validates path boundaries but does not require directory existence (use for metadata/config endpoints).
+
+Both dependencies enforce `project_root` boundaries when present; in non-local mode, absolute `project` query values are rejected.
 
 **`save()` behaviour**: `CEALocalConfig.save()` writes `~/cea.config`; `CEAStatelessConfig.save()` is a no-op. Call `config.save()` unconditionally where appropriate — it does the right thing in both modes.
 

--- a/cea/interfaces/dashboard/AGENTS.md
+++ b/cea/interfaces/dashboard/AGENTS.md
@@ -85,9 +85,13 @@ Not every user action should become a background job. Keep fast synchronous API 
 
 ## Statelessness (important for container scaling)
 
-Treat the dashboard server as stateless. Do not persist request-scoped selections (e.g. pathway child scenario) to `config` or any server-side store. Prefer passing such context per request — accept it as a query or body parameter and apply it in memory for that request only; never call `save()` on it. Persisting shared global state blocks horizontal scaling across containers and causes cross-request / cross-client staleness bugs. When you must apply per-request state to a shared config object (e.g. as a FastAPI router-level dependency), snapshot the original values and restore them in a `finally` block.
+Treat the dashboard server as stateless. Do not persist request-scoped selections (e.g. scenario) to `config` or any server-side store. Pass context per request — accept it as a query parameter and apply it in memory for that request only; never call `save()` on it.
 
-**Current exception — project/scenario selection**: The active project and scenario (`general:project` + `general:scenario-name` in config) are still persisted to disk via `PUT /api/project/`. This is intentional for now; making scenario selection stateless is planned for a future refactor. Refrain from adding new server-side persistence beyond this existing exception. Warn if user insists on breaking this rule.
+**Config is per-request**: `get_cea_config()` creates a fresh instance on every request (local: `CEALocalConfig` from disk, non-local: `CEAStatelessConfig` from `DEFAULT_CONFIG`). There is no shared config singleton — mutations are request-scoped and need no snapshot/restore.
+
+**`CEAScenario`** (`api/utils.py`) is the standard dependency for resolving the effective scenario. Routes set `config.scenario = scenario` directly; no `finally` restore is needed.
+
+**`save()` behaviour**: `CEALocalConfig.save()` writes `~/cea.config`; `CEAStatelessConfig.save()` is a no-op. Call `config.save()` unconditionally where appropriate — it does the right thing in both modes.
 
 ## Docker
 

--- a/cea/interfaces/dashboard/api/AGENTS.md
+++ b/cea/interfaces/dashboard/api/AGENTS.md
@@ -26,9 +26,22 @@ return await run_in_threadpool(get_pathway_timeline, config, pathway_name)
 detail={"message": str(exc), "state_kind": "stock", "requires_edit": True}
 ```
 
+### DO: Guard user-derived path segments before filesystem checks
+```python
+candidate = os.path.realpath(os.path.join(base_dir, user_value))
+if os.path.commonpath((base_dir, candidate)) != base_dir:
+	return []
+```
+
 ### DO: Reserve `/api/pathways/*` for dashboard-specific pathway UX
 ```python
 # Timeline/editor actions should not be routed through `/api/tools/*`.
+```
+
+### DO: Use InputLocator directly for CEAScenario-derived paths
+```python
+locator = cea.inputlocator.InputLocator(scenario)  # scenario: CEAScenario already sanitised
+folder = secure_join_under_root(parent_folder, user_segment)
 ```
 
 ### DON'T: Bake or simulate directly inside route handlers

--- a/cea/interfaces/dashboard/api/canvas.py
+++ b/cea/interfaces/dashboard/api/canvas.py
@@ -47,7 +47,8 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 import cea.inputlocator
-from cea.interfaces.dashboard.dependencies import CEAConfig, CEAProjectRoot
+from cea.interfaces.dashboard.api.utils import CEAScenario
+from cea.interfaces.dashboard.dependencies import CEAConfig
 from cea.interfaces.dashboard.lib.canvas_capture import capture_canvas_data
 from cea.interfaces.dashboard.lib.canvas_storage import (
     CanvasMeta,
@@ -64,7 +65,6 @@ from cea.interfaces.dashboard.lib.canvas_storage import (
     sanitize_canvas_name,
     write_canvas,
 )
-from cea.interfaces.dashboard.utils import resolve_scenario_path
 
 
 __author__ = "Zhongming Shi"
@@ -107,11 +107,6 @@ class SparseWriteRequest(BaseModel):
 # ── Helpers ─────────────────────────────────────────────────────
 
 
-def _locator_for(project_root, project: str, scenario: str) -> cea.inputlocator.InputLocator:
-    scenario_path = resolve_scenario_path(project_root, project, scenario)
-    return cea.inputlocator.InputLocator(scenario_path)
-
-
 def _safe_name(name: str) -> str:
     """Sanitize a path-segment name from a URL before any filesystem
     use. Rejects path-traversal characters (``\\ / .. *``) and reserved
@@ -145,21 +140,15 @@ def _require_saved(locator: cea.inputlocator.InputLocator, name: str) -> str:
 
 
 @router.get('/')
-async def get_saved_canvases(
-    project_root: CEAProjectRoot,
-    project: str,
-    scenario: str,
-) -> List[str]:
+async def get_saved_canvases(scenario: CEAScenario) -> List[str]:
     """Return the display names of every saved canvas in the scenario."""
-    locator = _locator_for(project_root, project, scenario)
+    locator = cea.inputlocator.InputLocator(scenario)
     return await run_in_threadpool(list_saved_canvases, locator)
 
 
 @router.post('/')
 async def create_canvas(
-    project_root: CEAProjectRoot,
-    project: str,
-    scenario: str,
+    scenario: CEAScenario,
     body: CreateCanvasRequest,
 ) -> dict:
     """Create a fresh canvas folder.
@@ -168,7 +157,7 @@ async def create_canvas(
     saved canvas already exists under the same sanitised name; 400
     on illegal name.
     """
-    locator = _locator_for(project_root, project, scenario)
+    locator = cea.inputlocator.InputLocator(scenario)
 
     def _do() -> str:
         try:
@@ -192,25 +181,18 @@ async def create_canvas(
 
 
 @router.get('/{name}')
-async def get_saved_canvas(
-    project_root: CEAProjectRoot,
-    project: str,
-    scenario: str,
-    name: str,
-) -> CanvasState:
+async def get_saved_canvas(scenario: CEAScenario, name: str) -> CanvasState:
     """Read a saved canvas's full state (canvas + layout +
     feature_card YAMLs)."""
     name = _safe_name(name)
-    locator = _locator_for(project_root, project, scenario)
+    locator = cea.inputlocator.InputLocator(scenario)
     folder = _require_saved(locator, name)
     return await run_in_threadpool(read_canvas, locator, folder)
 
 
 @router.put('/{name}')
 async def update_saved_canvas(
-    project_root: CEAProjectRoot,
-    project: str,
-    scenario: str,
+    scenario: CEAScenario,
     name: str,
     body: SparseWriteRequest,
 ) -> dict:
@@ -222,7 +204,7 @@ async def update_saved_canvas(
       - toggling a navigator switch lands as ``{ canvas: … }``
     """
     name = _safe_name(name)
-    locator = _locator_for(project_root, project, scenario)
+    locator = cea.inputlocator.InputLocator(scenario)
     folder = _require_saved(locator, name)
     await run_in_threadpool(
         write_canvas,
@@ -236,15 +218,10 @@ async def update_saved_canvas(
 
 
 @router.delete('/{name}')
-async def delete_saved_canvas(
-    project_root: CEAProjectRoot,
-    project: str,
-    scenario: str,
-    name: str,
-) -> dict:
+async def delete_saved_canvas(scenario: CEAScenario, name: str) -> dict:
     """Permanently remove a saved canvas folder. No-op if missing."""
     name = _safe_name(name)
-    locator = _locator_for(project_root, project, scenario)
+    locator = cea.inputlocator.InputLocator(scenario)
     folder = locator.get_saved_canvas_folder(name)
     await run_in_threadpool(delete_canvas_folder, folder)
     return {'ok': True}
@@ -252,9 +229,7 @@ async def delete_saved_canvas(
 
 @router.post('/{name}/duplicate')
 async def duplicate_saved_canvas(
-    project_root: CEAProjectRoot,
-    project: str,
-    scenario: str,
+    scenario: CEAScenario,
     name: str,
     body: DuplicateCanvasRequest,
 ) -> dict:
@@ -269,7 +244,7 @@ async def duplicate_saved_canvas(
     400 — illegal target name.
     """
     name = _safe_name(name)
-    locator = _locator_for(project_root, project, scenario)
+    locator = cea.inputlocator.InputLocator(scenario)
     _require_saved(locator, name)
 
     def _do() -> str:
@@ -300,9 +275,7 @@ async def duplicate_saved_canvas(
 @router.get('/{name}/export')
 async def export_canvas(
     config: CEAConfig,
-    project_root: CEAProjectRoot,
-    project: str,
-    scenario: str,
+    scenario: CEAScenario,
     name: str,
 ) -> StreamingResponse:
     """Capture every plot card to HTML, then stream a zip of the
@@ -315,7 +288,7 @@ async def export_canvas(
     the original CEA scenario.
     """
     name = _safe_name(name)
-    locator = _locator_for(project_root, project, scenario)
+    locator = cea.inputlocator.InputLocator(scenario)
     folder = _require_saved(locator, name)
 
     # `capture_canvas_data` mutates `config.project` and
@@ -357,9 +330,7 @@ async def export_canvas(
 
 @router.post('/import')
 async def import_canvas(
-    project_root: CEAProjectRoot,
-    project: str,
-    scenario: str,
+    scenario: CEAScenario,
     file: UploadFile = File(...),
     as_name: Optional[str] = Query(None, alias='as'),
 ) -> dict:
@@ -376,7 +347,7 @@ async def import_canvas(
     400 — malformed zip / missing canvas marker / illegal name.
     409 — a saved canvas with the same target name already exists.
     """
-    locator = _locator_for(project_root, project, scenario)
+    locator = cea.inputlocator.InputLocator(scenario)
     payload = await file.read()
 
     def _do() -> str:

--- a/cea/interfaces/dashboard/api/dashboards.py
+++ b/cea/interfaces/dashboard/api/dashboards.py
@@ -1,4 +1,5 @@
 import hashlib
+import os
 from typing import Dict, Any
 
 from fastapi import APIRouter
@@ -7,10 +8,10 @@ from fastapi.concurrency import run_in_threadpool
 import cea.config
 import cea.plots
 from .utils import (
+    CEAScenarioLenient,
     deconstruct_parameters,
     split_scenario_subpath,
     validate_scenario_name,
-    validate_scenario_name_or_subpath,
 )
 from cea.interfaces.dashboard.dependencies import CEAConfig, CEAPlotCache
 
@@ -115,14 +116,16 @@ async def get_plot_categories(config: CEAConfig):
 
 
 @router.get('/plot-categories/{category_name}/plots/{plot_id}/parameters')
-async def get_plot_category_parameters(config: CEAConfig, category_name: str, plot_id: str, scenario: str = None):
-    if scenario is not None:
-        # `validate_scenario_name_or_subpath` accepts the project-
-        # relative path that pathway-single columns use; the path is
-        # split downstream in `get_parameters_from_plot_class`.
-        scenario = validate_scenario_name_or_subpath(scenario)
+async def get_plot_category_parameters(
+    config: CEAConfig,
+    scenario: CEAScenarioLenient,
+    category_name: str,
+    plot_id: str,
+):
+    config.project = os.path.dirname(scenario)
+    config.scenario_name = os.path.basename(scenario)
     plot_class = cea.plots.categories.load_plot_by_id(category_name, plot_id, config.plugins)
-    return get_parameters_from_plot_class(config, plot_class, scenario)
+    return get_parameters_from_plot_class(config, plot_class, config.scenario_name)
 
 
 @router.post('/duplicate')
@@ -231,19 +234,24 @@ async def delete_plot(config: CEAConfig, plot_cache: CEAPlotCache,  dashboard_in
 
 
 @router.get('/{dashboard_index}/plots/{plot_index}/parameters')
-async def get_plot_parameters(config: CEAConfig, plot_cache: CEAPlotCache,
-                              dashboard_index: int, plot_index: int, scenario: str = None):
+async def get_plot_parameters(
+    config: CEAConfig,
+    plot_cache: CEAPlotCache,
+    scenario: CEAScenarioLenient,
+    dashboard_index: int,
+    plot_index: int,
+):
     """
     Get Plot Form Parameters of Plot in Dashboard
     """
-    if scenario is not None:
-        scenario = validate_scenario_name(scenario)
+    config.project = os.path.dirname(scenario)
+    config.scenario_name = os.path.basename(scenario)
     dashboards = await run_in_threadpool(lambda: cea.plots.read_dashboards(config, plot_cache))
 
     dashboard = dashboards[dashboard_index]
     plot = dashboard.plots[plot_index]
 
-    return get_parameters_from_plot(config, plot, scenario)
+    return get_parameters_from_plot(config, plot, config.scenario_name)
 
 
 @router.get('/{dashboard_index}/plots/{plot_index}/input-files')

--- a/cea/interfaces/dashboard/api/inputs.py
+++ b/cea/interfaces/dashboard/api/inputs.py
@@ -8,13 +8,13 @@ import traceback
 import warnings
 from collections import defaultdict
 from contextlib import redirect_stdout
-from typing import Dict, Any, Annotated
+from typing import Dict, Any
 import zipfile
 
 from fastapi.responses import StreamingResponse
 import geopandas
 import pandas as pd
-from fastapi import APIRouter, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, HTTPException, UploadFile, status
 from fastapi.concurrency import run_in_threadpool
 from fiona.errors import DriverError
 from pydantic import BaseModel, Field
@@ -26,9 +26,9 @@ from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
 import cea.schemas
 from cea.databases import CEADatabase, CEADatabaseException
 from cea.datamanagement.format_helper.cea4_verify_db import cea4_verify_db
-from cea.interfaces.dashboard.dependencies import CEAConfig, CEAProjectRoot, CEASeverDemoAuthCheck
+from cea.interfaces.dashboard.dependencies import CEASeverDemoAuthCheck
 from cea.interfaces.dashboard.utils import secure_path
-from cea.interfaces.dashboard.api.utils import ScenarioQuery
+from cea.interfaces.dashboard.api.utils import CEAScenario
 from cea.plots.supply_system.a_supply_system_map import get_building_connectivity, newer_network_layout_exists
 from cea.plots.variable_naming import get_color_array
 from cea.technologies.network_layout.main import auto_layout_network, NetworkLayout
@@ -98,10 +98,8 @@ async def get_building_props_db(db: str):
 
 
 @router.get('/geojson/{kind}')
-async def get_input_geojson(config: CEAConfig, project_root: CEAProjectRoot,
-                            scenario: Annotated[ScenarioQuery, Query()], kind: str):
-    effective_scenario = scenario.resolve(config, project_root)
-    locator = cea.inputlocator.InputLocator(effective_scenario)
+async def get_input_geojson(scenario: CEAScenario, kind: str):
+    locator = cea.inputlocator.InputLocator(scenario)
 
     if kind not in GEOJSON_KEYS:
         raise HTTPException(
@@ -119,30 +117,23 @@ async def get_input_geojson(config: CEAConfig, project_root: CEAProjectRoot,
             )
         return df_to_json(location)[0]
     elif kind in NETWORK_KEYS:
-        return get_network(effective_scenario, kind)[0]
+        return get_network(scenario, kind)[0]
     elif kind == 'streets':
         return df_to_json(locator.get_street_network())[0]
 
 
 @router.get('/building-properties')
-async def get_building_props(config: CEAConfig, project_root: CEAProjectRoot,
-                             scenario: Annotated[ScenarioQuery, Query()]):
-    effective_scenario = scenario.resolve(config, project_root)
-    return get_building_properties(effective_scenario)
+async def get_building_props(scenario: CEAScenario):
+    return get_building_properties(scenario)
 
 
 @router.get('/all-inputs')
-async def get_all_inputs(
-    config: CEAConfig,
-    project_root: CEAProjectRoot,
-    scenario: Annotated[ScenarioQuery, Query()],
-):
-    effective_scenario = scenario.resolve(config, project_root)
-    locator = cea.inputlocator.InputLocator(effective_scenario)
+async def get_all_inputs(scenario: CEAScenario):
+    locator = cea.inputlocator.InputLocator(scenario)
 
     # FIXME: Find a better way, current used to test for Input Editor
     def fn():
-        store = get_building_properties(effective_scenario)
+        store = get_building_properties(scenario)
         store['geojsons'] = {}
         store['connected_buildings'] = {'dc': [], 'dh': []}
         store['crs'] = {}
@@ -171,14 +162,8 @@ class InputForm(BaseModel):
 
 
 @router.put('/all-inputs', dependencies=[CEASeverDemoAuthCheck])
-async def save_all_inputs(
-    config: CEAConfig,
-    project_root: CEAProjectRoot,
-    scenario: Annotated[ScenarioQuery, Query()],
-    form: InputForm,
-):
-    effective_scenario = scenario.resolve(config, project_root)
-    locator = cea.inputlocator.InputLocator(effective_scenario)
+async def save_all_inputs(scenario: CEAScenario, form: InputForm):
+    locator = cea.inputlocator.InputLocator(scenario)
 
     tables = form.tables
     geojsons = form.geojsons
@@ -258,7 +243,7 @@ async def save_all_inputs(
     # If the save happened inside a pathway state (sub-scenario), mark
     # the state as custom so the pathway viewer shows it in purple and
     # bake/simulate can handle it appropriately.
-    child_scenario = PathwayChildScenario.parse(effective_scenario)
+    child_scenario = PathwayChildScenario.parse(scenario)
     if child_scenario:
         from cea.datamanagement.district_pathways.pathway_status import record_custom_state
         parent_locator = cea.inputlocator.InputLocator(child_scenario.parent)
@@ -432,10 +417,8 @@ def df_to_json(file_location):
 
 
 @router.get('/building-schedule/{building}')
-async def get_building_schedule(config: CEAConfig, project_root: CEAProjectRoot,
-                                scenario: Annotated[ScenarioQuery, Query()], building: str):
-    effective_scenario = scenario.resolve(config, project_root)
-    locator = cea.inputlocator.InputLocator(effective_scenario)
+async def get_building_schedule(scenario: CEAScenario, building: str):
+    locator = cea.inputlocator.InputLocator(scenario)
     try:
         schedule_data, schedule_complementary_data = read_cea_schedule(locator, use_type=None, building=building)
         df = pd.DataFrame(schedule_data).set_index(['hour'])
@@ -453,10 +436,8 @@ async def get_building_schedule(config: CEAConfig, project_root: CEAProjectRoot,
 
 
 @router.get('/databases')
-async def get_input_database_data(config: CEAConfig, project_root: CEAProjectRoot,
-                                  scenario: Annotated[ScenarioQuery, Query()]):
-    effective_scenario = scenario.resolve(config, project_root)
-    locator = cea.inputlocator.InputLocator(effective_scenario)
+async def get_input_database_data(scenario: CEAScenario):
+    locator = cea.inputlocator.InputLocator(scenario)
     try:
         cea_db = await run_in_threadpool(lambda: CEADatabase.from_locator(locator))
     except CEADatabaseException as e:
@@ -475,10 +456,8 @@ async def get_input_database_data(config: CEAConfig, project_root: CEAProjectRoo
 
 
 @router.put('/databases', dependencies=[CEASeverDemoAuthCheck])
-async def put_input_database_data(config: CEAConfig, project_root: CEAProjectRoot,
-                                  scenario: Annotated[ScenarioQuery, Query()], payload: Dict[str, Any]):
-    effective_scenario = scenario.resolve(config, project_root)
-    locator = cea.inputlocator.InputLocator(effective_scenario)
+async def put_input_database_data(scenario: CEAScenario, payload: Dict[str, Any]):
+    locator = cea.inputlocator.InputLocator(scenario)
     try:
         def fn():
             db = CEADatabase.from_dict(payload)
@@ -494,13 +473,11 @@ async def put_input_database_data(config: CEAConfig, project_root: CEAProjectRoo
 
 
 @router.post('/databases/upload', dependencies=[CEASeverDemoAuthCheck])
-async def upload_input_database(config: CEAConfig, project_root: CEAProjectRoot,
-                                scenario: Annotated[ScenarioQuery, Query()], file: UploadFile):
-    effective_scenario = scenario.resolve(config, project_root)
-    locator = cea.inputlocator.InputLocator(effective_scenario)
+async def upload_input_database(scenario: CEAScenario, file: UploadFile):
+    locator = cea.inputlocator.InputLocator(scenario)
 
     # Create a lock file path specific to this scenario
-    lock_file_path = os.path.join(tempfile.gettempdir(), f'cea_db_upload_{hash(effective_scenario)}.lock')
+    lock_file_path = os.path.join(tempfile.gettempdir(), f'cea_db_upload_{hash(scenario)}.lock')
 
     def do_upload():
         """Perform the upload operation with file-based locking"""
@@ -605,10 +582,8 @@ async def upload_input_database(config: CEAConfig, project_root: CEAProjectRoot,
     return await run_in_threadpool(do_upload)
 
 @router.get('/databases/download', dependencies=[CEASeverDemoAuthCheck])
-async def download_input_database(config: CEAConfig, project_root: CEAProjectRoot,
-                                  scenario: Annotated[ScenarioQuery, Query()]):
-    effective_scenario = scenario.resolve(config, project_root)
-    locator = cea.inputlocator.InputLocator(effective_scenario)
+async def download_input_database(scenario: CEAScenario):
+    locator = cea.inputlocator.InputLocator(scenario)
     filename = 'database.zip'
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -643,13 +618,10 @@ async def download_input_database(config: CEAConfig, project_root: CEAProjectRoo
 
 # Move to database route
 @router.get('/databases/check')
-async def check_input_database(config: CEAConfig, project_root: CEAProjectRoot,
-                               scenario: Annotated[ScenarioQuery, Query()]):
+async def check_input_database(scenario: CEAScenario):
     """Check if the databases are valid"""
-    effective_scenario = scenario.resolve(config, project_root)
-
     try:
-        verify_database(effective_scenario)
+        verify_database(scenario)
         return {'status': 'success', 'message': True}
     except CEADatabaseException as e:
         output = str(e.message).strip()

--- a/cea/interfaces/dashboard/api/inputs.py
+++ b/cea/interfaces/dashboard/api/inputs.py
@@ -26,7 +26,7 @@ from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
 import cea.schemas
 from cea.databases import CEADatabase, CEADatabaseException
 from cea.datamanagement.format_helper.cea4_verify_db import cea4_verify_db
-from cea.interfaces.dashboard.dependencies import CEAConfig, CEAProjectInfo, CEAProjectRoot, CEASeverDemoAuthCheck
+from cea.interfaces.dashboard.dependencies import CEAConfig, CEAProjectRoot, CEASeverDemoAuthCheck
 from cea.interfaces.dashboard.utils import secure_path
 from cea.interfaces.dashboard.api.utils import ScenarioQuery
 from cea.plots.supply_system.a_supply_system_map import get_building_connectivity, newer_network_layout_exists
@@ -98,8 +98,10 @@ async def get_building_props_db(db: str):
 
 
 @router.get('/geojson/{kind}')
-async def get_input_geojson(project_info: CEAProjectInfo, kind: str):
-    locator = cea.inputlocator.InputLocator(project_info.scenario)
+async def get_input_geojson(config: CEAConfig, project_root: CEAProjectRoot,
+                            scenario: Annotated[ScenarioQuery, Query()], kind: str):
+    effective_scenario = scenario.resolve(config, project_root)
+    locator = cea.inputlocator.InputLocator(effective_scenario)
 
     if kind not in GEOJSON_KEYS:
         raise HTTPException(
@@ -109,7 +111,6 @@ async def get_input_geojson(project_info: CEAProjectInfo, kind: str):
     # Building geojsons
     elif kind in INPUT_KEYS and kind in GEOJSON_KEYS:
         db_info = INPUTS[kind]
-        locator = cea.inputlocator.InputLocator(project_info.scenario)
         location = getattr(locator, db_info['location'])()
         if db_info['file_type'] != 'shp':
             raise HTTPException(
@@ -118,14 +119,16 @@ async def get_input_geojson(project_info: CEAProjectInfo, kind: str):
             )
         return df_to_json(location)[0]
     elif kind in NETWORK_KEYS:
-        return get_network(project_info.scenario, kind)[0]
+        return get_network(effective_scenario, kind)[0]
     elif kind == 'streets':
         return df_to_json(locator.get_street_network())[0]
 
 
 @router.get('/building-properties')
-async def get_building_props(project_info: CEAProjectInfo):
-    return get_building_properties(project_info.scenario)
+async def get_building_props(config: CEAConfig, project_root: CEAProjectRoot,
+                             scenario: Annotated[ScenarioQuery, Query()]):
+    effective_scenario = scenario.resolve(config, project_root)
+    return get_building_properties(effective_scenario)
 
 
 @router.get('/all-inputs')
@@ -429,8 +432,10 @@ def df_to_json(file_location):
 
 
 @router.get('/building-schedule/{building}')
-async def get_building_schedule(project_info: CEAProjectInfo, building: str):
-    locator = cea.inputlocator.InputLocator(project_info.scenario)
+async def get_building_schedule(config: CEAConfig, project_root: CEAProjectRoot,
+                                scenario: Annotated[ScenarioQuery, Query()], building: str):
+    effective_scenario = scenario.resolve(config, project_root)
+    locator = cea.inputlocator.InputLocator(effective_scenario)
     try:
         schedule_data, schedule_complementary_data = read_cea_schedule(locator, use_type=None, building=building)
         df = pd.DataFrame(schedule_data).set_index(['hour'])
@@ -448,8 +453,10 @@ async def get_building_schedule(project_info: CEAProjectInfo, building: str):
 
 
 @router.get('/databases')
-async def get_input_database_data(project_info: CEAProjectInfo):
-    locator = cea.inputlocator.InputLocator(project_info.scenario)
+async def get_input_database_data(config: CEAConfig, project_root: CEAProjectRoot,
+                                  scenario: Annotated[ScenarioQuery, Query()]):
+    effective_scenario = scenario.resolve(config, project_root)
+    locator = cea.inputlocator.InputLocator(effective_scenario)
     try:
         cea_db = await run_in_threadpool(lambda: CEADatabase.from_locator(locator))
     except CEADatabaseException as e:
@@ -468,8 +475,10 @@ async def get_input_database_data(project_info: CEAProjectInfo):
 
 
 @router.put('/databases', dependencies=[CEASeverDemoAuthCheck])
-async def put_input_database_data(project_info: CEAProjectInfo, payload: Dict[str, Any]):
-    locator = cea.inputlocator.InputLocator(project_info.scenario)
+async def put_input_database_data(config: CEAConfig, project_root: CEAProjectRoot,
+                                  scenario: Annotated[ScenarioQuery, Query()], payload: Dict[str, Any]):
+    effective_scenario = scenario.resolve(config, project_root)
+    locator = cea.inputlocator.InputLocator(effective_scenario)
     try:
         def fn():
             db = CEADatabase.from_dict(payload)
@@ -485,11 +494,13 @@ async def put_input_database_data(project_info: CEAProjectInfo, payload: Dict[st
 
 
 @router.post('/databases/upload', dependencies=[CEASeverDemoAuthCheck])
-async def upload_input_database(project_info: CEAProjectInfo, file: UploadFile):
-    locator = cea.inputlocator.InputLocator(project_info.scenario)
+async def upload_input_database(config: CEAConfig, project_root: CEAProjectRoot,
+                                scenario: Annotated[ScenarioQuery, Query()], file: UploadFile):
+    effective_scenario = scenario.resolve(config, project_root)
+    locator = cea.inputlocator.InputLocator(effective_scenario)
 
     # Create a lock file path specific to this scenario
-    lock_file_path = os.path.join(tempfile.gettempdir(), f'cea_db_upload_{hash(project_info.scenario)}.lock')
+    lock_file_path = os.path.join(tempfile.gettempdir(), f'cea_db_upload_{hash(effective_scenario)}.lock')
 
     def do_upload():
         """Perform the upload operation with file-based locking"""
@@ -594,8 +605,10 @@ async def upload_input_database(project_info: CEAProjectInfo, file: UploadFile):
     return await run_in_threadpool(do_upload)
 
 @router.get('/databases/download', dependencies=[CEASeverDemoAuthCheck])
-async def download_input_database(project_info: CEAProjectInfo):
-    locator = cea.inputlocator.InputLocator(project_info.scenario)
+async def download_input_database(config: CEAConfig, project_root: CEAProjectRoot,
+                                  scenario: Annotated[ScenarioQuery, Query()]):
+    effective_scenario = scenario.resolve(config, project_root)
+    locator = cea.inputlocator.InputLocator(effective_scenario)
     filename = 'database.zip'
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -630,12 +643,13 @@ async def download_input_database(project_info: CEAProjectInfo):
 
 # Move to database route
 @router.get('/databases/check')
-async def check_input_database(project_info: CEAProjectInfo):
+async def check_input_database(config: CEAConfig, project_root: CEAProjectRoot,
+                               scenario: Annotated[ScenarioQuery, Query()]):
     """Check if the databases are valid"""
-    scenario = project_info.scenario
+    effective_scenario = scenario.resolve(config, project_root)
 
     try:
-        verify_database(scenario)
+        verify_database(effective_scenario)
         return {'status': 'success', 'message': True}
     except CEADatabaseException as e:
         output = str(e.message).strip()

--- a/cea/interfaces/dashboard/api/inputs.py
+++ b/cea/interfaces/dashboard/api/inputs.py
@@ -28,7 +28,11 @@ import cea.schemas
 from cea.databases import CEADatabase, CEADatabaseException
 from cea.datamanagement.format_helper.cea4_verify_db import cea4_verify_db
 from cea.interfaces.dashboard.dependencies import CEASeverDemoAuthCheck
-from cea.interfaces.dashboard.utils import secure_path
+from cea.interfaces.dashboard.utils import (
+    secure_path,
+    secure_join_under_root,
+    OutsideProjectRootError,
+)
 from cea.interfaces.dashboard.api.utils import CEAScenario
 from cea.plots.supply_system.a_supply_system_map import get_building_connectivity, newer_network_layout_exists
 from cea.plots.variable_naming import get_color_array
@@ -478,7 +482,7 @@ async def upload_input_database(scenario: CEAScenario, file: UploadFile):
     locator = cea.inputlocator.InputLocator(scenario)
 
     # Create a lock file path specific to this scenario
-    scenario_id = hashlib.sha256(os.path.realpath(scenario).encode('utf-8')).hexdigest()
+    scenario_id = hashlib.sha256(scenario.encode('utf-8')).hexdigest()
     lock_file_path = os.path.join(tempfile.gettempdir(), f'cea_db_upload_{scenario_id}.lock')
 
     def do_upload():
@@ -513,14 +517,15 @@ async def upload_input_database(scenario: CEAScenario, file: UploadFile):
                         # Normalize and validate the path to prevent directory traversal attacks
                         member_path = os.path.normpath(adjusted_filename)
 
-                        # Construct the full target path
-                        target_path = os.path.join(temp_db_folder, member_path)
-
-                        # Verify the resolved path is within the target directory
-                        target_path_resolved = os.path.realpath(target_path)
-                        db_folder_resolved = os.path.realpath(temp_db_folder)
-
-                        if os.path.isabs(member_path) or '..' in member_path.split(os.sep) or not target_path_resolved.startswith(db_folder_resolved + os.sep):
+                        # Construct the full target path and enforce root containment
+                        if os.path.isabs(member_path) or '..' in member_path.split(os.sep):
+                            raise HTTPException(
+                                status_code=status.HTTP_400_BAD_REQUEST,
+                                detail=f'Invalid ZIP file: {adjusted_filename}',
+                            )
+                        try:
+                            target_path = secure_join_under_root(temp_db_folder, member_path)
+                        except OutsideProjectRootError:
                             raise HTTPException(
                                 status_code=status.HTTP_400_BAD_REQUEST,
                                 detail=f'Invalid ZIP file: {adjusted_filename}',

--- a/cea/interfaces/dashboard/api/inputs.py
+++ b/cea/interfaces/dashboard/api/inputs.py
@@ -1,3 +1,4 @@
+import hashlib
 import io
 import json
 import os
@@ -477,7 +478,8 @@ async def upload_input_database(scenario: CEAScenario, file: UploadFile):
     locator = cea.inputlocator.InputLocator(scenario)
 
     # Create a lock file path specific to this scenario
-    lock_file_path = os.path.join(tempfile.gettempdir(), f'cea_db_upload_{hash(scenario)}.lock')
+    scenario_id = hashlib.sha256(os.path.realpath(scenario).encode('utf-8')).hexdigest()
+    lock_file_path = os.path.join(tempfile.gettempdir(), f'cea_db_upload_{scenario_id}.lock')
 
     def do_upload():
         """Perform the upload operation with file-based locking"""

--- a/cea/interfaces/dashboard/api/map_layers.py
+++ b/cea/interfaces/dashboard/api/map_layers.py
@@ -1,62 +1,22 @@
 import os
-from typing import List, Optional
+from typing import List
 
 from fastapi import APIRouter, HTTPException, status
-from pydantic import BaseModel, field_validator
 
 from cea import MissingInputDataException
-from cea.interfaces.dashboard.api.utils import (
-    split_scenario_subpath,
-    validate_scenario_name_or_subpath,
-)
-from cea.interfaces.dashboard.dependencies import CEAProjectRoot
+from cea.interfaces.dashboard.api.utils import CEAScenario
 from cea.interfaces.dashboard.map_layers import get_layers_grouped_by_category, load_layer
-from cea.interfaces.dashboard.utils import secure_path
+from pydantic import BaseModel
 
 router = APIRouter()
 
 
-def _resolve_layer_scenario(params_project, params_scenario_name, scenario_path=None):
-    """Return the effective (project, scenario_name) for a map-layer request.
-
-    When the client is viewing a pathway state it sends ``scenario_path``
-    (the full child-state folder).  Derive project / scenario_name from it so
-    the map layer reads state-level results.  Otherwise use the
-    frontend-supplied project / scenario_name directly.
-    """
-    if scenario_path is not None:
-        return os.path.dirname(scenario_path), os.path.basename(scenario_path)
-    return split_scenario_subpath(params_scenario_name, params_project)
-
-
 class LayerParams(BaseModel):
-    project: str
-    scenario_name: str
     parameters: dict
-    scenario_path: Optional[str] = None
-
-    @field_validator('scenario_name')
-    @classmethod
-    def _validate_scenario_name(cls, v):
-        return validate_scenario_name_or_subpath(v)
-
-    @field_validator('scenario_path')
-    @classmethod
-    def _validate_scenario_path(cls, v):
-        if v is not None:
-            return secure_path(v)
-        return v
 
 
 class DeleteChoiceParams(BaseModel):
-    project: str
-    scenario_name: str
     value: str
-
-    @field_validator('scenario_name')
-    @classmethod
-    def _validate_scenario_name(cls, v):
-        return validate_scenario_name_or_subpath(v)
 
 
 class LayerDescription(BaseModel):
@@ -97,16 +57,16 @@ async def get_layers() -> LayersList:
 
 
 @router.post('/{layer_category}/{layer_name}/{parameter}/choices')
-async def get_layer_parameter_choices(project_root: CEAProjectRoot, params: LayerParams, layer_category: str, layer_name: str, parameter: str):
+async def get_layer_parameter_choices(
+    scenario: CEAScenario,
+    params: LayerParams,
+    layer_category: str,
+    layer_name: str,
+    parameter: str,
+):
     layer_class = load_layer(layer_name, layer_category)
-
-    project_path = params.project
-    if project_root is not None and not project_path.startswith(project_root):
-        project_path = os.path.join(project_root, project_path)
-
-    eff_project, eff_scenario = _resolve_layer_scenario(project_path, params.scenario_name, params.scenario_path)
     try:
-        layer = layer_class(project=eff_project, scenario_name=eff_scenario)
+        layer = layer_class(project=os.path.dirname(scenario), scenario_name=os.path.basename(scenario))
         choices = layer.get_parameter_choices(parameter, params.parameters)
     except ValueError as e:
         print(e)
@@ -117,21 +77,15 @@ async def get_layer_parameter_choices(project_root: CEAProjectRoot, params: Laye
 
 @router.post('/{layer_category}/{layer_name}/{parameter}/choice/delete')
 async def delete_layer_parameter_choice(
-    project_root: CEAProjectRoot,
+    scenario: CEAScenario,
     params: DeleteChoiceParams,
     layer_category: str,
     layer_name: str,
     parameter: str,
 ):
     layer_class = load_layer(layer_name, layer_category)
-
-    project_path = params.project
-    if project_root is not None and not project_path.startswith(project_root):
-        project_path = os.path.join(project_root, project_path)
-
-    eff_project, eff_scenario = _resolve_layer_scenario(project_path, params.scenario_name)
     try:
-        layer = layer_class(project=eff_project, scenario_name=eff_scenario)
+        layer = layer_class(project=os.path.dirname(scenario), scenario_name=os.path.basename(scenario))
         layer.delete_parameter_choice(parameter, params.value)
     except NotImplementedError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
@@ -144,16 +98,16 @@ async def delete_layer_parameter_choice(
 
 
 @router.post('/{layer_category}/{layer_name}/{parameter}/range')
-async def get_layer_parameter_range(project_root: CEAProjectRoot, params: LayerParams, layer_category: str, layer_name: str, parameter: str):
+async def get_layer_parameter_range(
+    scenario: CEAScenario,
+    params: LayerParams,
+    layer_category: str,
+    layer_name: str,
+    parameter: str,
+):
     layer_class = load_layer(layer_name, layer_category)
-
-    project_path = params.project
-    if project_root is not None and not project_path.startswith(project_root):
-        project_path = os.path.join(project_root, project_path)
-
-    eff_project, eff_scenario = _resolve_layer_scenario(project_path, params.scenario_name, params.scenario_path)
     try:
-        layer = layer_class(project=eff_project, scenario_name=eff_scenario)
+        layer = layer_class(project=os.path.dirname(scenario), scenario_name=os.path.basename(scenario))
         range_values = layer.get_parameter_range(parameter, params.parameters)
     except ValueError as e:
         print(e)
@@ -163,16 +117,15 @@ async def get_layer_parameter_range(project_root: CEAProjectRoot, params: LayerP
 
 
 @router.post('/{layer_category}/{layer_name}/generate')
-async def generate_map_layer(project_root: CEAProjectRoot, params: LayerParams, layer_category: str, layer_name: str):
+async def generate_map_layer(
+    scenario: CEAScenario,
+    params: LayerParams,
+    layer_category: str,
+    layer_name: str,
+):
     layer_class = load_layer(layer_name, layer_category)
-
-    project_path = params.project
-    if project_root is not None and not project_path.startswith(project_root):
-        project_path = os.path.join(project_root, project_path)
-
-    eff_project, eff_scenario = _resolve_layer_scenario(project_path, params.scenario_name, params.scenario_path)
     try:
-        layer = layer_class(project=eff_project, scenario_name=eff_scenario)
+        layer = layer_class(project=os.path.dirname(scenario), scenario_name=os.path.basename(scenario))
         output = layer.generate_output(params.parameters)
     except MissingInputDataException as e:
         print(e)
@@ -185,16 +138,15 @@ async def generate_map_layer(project_root: CEAProjectRoot, params: LayerParams, 
 
 
 @router.post('/{layer_category}/{layer_name}/check')
-async def check_map_layer(project_root: CEAProjectRoot, params: LayerParams, layer_category: str, layer_name: str):
+async def check_map_layer(
+    scenario: CEAScenario,
+    params: LayerParams,
+    layer_category: str,
+    layer_name: str,
+):
     layer_class = load_layer(layer_name, layer_category)
-
-    project_path = params.project
-    if project_root is not None and not project_path.startswith(project_root):
-        project_path = os.path.join(project_root, project_path)
-
-    eff_project, eff_scenario = _resolve_layer_scenario(project_path, params.scenario_name, params.scenario_path)
     try:
-        layer = layer_class(project=eff_project, scenario_name=eff_scenario)
+        layer = layer_class(project=os.path.dirname(scenario), scenario_name=os.path.basename(scenario))
         layer.check_for_missing_input_files(params.parameters)
     except MissingInputDataException as e:
         print(e)

--- a/cea/interfaces/dashboard/api/map_layers.py
+++ b/cea/interfaces/dashboard/api/map_layers.py
@@ -12,10 +12,14 @@ router = APIRouter()
 
 
 class LayerParams(BaseModel):
+    model_config = {"extra": "forbid"}
+
     parameters: dict
 
 
 class DeleteChoiceParams(BaseModel):
+    model_config = {"extra": "forbid"}
+
     value: str
 
 

--- a/cea/interfaces/dashboard/api/pathways.py
+++ b/cea/interfaces/dashboard/api/pathways.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Optional, Annotated
+from typing import Any
 
 import cea.inputlocator
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel
 
@@ -30,22 +30,17 @@ from cea.datamanagement.district_pathways.pathway_timeline import (
     validate_baked_state,
     validate_pathway_log,
 )
-from cea.interfaces.dashboard.dependencies import CEAConfig, CEASeverDemoAuthCheck, CEAProjectRoot
-from cea.interfaces.dashboard.api.utils import ScenarioQuery
+from cea.interfaces.dashboard.dependencies import CEAConfig, CEASeverDemoAuthCheck
+from cea.interfaces.dashboard.api.utils import CEAScenario
 
 
-async def _apply_parent_scenario(
-    config: CEAConfig,
-    project_root: CEAProjectRoot,
-    project: Annotated[Optional[str], Query()] = None,
-    scenario_name: Annotated[Optional[str], Query(alias='scenario_name')] = None,
-):
+async def _apply_parent_scenario(config: CEAConfig, scenario: CEAScenario):
     """Router-level dependency: apply the per-request parent scenario to config
     in memory for the duration of the request, then restore the original values.
     Never calls save() — this is a stateless, request-scoped override.
     Falls back to config.scenario when no params are provided."""
     original_scenario = str(config.scenario)
-    config.scenario = ScenarioQuery(project=project, scenario_name=scenario_name).resolve(config, project_root)
+    config.scenario = scenario
     try:
         yield
     finally:

--- a/cea/interfaces/dashboard/api/pathways.py
+++ b/cea/interfaces/dashboard/api/pathways.py
@@ -35,16 +35,7 @@ from cea.interfaces.dashboard.api.utils import CEAScenario
 
 
 async def _apply_parent_scenario(config: CEAConfig, scenario: CEAScenario):
-    """Router-level dependency: apply the per-request parent scenario to config
-    in memory for the duration of the request, then restore the original values.
-    Never calls save() — this is a stateless, request-scoped override.
-    Falls back to config.scenario when no params are provided."""
-    original_scenario = str(config.scenario)
     config.scenario = scenario
-    try:
-        yield
-    finally:
-        config.scenario = original_scenario
 
 
 router = APIRouter(dependencies=[Depends(_apply_parent_scenario)])

--- a/cea/interfaces/dashboard/api/project.py
+++ b/cea/interfaces/dashboard/api/project.py
@@ -24,7 +24,7 @@ import cea.inputlocator
 from cea.datamanagement.databases_verification import verify_input_geometry_zone, verify_input_geometry_surroundings, \
     verify_input_typology, COLUMNS_ZONE_TYPOLOGY, COLUMNS_ZONE_GEOMETRY, verify_input_terrain
 from cea.datamanagement.surroundings_helper import generate_empty_surroundings
-from cea.interfaces.dashboard.dependencies import CEAConfig, CEADatabaseConfig, CEAProjectRoot, CEAProjectInfo, \
+from cea.interfaces.dashboard.dependencies import CEAConfig, CEAProjectRoot, CEAProjectInfo, \
     create_project, CEAUserID, \
     CEASeverDemoAuthCheck, CEAServerLimits
 from cea.interfaces.dashboard.lib.database.session import SessionDep
@@ -317,7 +317,10 @@ async def create_new_project(project_root: CEAProjectRoot, new_project: NewProje
 @router.put('/')
 async def update_project(project_root: CEAProjectRoot, config: CEAConfig, scenario_path: ScenarioPath):
     """
-    Update Project info in config
+    Update Project info in config.
+
+    In local mode, persists the selection to ~/cea.config (keeps CLI parity).
+    In non-local (stateless) mode, save() is a no-op so only validation occurs.
     """
     project_path = scenario_path.project
     if project_root is not None and not project_path.startswith(project_root):
@@ -331,10 +334,7 @@ async def update_project(project_root: CEAProjectRoot, config: CEAConfig, scenar
         if os.path.exists(project):
             config.project = project
             config.scenario_name = scenario_name
-            if isinstance(config, CEADatabaseConfig):
-                await config.save()
-            else:
-                config.save()
+            config.save()
 
             return {'message': 'Updated project info in config', 'project': project, 'scenario_name': scenario_name}
         else:
@@ -696,7 +696,7 @@ async def put(config: CEAConfig, scenario: str, payload: Dict[str, Any]):
     """Update scenario"""
     scenario_path = secure_path(os.path.join(config.project, scenario))
     new_scenario_name = payload.get('name')
-    
+
     # Assume no operations done, return None
     if new_scenario_name is None:
         return None
@@ -708,10 +708,7 @@ async def put(config: CEAConfig, scenario: str, payload: Dict[str, Any]):
         os.rename(scenario_path, new_path)
         if config.scenario_name == scenario:
             config.scenario_name = new_scenario_name
-            if isinstance(config, CEADatabaseConfig):
-                await config.save()
-            else:
-                config.save()
+            config.save()
         return {'name': new_scenario_name}
     except OSError:
         raise HTTPException(

--- a/cea/interfaces/dashboard/api/project.py
+++ b/cea/interfaces/dashboard/api/project.py
@@ -31,7 +31,7 @@ from cea.interfaces.dashboard.lib.database.session import SessionDep
 from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
 from cea.interfaces.dashboard.settings import get_settings
 from cea.interfaces.dashboard.utils import secure_path, OutsideProjectRootError
-from cea.interfaces.dashboard.api.utils import ScenarioQuery, validate_scenario_name
+from cea.interfaces.dashboard.api.utils import CEAScenario, validate_scenario_name
 from cea.utilities.dbf import dbf_to_dataframe
 from cea.utilities.standardize_coordinates import get_geographic_coordinate_system, raster_to_WSG_and_UTM
 
@@ -351,27 +351,18 @@ async def update_project(project_root: CEAProjectRoot, config: CEAConfig, scenar
 
 @router.get('/state-folder')
 async def get_state_folder(
-    config: CEAConfig,
-    project_root: CEAProjectRoot,
+    scenario: CEAScenario,
     pathway_name: str = Query(...),
     year: int = Query(...),
-    project: Optional[str] = Query(None),
-    scenario_name: Optional[str] = Query(None),
 ):
-    """Return the path to a pathway state folder without mutating server state.
-
-    Accepts an optional ``project`` + ``scenario_name`` pair to identify the
-    parent scenario; falls back to ``config.scenario`` when omitted.
-    """
+    """Return the path to a pathway state folder without mutating server state."""
     from cea.datamanagement.district_pathways.pathway_state import validate_pathway_name
     try:
         pathway_name = validate_pathway_name(pathway_name)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
-    parent_scenario = ScenarioQuery(project=project, scenario_name=scenario_name).resolve(config, project_root)
-
-    locator = cea.inputlocator.InputLocator(parent_scenario)
+    locator = cea.inputlocator.InputLocator(scenario)
     state_folder = locator.get_state_in_time_scenario_folder(pathway_name, year)
 
     if not os.path.isdir(state_folder):
@@ -382,7 +373,7 @@ async def get_state_folder(
 
     return {
         'scenario_path': state_folder,
-        'parent_scenario': parent_scenario,
+        'parent_scenario': scenario,
         'pathway_name': pathway_name,
         'year': year,
     }

--- a/cea/interfaces/dashboard/api/tools.py
+++ b/cea/interfaces/dashboard/api/tools.py
@@ -4,24 +4,17 @@ from itertools import groupby
 from typing import Dict, Any, List, Optional
 import logging
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel
-from typing import Annotated
 
 import cea.config
 import cea.inputlocator
 import cea.scripts
 from cea.schemas import schemas
-from .utils import (
-    deconstruct_parameters,
-    split_scenario_subpath,
-    validate_scenario_name,
-    validate_scenario_name_or_subpath,
-    ScenarioQuery,
-)
+from .utils import deconstruct_parameters
 from cea.interfaces.dashboard.utils import secure_path, OutsideProjectRootError
-from cea.interfaces.dashboard.dependencies import CEAConfig, CEASeverDemoAuthCheck, CEAProjectRoot
-from cea.datamanagement.district_pathways.pathway_timeline import PathwayChildScenario
+from cea.interfaces.dashboard.dependencies import CEAConfig, CEASeverDemoAuthCheck
+from cea.interfaces.dashboard.api.utils import CEAScenario
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -147,21 +140,11 @@ async def get_tool_list(config: CEAConfig) -> Dict[str, List[ToolDescription]]:
 
 
 @router.get('/{tool_name}')
-async def get_tool_properties(config: CEAConfig, project_root: CEAProjectRoot, tool_name: str,
-                              scenario: Annotated[ScenarioQuery, Query()]) -> ToolProperties:
+async def get_tool_properties(config: CEAConfig, tool_name: str, scenario: CEAScenario) -> ToolProperties:
     # TODO: Add plugin support
     original_scenario = str(config.scenario)
     try:
-        if scenario.scenario_path is not None:
-            config.scenario = secure_path(scenario.scenario_path)
-        else:
-            if scenario.project is not None:
-                project = scenario.project
-                if project_root is not None and not project.startswith(project_root):
-                    project = os.path.join(project_root, project)
-                config.project = secure_path(project)
-            if scenario.scenario_name is not None:
-                config.scenario_name = validate_scenario_name(scenario.scenario_name)
+        config.scenario = scenario
 
         script = cea.scripts.by_name(tool_name, plugins=config.plugins)
 
@@ -358,78 +341,53 @@ async def get_parameter_metadata(config: CEAConfig, tool_name: str, payload: Dic
 
 
 @router.post('/{tool_name}/check')
-async def check_tool_inputs(
-    config: CEAConfig,
-    project_root: CEAProjectRoot,
-    tool_name: str,
-    payload: Dict[str, Any],
-    project: Optional[str] = None,
-    scenario_name: Optional[str] = None,
-):
-    # Optional `project` + `scenario_name` query params let the
-    # caller validate inputs against a *different* scenario than
-    # the project store's active one. Used by the Canvas Builder's
-    # compare-mode per-column edit so the validation runs against
-    # the column's scenario (and pulls *its* choices for things
-    # like `what-if-name`) rather than whichever scenario the
-    # project store happens to be on. Mirrors the same override
-    # pattern in `get_tool_properties` above, including the
-    # pathway-viewer guard.
-    in_child_scenario = PathwayChildScenario.is_valid(config.scenario)
-    if not in_child_scenario:
-        if project is not None:
-            if project_root is not None and not project.startswith(project_root):
-                project = os.path.join(project_root, project)
-            config.project = secure_path(project)
-        if scenario_name is not None:
-            # See `get_tool_properties` for the path-handling rationale.
-            scenario_name = validate_scenario_name_or_subpath(scenario_name)
-            project_dir, scenario_name = split_scenario_subpath(
-                scenario_name, config.project,
-            )
-            config.project = secure_path(project_dir)
-            config.scenario_name = scenario_name
-    candidates = [
-        (parameter, payload[parameter.name])
-        for parameter in parameters_for_script(tool_name, config)
-        if parameter.name in payload and parameter.name != 'scenario'
-    ]
+async def check_tool_inputs(config: CEAConfig, tool_name: str, payload: Dict[str, Any], scenario: CEAScenario):
+    original_scenario = str(config.scenario)
     try:
-        validate_and_apply_parameters(candidates)
-    except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail={'message': 'Validation failed', 'field_errors': e.args[0]})
+        config.scenario = scenario
+        candidates = [
+            (parameter, payload[parameter.name])
+            for parameter in parameters_for_script(tool_name, config)
+            if parameter.name in payload and parameter.name != 'scenario'
+        ]
+        try:
+            validate_and_apply_parameters(candidates)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail={'message': 'Validation failed', 'field_errors': e.args[0]})
 
-    # TODO: Add plugin support
-    script = cea.scripts.by_name(tool_name, plugins=config.plugins)
-    schema_data = schemas(config.plugins)
+        # TODO: Add plugin support
+        script = cea.scripts.by_name(tool_name, plugins=config.plugins)
+        schema_data = schemas(config.plugins)
 
-    script_suggestions = set()
+        script_suggestions = set()
 
-    for method_name, path in script.missing_input_files(config):
-        _script_suggestions = schema_data[method_name]['created_by'] if 'created_by' in schema_data[
-            method_name] else None
+        for method_name, _ in script.missing_input_files(config):
+            _script_suggestions = schema_data[method_name]['created_by'] if 'created_by' in schema_data[
+                method_name] else None
 
-        if _script_suggestions is not None:
-            script_suggestions.update(_script_suggestions)
+            if _script_suggestions is not None:
+                script_suggestions.update(_script_suggestions)
 
-    if script_suggestions:
-        scripts = []
-        for script_suggestion in script_suggestions:
-            _script = cea.scripts.by_name(script_suggestion, plugins=config.plugins)
-            scripts.append({"label": _script.label, "name": _script.name})
+        if script_suggestions:
+            scripts = []
+            for script_suggestion in script_suggestions:
+                _script = cea.scripts.by_name(script_suggestion, plugins=config.plugins)
+                scripts.append({"label": _script.label, "name": _script.name})
 
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
-                            detail={"message": "Missing input files",
-                                    "script_suggestions": list(scripts)})
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                detail={"message": "Missing input files",
+                                        "script_suggestions": list(scripts)})
 
-    # Collision warnings from the check-inputs path (Run button confirmation)
-    warnings = []
-    for field_name in ('network-name', 'what-if-name'):
-        if field_name in payload:
-            warnings.extend(
-                _collect_field_warnings(tool_name, field_name, payload[field_name], config)
-            )
-    return {"warnings": warnings} if warnings else None
+        # Collision warnings from the check-inputs path (Run button confirmation)
+        warnings = []
+        for field_name in ('network-name', 'what-if-name'):
+            if field_name in payload:
+                warnings.extend(
+                    _collect_field_warnings(tool_name, field_name, payload[field_name], config)
+                )
+        return {"warnings": warnings} if warnings else None
+    finally:
+        config.scenario = original_scenario
 
 
 def _collect_field_warnings(tool_name, parameter_name, value, config):

--- a/cea/interfaces/dashboard/api/tools.py
+++ b/cea/interfaces/dashboard/api/tools.py
@@ -1,3 +1,7 @@
+# TODO: Refactor to PUT /projects/{project_id}/scenarios/{scenario_name}/tools/{tool}/config
+# Requires: projects table mapping project_id → project_path (local + non-local compatible).
+# Pathway children use ?child_scenario=subpath. See AGENTS.md.
+
 import os
 from collections import defaultdict
 from itertools import groupby

--- a/cea/interfaces/dashboard/api/tools.py
+++ b/cea/interfaces/dashboard/api/tools.py
@@ -20,7 +20,7 @@ from .utils import (
     ScenarioQuery,
 )
 from cea.interfaces.dashboard.utils import secure_path, OutsideProjectRootError
-from cea.interfaces.dashboard.dependencies import CEAConfig, CEADatabaseConfig, CEASeverDemoAuthCheck, CEAProjectRoot
+from cea.interfaces.dashboard.dependencies import CEAConfig, CEASeverDemoAuthCheck, CEAProjectRoot
 from cea.datamanagement.district_pathways.pathway_timeline import PathwayChildScenario
 
 router = APIRouter()
@@ -214,10 +214,7 @@ async def restore_default_config(config: CEAConfig, tool_name: str):
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail={'message': 'Validation failed', 'field_errors': e.args[0]})
 
-    if isinstance(config, CEADatabaseConfig):
-        await config.save()
-    else:
-        config.save()
+    config.save()
 
     return 'Success'
 
@@ -255,10 +252,7 @@ async def save_tool_config(config: CEAConfig, tool_name: str, payload: Dict[str,
             value = payload[parameter.name]
             parameter.set(value)
 
-    if isinstance(config, CEADatabaseConfig):
-        await config.save()
-    else:
-        config.save()
+    config.save()
     return 'Success'
 
 

--- a/cea/interfaces/dashboard/api/tools.py
+++ b/cea/interfaces/dashboard/api/tools.py
@@ -142,33 +142,28 @@ async def get_tool_list(config: CEAConfig) -> Dict[str, List[ToolDescription]]:
 @router.get('/{tool_name}')
 async def get_tool_properties(config: CEAConfig, tool_name: str, scenario: CEAScenario) -> ToolProperties:
     # TODO: Add plugin support
-    original_scenario = str(config.scenario)
-    try:
-        config.scenario = scenario
+    config.scenario = scenario
+    script = cea.scripts.by_name(tool_name, plugins=config.plugins)
 
-        script = cea.scripts.by_name(tool_name, plugins=config.plugins)
+    parameters = []
+    categories = defaultdict(list)
+    for _, parameter in config.matching_parameters(script.parameters):
+        parameter_dict = deconstruct_parameters(parameter, config)
 
-        parameters = []
-        categories = defaultdict(list)
-        for _, parameter in config.matching_parameters(script.parameters):
-            parameter_dict = deconstruct_parameters(parameter, config)
+        if parameter.category:
+            categories[parameter.category].append(parameter_dict)
+        else:
+            parameters.append(parameter_dict)
 
-            if parameter.category:
-                categories[parameter.category].append(parameter_dict)
-            else:
-                parameters.append(parameter_dict)
-
-        return ToolProperties(
-            name=tool_name,
-            label=script.label,
-            description=script.description,
-            short_description=script.short_description,
-            category=script.category,
-            categorical_parameters=categories,
-            parameters=parameters,
-        )
-    finally:
-        config.scenario = original_scenario
+    return ToolProperties(
+        name=tool_name,
+        label=script.label,
+        description=script.description,
+        short_description=script.short_description,
+        category=script.category,
+        categorical_parameters=categories,
+        parameters=parameters,
+    )
 
 
 @router.post('/{tool_name}/default', dependencies=[CEASeverDemoAuthCheck])
@@ -342,52 +337,48 @@ async def get_parameter_metadata(config: CEAConfig, tool_name: str, payload: Dic
 
 @router.post('/{tool_name}/check')
 async def check_tool_inputs(config: CEAConfig, tool_name: str, payload: Dict[str, Any], scenario: CEAScenario):
-    original_scenario = str(config.scenario)
+    config.scenario = scenario
+    candidates = [
+        (parameter, payload[parameter.name])
+        for parameter in parameters_for_script(tool_name, config)
+        if parameter.name in payload and parameter.name != 'scenario'
+    ]
     try:
-        config.scenario = scenario
-        candidates = [
-            (parameter, payload[parameter.name])
-            for parameter in parameters_for_script(tool_name, config)
-            if parameter.name in payload and parameter.name != 'scenario'
-        ]
-        try:
-            validate_and_apply_parameters(candidates)
-        except ValueError as e:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail={'message': 'Validation failed', 'field_errors': e.args[0]})
+        validate_and_apply_parameters(candidates)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail={'message': 'Validation failed', 'field_errors': e.args[0]})
 
-        # TODO: Add plugin support
-        script = cea.scripts.by_name(tool_name, plugins=config.plugins)
-        schema_data = schemas(config.plugins)
+    # TODO: Add plugin support
+    script = cea.scripts.by_name(tool_name, plugins=config.plugins)
+    schema_data = schemas(config.plugins)
 
-        script_suggestions = set()
+    script_suggestions = set()
 
-        for method_name, _ in script.missing_input_files(config):
-            _script_suggestions = schema_data[method_name]['created_by'] if 'created_by' in schema_data[
-                method_name] else None
+    for method_name, _ in script.missing_input_files(config):
+        _script_suggestions = schema_data[method_name]['created_by'] if 'created_by' in schema_data[
+            method_name] else None
 
-            if _script_suggestions is not None:
-                script_suggestions.update(_script_suggestions)
+        if _script_suggestions is not None:
+            script_suggestions.update(_script_suggestions)
 
-        if script_suggestions:
-            scripts = []
-            for script_suggestion in script_suggestions:
-                _script = cea.scripts.by_name(script_suggestion, plugins=config.plugins)
-                scripts.append({"label": _script.label, "name": _script.name})
+    if script_suggestions:
+        scripts = []
+        for script_suggestion in script_suggestions:
+            _script = cea.scripts.by_name(script_suggestion, plugins=config.plugins)
+            scripts.append({"label": _script.label, "name": _script.name})
 
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
-                                detail={"message": "Missing input files",
-                                        "script_suggestions": list(scripts)})
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail={"message": "Missing input files",
+                                    "script_suggestions": list(scripts)})
 
-        # Collision warnings from the check-inputs path (Run button confirmation)
-        warnings = []
-        for field_name in ('network-name', 'what-if-name'):
-            if field_name in payload:
-                warnings.extend(
-                    _collect_field_warnings(tool_name, field_name, payload[field_name], config)
-                )
-        return {"warnings": warnings} if warnings else None
-    finally:
-        config.scenario = original_scenario
+    # Collision warnings from the check-inputs path (Run button confirmation)
+    warnings = []
+    for field_name in ('network-name', 'what-if-name'):
+        if field_name in payload:
+            warnings.extend(
+                _collect_field_warnings(tool_name, field_name, payload[field_name], config)
+            )
+    return {"warnings": warnings} if warnings else None
 
 
 def _collect_field_warnings(tool_name, parameter_name, value, config):

--- a/cea/interfaces/dashboard/api/tools.py
+++ b/cea/interfaces/dashboard/api/tools.py
@@ -14,7 +14,7 @@ import cea.inputlocator
 import cea.scripts
 from cea.schemas import schemas
 from .utils import deconstruct_parameters
-from cea.interfaces.dashboard.utils import secure_path, OutsideProjectRootError
+from cea.interfaces.dashboard.utils import secure_path, OutsideProjectRootError, secure_join_under_root
 from cea.interfaces.dashboard.dependencies import CEAConfig, CEASeverDemoAuthCheck
 from cea.interfaces.dashboard.api.utils import CEAScenario, CEAScenarioLenient
 from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
@@ -395,12 +395,16 @@ def _collect_field_warnings(tool_name, parameter_name, value, config):
     v = (value or '').strip()
     if not v:
         return []
-    locator = cea.inputlocator.InputLocator(config.scenario)
+    try:
+        scenario_root = config.scenario
+        locator = cea.inputlocator.InputLocator(scenario_root)
+    except OutsideProjectRootError:
+        return []
 
     if tool_name == 'network-layout' and parameter_name == 'network-name':
         folder = locator.get_thermal_network_folder_network_name_folder(v)
         try:
-            folder = secure_path(folder, root=config.scenario)
+            folder = secure_path(folder, root=scenario_root)
         except OutsideProjectRootError:
             return []
         if os.path.isdir(folder):
@@ -413,10 +417,10 @@ def _collect_field_warnings(tool_name, parameter_name, value, config):
             }]
 
     if tool_name == 'final-energy' and parameter_name == 'what-if-name':
-        folder = locator.get_analysis_folder(v)
         try:
-            folder = secure_path(folder, root=config.scenario)
-        except OutsideProjectRootError:
+            analysis_parent = secure_path(locator.get_analysis_parent_folder(), root=scenario_root)
+            folder = secure_join_under_root(analysis_parent, v)
+        except (OutsideProjectRootError, ValueError):
             return []
         if os.path.isdir(folder):
             return [{

--- a/cea/interfaces/dashboard/api/tools.py
+++ b/cea/interfaces/dashboard/api/tools.py
@@ -6,8 +6,6 @@ import os
 from collections import defaultdict
 from itertools import groupby
 from typing import Dict, Any, List, Optional
-import logging
-
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel
 
@@ -19,9 +17,10 @@ from .utils import deconstruct_parameters
 from cea.interfaces.dashboard.utils import secure_path, OutsideProjectRootError
 from cea.interfaces.dashboard.dependencies import CEAConfig, CEASeverDemoAuthCheck
 from cea.interfaces.dashboard.api.utils import CEAScenario, CEAScenarioLenient
+from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
 
 router = APIRouter()
-logger = logging.getLogger(__name__)
+logger = getCEAServerLogger("cea-server-tools")
 
 
 

--- a/cea/interfaces/dashboard/api/tools.py
+++ b/cea/interfaces/dashboard/api/tools.py
@@ -14,7 +14,7 @@ from cea.schemas import schemas
 from .utils import deconstruct_parameters
 from cea.interfaces.dashboard.utils import secure_path, OutsideProjectRootError
 from cea.interfaces.dashboard.dependencies import CEAConfig, CEASeverDemoAuthCheck
-from cea.interfaces.dashboard.api.utils import CEAScenario
+from cea.interfaces.dashboard.api.utils import CEAScenario, CEAScenarioLenient
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -140,7 +140,7 @@ async def get_tool_list(config: CEAConfig) -> Dict[str, List[ToolDescription]]:
 
 
 @router.get('/{tool_name}')
-async def get_tool_properties(config: CEAConfig, tool_name: str, scenario: CEAScenario) -> ToolProperties:
+async def get_tool_properties(config: CEAConfig, tool_name: str, scenario: CEAScenarioLenient) -> ToolProperties:
     # TODO: Add plugin support
     config.scenario = scenario
     script = cea.scripts.by_name(tool_name, plugins=config.plugins)

--- a/cea/interfaces/dashboard/api/utils.py
+++ b/cea/interfaces/dashboard/api/utils.py
@@ -42,13 +42,20 @@ class ScenarioQuery(BaseModel):
         Never mutates config.
         """
         if self.scenario_path is not None:
-            return secure_path(self.scenario_path)
+            return secure_path(self.scenario_path, root=project_root)
         if self.project is not None and self.scenario_name is not None:
             p = self.project
-            if project_root is not None and not p.startswith(project_root):
+            if project_root is not None:
+                if os.path.isabs(p):
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="project must be a relative path when project_root is enforced.",
+                    )
                 p = os.path.join(project_root, p)
-            return os.path.join(secure_path(p), validate_scenario_name(self.scenario_name))
-        return str(config.scenario)
+            project_path = secure_path(p, root=project_root)
+            scenario_path = os.path.join(project_path, validate_scenario_name(self.scenario_name))
+            return secure_path(scenario_path, root=project_root)
+        return secure_path(str(config.scenario), root=project_root)
 
 
 def validate_scenario_name(scenario_name: str) -> str:
@@ -158,20 +165,38 @@ def _should_validate(p: cea.config.Parameter) -> bool:
     return False
 
 
-def get_effective_scenario(
+def _get_effective_scenario(
     config: CEAConfig,
     project_root: CEAProjectRoot,
     scenario: Annotated[ScenarioQuery, Query()],
+    require_exists: bool,
 ) -> str:
     logger.debug("Resolving scenario: %s", scenario.model_dump(exclude_none=True))
     path = scenario.resolve(config, project_root)
-    if not os.path.isdir(path):
+    if require_exists and not os.path.isdir(path):
         logger.error("Scenario directory not found: %s", path)
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_404_NOT_FOUND,
             detail="Scenario not found.",
         )
     return path
 
 
+def get_effective_scenario(
+    config: CEAConfig,
+    project_root: CEAProjectRoot,
+    scenario: Annotated[ScenarioQuery, Query()],
+) -> str:
+    return _get_effective_scenario(config, project_root, scenario, require_exists=True)
+
+
+def get_effective_scenario_lenient(
+    config: CEAConfig,
+    project_root: CEAProjectRoot,
+    scenario: Annotated[ScenarioQuery, Query()],
+) -> str:
+    return _get_effective_scenario(config, project_root, scenario, require_exists=False)
+
+
 CEAScenario = Annotated[str, Depends(get_effective_scenario)]
+CEAScenarioLenient = Annotated[str, Depends(get_effective_scenario_lenient)]

--- a/cea/interfaces/dashboard/api/utils.py
+++ b/cea/interfaces/dashboard/api/utils.py
@@ -1,15 +1,17 @@
-# TODO: Refactor to PUT /projects/{project_id}/scenarios/{scenario_name}/tools/{tool}/config
-# Requires: projects table mapping project_id → project_path (works in local + non-local modes).
-# Pathway children use ?child_scenario=subpath (e.g., pathway_output/year_2050/scenario).
-# See AGENTS.md for refactor details.
+# Scenario context is passed via X-CEA-* request headers (preferred) or query params (deprecated
+# compat, accepted during frontend migration). Header names: X-CEA-Project, X-CEA-Scenario-Name,
+# X-CEA-Child-Scenario (logical token "<pathway_name>/<year>"). If no header or query param is
+# supplied the endpoint falls back to config.scenario.
+# Future phase (separate plan): PUT /projects/{id}/scenarios/{name}/... — requires a projects
+# table mapping project_id → path for both local and non-local modes. See AGENTS.md for details.
 
 import os
 from typing import Optional
 
 import cea.config
 import cea.inputlocator
-from fastapi import Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field, model_validator
+from fastapi import Depends, Header, HTTPException, Query, status
+from pydantic import BaseModel, Field, ValidationError, model_validator
 from typing_extensions import Annotated
 
 from cea.interfaces.dashboard.dependencies import CEAConfig, CEAProjectRoot
@@ -18,36 +20,89 @@ from cea.interfaces.dashboard.utils import secure_path
 
 logger = getCEAServerLogger("cea-server-utils")
 
+_CHILD_SCENARIO_SEP = "/"
+
+
+def _parse_child_scenario_token(token: str) -> tuple:
+    """Parse a logical child-scenario token ``<pathway_name>/<year>`` into its components.
+
+    Returns ``(pathway_name, year_int)``. Raises ``ValueError`` on malformed input.
+    """
+    parts = token.split(_CHILD_SCENARIO_SEP, 1)
+    if len(parts) != 2:
+        raise ValueError(
+            f"Invalid child_scenario '{token}': expected '<pathway_name>/<year>'."
+        )
+    pathway_name, year_str = parts
+    if not pathway_name:
+        raise ValueError(
+            f"Invalid child_scenario '{token}': pathway_name must not be empty."
+        )
+    try:
+        year = int(year_str)
+    except ValueError:
+        raise ValueError(
+            f"Invalid child_scenario '{token}': year must be an integer, got '{year_str}'."
+        )
+    return pathway_name, year
+
 
 class ScenarioQuery(BaseModel):
     """
-    Two mutually exclusive ways to identify a scenario for per-request override:
-    - scenario_path: full absolute path (used for pathway child states)
-    - project + scenario_name: normal scenario (must be provided together)
-    If neither is provided the endpoint falls back to config.scenario.
+    Ways to identify a scenario for a request.
+
+    Normal scenario:
+        project + scenario_name (must be provided together)
+
+    Pathway child scenario (layers on top of normal):
+        project + scenario_name + child_scenario (logical token: ``<pathway_name>/<year>``)
+        The backend resolves the child path via InputLocator — no filesystem path in the request.
+
+    If no params are provided the endpoint falls back to config.scenario.
     """
     model_config = {"extra": "forbid"}
 
-    scenario_path: Optional[str] = Field(None, description="Full path to scenario (pathway mode)")
     project: Optional[str] = Field(None, description="Project directory; must be paired with scenario_name")
     scenario_name: Optional[str] = Field(None, description="Scenario name; must be paired with project")
+    child_scenario: Optional[str] = Field(
+        None,
+        description="Logical pathway child token '<pathway_name>/<year>'; requires project + scenario_name",
+    )
 
     @model_validator(mode='after')
     def validate_groups(self) -> 'ScenarioQuery':
-        if self.scenario_path is not None and (self.project is not None or self.scenario_name is not None):
-            raise ValueError("scenario_path is mutually exclusive with project and scenario_name")
-        if (self.project is None) != (self.scenario_name is None):
+        has_project_pair = self.project is not None and self.scenario_name is not None
+        has_partial_pair = (self.project is None) != (self.scenario_name is None)
+
+        if has_partial_pair:
             raise ValueError("project and scenario_name must be provided together")
+        if self.child_scenario is not None and not has_project_pair:
+            raise ValueError("child_scenario requires project and scenario_name")
         return self
+
+    @classmethod
+    def from_headers(cls, cea_headers: 'CEAScenarioHeaders') -> Optional['ScenarioQuery']:
+        """Build a ``ScenarioQuery`` from X-CEA-* headers, or ``None`` if all are absent."""
+        if cea_headers.x_cea_project is None and cea_headers.x_cea_scenario_name is None and cea_headers.x_cea_child_scenario is None:
+            return None
+        try:
+            return cls(
+                project=cea_headers.x_cea_project,
+                scenario_name=cea_headers.x_cea_scenario_name,
+                child_scenario=cea_headers.x_cea_child_scenario,
+            )
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=exc.errors(),
+            ) from exc
 
     def resolve(self, config, project_root=None) -> str:
         """Return the effective scenario path for this request.
 
-        Priority: scenario_path > project+scenario_name > config.scenario.
+        Uses project+scenario_name if provided (with optional child_scenario refinement), else config.scenario.
         Never mutates config.
         """
-        if self.scenario_path is not None:
-            return secure_path(self.scenario_path, root=project_root)
         if self.project is not None and self.scenario_name is not None:
             p = self.project
             if project_root is not None:
@@ -58,8 +113,29 @@ class ScenarioQuery(BaseModel):
                     )
                 p = os.path.join(project_root, p)
             project_path = secure_path(p, root=project_root)
-            scenario_path = os.path.join(project_path, validate_scenario_name(self.scenario_name))
-            return secure_path(scenario_path, root=project_root)
+            parent_path = os.path.join(project_path, validate_scenario_name(self.scenario_name))
+            parent_path = secure_path(parent_path, root=project_root)
+
+            if self.child_scenario is not None:
+                try:
+                    pathway_name, year = _parse_child_scenario_token(self.child_scenario)
+                except ValueError as exc:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+                    ) from exc
+                from cea.datamanagement.district_pathways.pathway_state import validate_pathway_name
+                try:
+                    pathway_name = validate_pathway_name(pathway_name)
+                except ValueError as exc:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+                    ) from exc
+                locator = cea.inputlocator.InputLocator(parent_path)
+                child_path = locator.get_state_in_time_scenario_folder(pathway_name, year)
+                return secure_path(child_path, root=project_root)
+
+            return parent_path
+
         return secure_path(str(config.scenario), root=project_root)
 
 
@@ -170,14 +246,23 @@ def _should_validate(p: cea.config.Parameter) -> bool:
     return False
 
 
+class CEAScenarioHeaders(BaseModel):
+    x_cea_project: Optional[str] = None
+    x_cea_scenario_name: Optional[str] = None
+    x_cea_child_scenario: Optional[str] = None
+
+
 def _get_effective_scenario(
     config: CEAConfig,
     project_root: CEAProjectRoot,
     scenario: Annotated[ScenarioQuery, Query()],
     require_exists: bool,
+    cea_headers: CEAScenarioHeaders,
 ) -> str:
-    logger.debug("Resolving scenario: %s", scenario.model_dump(exclude_none=True))
-    path = scenario.resolve(config, project_root)
+    header_query = ScenarioQuery.from_headers(cea_headers)
+    effective = header_query if header_query is not None else scenario
+    logger.debug("Resolving scenario: %s", effective.model_dump(exclude_none=True))
+    path = effective.resolve(config, project_root)
     if require_exists and not os.path.isdir(path):
         logger.error("Scenario directory not found: %s", path)
         raise HTTPException(
@@ -191,16 +276,18 @@ def get_effective_scenario(
     config: CEAConfig,
     project_root: CEAProjectRoot,
     scenario: Annotated[ScenarioQuery, Query()],
+    cea_headers: Annotated[CEAScenarioHeaders, Header()],
 ) -> str:
-    return _get_effective_scenario(config, project_root, scenario, require_exists=True)
+    return _get_effective_scenario(config, project_root, scenario, require_exists=True, cea_headers=cea_headers)
 
 
 def get_effective_scenario_lenient(
     config: CEAConfig,
     project_root: CEAProjectRoot,
     scenario: Annotated[ScenarioQuery, Query()],
+    cea_headers: Annotated[CEAScenarioHeaders, Header()],
 ) -> str:
-    return _get_effective_scenario(config, project_root, scenario, require_exists=False)
+    return _get_effective_scenario(config, project_root, scenario, require_exists=False, cea_headers=cea_headers)
 
 
 CEAScenario = Annotated[str, Depends(get_effective_scenario)]

--- a/cea/interfaces/dashboard/api/utils.py
+++ b/cea/interfaces/dashboard/api/utils.py
@@ -1,3 +1,8 @@
+# TODO: Refactor to PUT /projects/{project_id}/scenarios/{scenario_name}/tools/{tool}/config
+# Requires: projects table mapping project_id → project_path (works in local + non-local modes).
+# Pathway children use ?child_scenario=subpath (e.g., pathway_output/year_2050/scenario).
+# See AGENTS.md for refactor details.
+
 import os
 from typing import Optional
 

--- a/cea/interfaces/dashboard/api/utils.py
+++ b/cea/interfaces/dashboard/api/utils.py
@@ -8,7 +8,10 @@ from pydantic import BaseModel, Field, model_validator
 from typing_extensions import Annotated
 
 from cea.interfaces.dashboard.dependencies import CEAConfig, CEAProjectRoot
+from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
 from cea.interfaces.dashboard.utils import secure_path
+
+logger = getCEAServerLogger("cea-server-utils")
 
 
 class ScenarioQuery(BaseModel):
@@ -160,7 +163,15 @@ def get_effective_scenario(
     project_root: CEAProjectRoot,
     scenario: Annotated[ScenarioQuery, Query()],
 ) -> str:
-    return scenario.resolve(config, project_root)
+    logger.debug("Resolving scenario: %s", scenario.model_dump(exclude_none=True))
+    path = scenario.resolve(config, project_root)
+    if not os.path.isdir(path):
+        logger.error("Scenario directory not found: %s", path)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Scenario not found.",
+        )
+    return path
 
 
 CEAScenario = Annotated[str, Depends(get_effective_scenario)]

--- a/cea/interfaces/dashboard/api/utils.py
+++ b/cea/interfaces/dashboard/api/utils.py
@@ -3,9 +3,11 @@ from typing import Optional
 
 import cea.config
 import cea.inputlocator
-from fastapi import HTTPException, status
+from fastapi import Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Annotated
 
+from cea.interfaces.dashboard.dependencies import CEAConfig, CEAProjectRoot
 from cea.interfaces.dashboard.utils import secure_path
 
 
@@ -151,3 +153,14 @@ def _should_validate(p: cea.config.Parameter) -> bool:
 
     # By default, no explicit validation needed
     return False
+
+
+def get_effective_scenario(
+    config: CEAConfig,
+    project_root: CEAProjectRoot,
+    scenario: Annotated[ScenarioQuery, Query()],
+) -> str:
+    return scenario.resolve(config, project_root)
+
+
+CEAScenario = Annotated[str, Depends(get_effective_scenario)]

--- a/cea/interfaces/dashboard/app.py
+++ b/cea/interfaces/dashboard/app.py
@@ -119,7 +119,8 @@ cors_config = CORSConfig(
     origins=origins,
     allow_credentials=allow_credentials,
     methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
-    headers=["Content-Type", "Authorization", "X-Requested-With", "Accept"]
+    headers=["Content-Type", "Authorization", "X-Requested-With", "Accept",
+             "X-CEA-Project", "X-CEA-Scenario-Name", "X-CEA-Child-Scenario"]
 )
 
 app.add_middleware(

--- a/cea/interfaces/dashboard/app.py
+++ b/cea/interfaces/dashboard/app.py
@@ -12,7 +12,7 @@ import cea.interfaces.dashboard.plots.routes as plots
 import cea.interfaces.dashboard.server as server
 from cea.interfaces.dashboard.lib.database.models import create_db_and_tables
 from cea.interfaces.dashboard.lib.database.session import close_db_connection
-from cea.interfaces.dashboard.lib.cache.provider import cleanup_cache_connections
+from cea.interfaces.dashboard.lib.cache.provider import cleanup_cache_connections, init_cache
 from cea.interfaces.dashboard.lib.cors import CORSConfig
 from cea.interfaces.dashboard.lib.logs import logger, getCEAServerLogger
 from cea.interfaces.dashboard.lib.socketio import socket_app
@@ -65,6 +65,8 @@ def setup_sigchld_handler():
 async def lifespan(_: FastAPI):
     # Setup zombie process reaping
     setup_sigchld_handler()
+
+    await init_cache()
 
     try:
         # FIXME: sqlite not working with async adapter

--- a/cea/interfaces/dashboard/dependencies.py
+++ b/cea/interfaces/dashboard/dependencies.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import asyncio
 import os
-from collections import defaultdict
 from dataclasses import dataclass
-from typing import Optional, Dict, Union
+from typing import Optional, Dict
 
 from fastapi import Depends, Request, HTTPException, status
 from sqlmodel import select
@@ -14,148 +12,56 @@ import cea.config
 from cea.interfaces.dashboard.lib.auth import CEAAuthError
 from cea.interfaces.dashboard.lib.auth.providers import StackAuth, AuthClient
 from cea.interfaces.dashboard.lib.cache.base import AsyncDictCache
-from cea.interfaces.dashboard.lib.cache.provider import get_cache, get_dict_cache
-from cea.interfaces.dashboard.lib.cache.settings import CONFIG_CACHE_TTL
-from cea.interfaces.dashboard.lib.database.models import LOCAL_USER_ID, Project, Config
-from cea.interfaces.dashboard.lib.database.session import SessionDep, get_session_context
-from cea.interfaces.dashboard.lib.database.settings import database_settings
-from cea.interfaces.dashboard.lib.logs import logger, getCEAServerLogger
+from cea.interfaces.dashboard.lib.cache.provider import get_dict_cache
+from cea.interfaces.dashboard.lib.database.models import LOCAL_USER_ID, Project
+from cea.interfaces.dashboard.lib.database.session import SessionDep
+from cea.interfaces.dashboard.lib.logs import logger
 from cea.interfaces.dashboard.settings import Settings, get_settings, LimitSettings
 from cea.plots.cache import PlotCache
 
 IGNORE_CONFIG_SECTIONS = {"server", "development", "schemas"}
 
 settings = get_settings()
-cea_db_config_logger = getCEAServerLogger("cea-db-config")
 
 
 class CEALocalConfig(cea.config.Configuration):
     def __init__(self, config_file: str = settings.config_path):
-        if not settings.local:
-            logger.warning("Using local config in non-local mode")
-
-        if config_file.startswith("~"):
-            config_file = os.path.expanduser(config_file)
-        super().__init__(config_file)
+        super().__init__(os.path.expanduser(config_file))
 
     def save(self, config_file: str = settings.config_path) -> None:
-        if config_file.startswith("~"):
-            config_file = os.path.expanduser(config_file)
         logger.info(f"Saving config to {config_file}")
-        super().save(config_file)
+        super().save(os.path.expanduser(config_file))
 
 
-class CEADatabaseConfig(cea.config.Configuration):
-    def __init__(self, user_id: str):
-        self._user_id = user_id
+class CEAStatelessConfig(cea.config.Configuration):
+    """Per-request config for non-local (cloud) mode.
 
+    Built fresh from DEFAULT_CONFIG on each request. save() is a no-op so
+    nothing is ever persisted server-side, enabling stateless horizontal scaling.
+
+    The no-op save() also neutralises the init-time self.save() in
+    Configuration.__init__ (fired when ~/cea.config is absent, e.g. in containers).
+    """
+
+    def __init__(self):
         super().__init__(cea.config.DEFAULT_CONFIG)
 
-    def __getstate__(self) -> str:
-        # Add user_id to state when pickling
-        string = super().__getstate__()
-        return f"{self._user_id}\n{string}"
+    def save(self, config_file: str = None) -> None:
+        logger.debug("save() is a no-op in non-local (stateless) mode")
 
-    def __setstate__(self, state: str):
-        # Read user_id from state when unpickling
-        user_id, string = state.split("\n", 1)
-        self._user_id = user_id
 
-        super().__setstate__(string)
+def get_cea_config() -> cea.config.Configuration:
+    """Return a config instance for this request.
 
-    def from_dict(self, config_dict: dict):
-        """
-        Create a Configuration object from a dictionary.
-        """
-        for section_name, section_dict in config_dict.items():
-            section = self.sections[section_name]
-            for parameter_name, parameter_value in section_dict.items():
-                parameter = section.parameters[parameter_name]
-                try:
-                    parameter.set(parameter_value)
-                except Exception as e:
-                    cea_db_config_logger.warning(f"Error setting `{section_name}:{parameter_name}`: {e}")
-        return self
-
-    def to_dict(self) -> dict:
-        """
-        Returns the configuration as a dictionary.
-        """
-        out = defaultdict(dict)
-
-        for section in self.sections.values():
-            for parameter in section.parameters.values():
-                try:
-                    out[section.name][parameter.name] = parameter.get()
-                except Exception as e:
-                    cea_db_config_logger.warning(f"Error reading `{section.name}:{parameter.name}`: {e}")
-                    # default_value = self.default_config.get(section.name, parameter.name)
-                    # print(f"Using default value: '{default_value}'")
-                    # out[section.name][parameter.name] = default_value
-
-        return out
-
-    @staticmethod
-    def _cache_key(user_id: str) -> str:
-        return f"cea_config_{user_id}"
-
-    @classmethod
-    async def from_user_id(cls, user_id: str) -> "CEADatabaseConfig":
-        """Return config for user, from cache if available, otherwise load from database."""
-        cached = await get_cache().get(cls._cache_key(user_id))
-        if cached is not None:
-            cea_db_config_logger.debug(f"Using cached config for user: {user_id}")
-            return cached
-
-        config = cls(user_id)
-        cea_db_config_logger.debug(f"Cache miss for user: {user_id}")
-        # Fetch config from database and update cache (if config exists for user)
-        async with get_session_context() as session:
-            try:
-                result = await session.execute(select(Config).where(Config.user_id == user_id))
-                _config = result.scalar()
-                if _config:
-                    cea_db_config_logger.debug(f"Reading config from database for user: {user_id}")
-                    config.from_dict(_config.config)
-            except Exception as e:
-                cea_db_config_logger.warning(f"Error reading config from database: {e}")
-                cea_db_config_logger.warning("Returning default config")
-
-        await get_cache().set(cls._cache_key(user_id), config, ttl=CONFIG_CACHE_TTL)
-        return config
-
-    async def save(self, config_file: str = None) -> None:
-        """Saves config to database in dict format"""
-        cea_db_config_logger.debug(f"Saving config for user: {self._user_id}")
-
-        await get_cache().set(self._cache_key(self._user_id), self, ttl=CONFIG_CACHE_TTL)
-        cea_db_config_logger.debug(f"Updated config cache for user: {self._user_id}")
-
-        # Save new config to database
-        async def _save_to_db():
-            config_dict = self.to_dict()
-            async with get_session_context() as session:
-                result = await session.execute(select(Config).where(Config.user_id == self._user_id))
-                _config = result.scalar()
-                if _config:
-                    _config.config = config_dict
-                else:
-                    session.add(Config(user_id=self._user_id, config=config_dict))
-
-        asyncio.create_task(_save_to_db())
-
-async def get_cea_config(user_id: CEAUserID) -> cea.config.Configuration:
-    """Get configuration remote database or local file"""
-
-    # Don't read config from database if user is local
-    if database_settings.url is not None and user_id != LOCAL_USER_ID:
-        return await CEADatabaseConfig.from_user_id(user_id)
-
-    # Read config from file if config_path is set
-    if settings.config_path is not None:
+    Local mode: disk-backed CEALocalConfig (reads/writes ~/cea.config, keeps
+    CLI parity). Non-local mode: fresh CEAStatelessConfig built from
+    DEFAULT_CONFIG with a no-op save() for stateless horizontal scaling.
+    """
+    if settings.local:
+        if settings.config_path is None:
+            raise ValueError("No config provided")
         return CEALocalConfig()
-
-    raise ValueError("No config provided")
+    return CEAStatelessConfig()
 
 
 @dataclass
@@ -321,7 +227,7 @@ def get_limits(user: CEAUser) -> LimitSettings:
 
 CEAUserID = Annotated[str, Depends(get_user_id)]
 CEAUser = Annotated[dict, Depends(get_user)]
-CEAConfig = Annotated[Union[CEALocalConfig, CEADatabaseConfig], Depends(get_cea_config)]
+CEAConfig = Annotated[cea.config.Configuration, Depends(get_cea_config)]
 CEAProjectInfo = Annotated[ProjectInfo, Depends(get_project_info)]
 CEAProjectID = Annotated[str, Depends(get_project_id)]
 CEAPlotCache = Annotated[dict, Depends(get_plot_cache)]

--- a/cea/interfaces/dashboard/lib/cache/provider.py
+++ b/cea/interfaces/dashboard/lib/cache/provider.py
@@ -6,6 +6,7 @@ from aiocache.serializers import PickleSerializer
 from cea.interfaces.dashboard.lib.cache.base import AsyncDictCache
 from cea.interfaces.dashboard.lib.cache.settings import CACHE_NAME, cache_settings, DEFAULT_CACHE_TTL
 from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
+from cea.interfaces.dashboard.settings import get_settings
 
 logger = getCEAServerLogger("cea-cache")
 
@@ -74,6 +75,11 @@ async def init_cache():
         await asyncio.wait_for(cache.exists("_startup"), timeout=5.0)
         logger.info("Redis cache connected")
     except Exception as e:
+        worker_count = get_settings().workers or 1
+        if worker_count > 1:
+            raise RuntimeError(
+                "Redis cache is required when multiple dashboard workers are configured."
+            ) from e
         logger.warning(f"Redis cache unreachable ({e}), falling back to SimpleMemoryCache")
         if hasattr(cache, 'close'):
             try:

--- a/cea/interfaces/dashboard/lib/cache/provider.py
+++ b/cea/interfaces/dashboard/lib/cache/provider.py
@@ -58,6 +58,31 @@ def get_cache():
     return _cache_instance
 
 
+async def init_cache():
+    """Initialize and probe the cache connection on startup.
+
+    If Redis is configured but unreachable, falls back to SimpleMemoryCache so the
+    server stays healthy instead of spinning in aiocache's retry loop on every request.
+    """
+    global _cache_instance
+    cache = get_cache()
+    if not isinstance(cache, RedisCache):
+        return
+
+    try:
+        import asyncio
+        await asyncio.wait_for(cache.exists("_startup"), timeout=5.0)
+        logger.info("Redis cache connected")
+    except Exception as e:
+        logger.warning(f"Redis cache unreachable ({e}), falling back to SimpleMemoryCache")
+        if hasattr(cache, 'close'):
+            try:
+                await cache.close()
+            except Exception:
+                pass
+        _cache_instance = SimpleMemoryCache(serializer=PickleSerializer(), namespace=CACHE_NAME)
+
+
 async def get_dict_cache(key: str, default_ttl: Optional[int] = DEFAULT_CACHE_TTL) -> AsyncDictCache:
     """
     Get or create a dictionary cache for a specific key.

--- a/cea/interfaces/dashboard/lib/database/models.py
+++ b/cea/interfaces/dashboard/lib/database/models.py
@@ -78,12 +78,6 @@ class User(SQLModel, table=True):
     id: str = Field(default_factory=lambda: uuid.uuid4().hex, primary_key=True)
 
 
-class Config(SQLModel, table=True):
-    id: str = Field(default_factory=lambda: uuid.uuid4().hex, primary_key=True)
-    config: dict = Field(sa_type=JSON, nullable=False)
-    user_id: str = Field(foreign_key=f"{user_table_ref}.id", index=True)
-
-
 class Project(SQLModel, table=True):
     id: str = Field(default_factory=lambda: uuid.uuid4().hex, primary_key=True)
     uri: str = Field(nullable=False, index=True)

--- a/cea/interfaces/dashboard/lib/logs.py
+++ b/cea/interfaces/dashboard/lib/logs.py
@@ -27,7 +27,14 @@ class CustomFormatter(logging.Formatter):
     def format(self, record):
         log_fmt = self.FORMATS.get(record.levelno)
         formatter = logging.Formatter(log_fmt)
-        return formatter.format(record)
+        formatted = formatter.format(record)
+
+        # Check for extra fields added via logger.error(..., extra={...})
+        redis_exception = record.__dict__.get('redis_exception')
+        if redis_exception:
+            return f"{formatted} | redis_exception={redis_exception}"
+
+        return formatted
 
 
 def getCEAServerLogger(name="cea-server"):

--- a/cea/interfaces/dashboard/lib/logs.py
+++ b/cea/interfaces/dashboard/lib/logs.py
@@ -1,5 +1,7 @@
 import logging
 
+from cea.interfaces.dashboard.settings import get_settings
+
 FORMAT = "%(levelname)-10s[%(name)s] - %(message)s"
 
 class CustomFormatter(logging.Formatter):
@@ -30,7 +32,7 @@ class CustomFormatter(logging.Formatter):
 
 def getCEAServerLogger(name="cea-server"):
     logger = logging.getLogger(name)
-    logger.setLevel(logging.INFO)
+    logger.setLevel(get_settings().log_level.upper())
 
     stdout_handler = logging.StreamHandler()
     stdout_handler.setFormatter(CustomFormatter(FORMAT))

--- a/cea/interfaces/dashboard/lib/socketio.py
+++ b/cea/interfaces/dashboard/lib/socketio.py
@@ -28,9 +28,22 @@ def _get_cors_origin():
 def _get_client_manager():
     if cache_settings.host and cache_settings.port:
         try:
+            redis_options = {
+                # redis-py 8.0+ defaults socket_timeout to 5s (changed from None in v6).
+                # Pub/sub listen() is a blocking generator that indefinitely waits for messages.
+                # With socket_timeout=5, any idle period >5s raises TimeoutError and triggers reconnect loops.
+                # socket_timeout=None = indefinite wait (correct for blocking pub/sub operations).
+                # socket_connect_timeout=5 = still bounds initial connection (prevents hung connections).
+                # health_check_interval=30 = periodic PING to detect dead connections without timeouts.
+                'socket_timeout': None,
+                'socket_connect_timeout': 5,
+                'health_check_interval': 30,
+            }
             mgr = socketio.AsyncRedisManager(f'redis://{cache_settings.host}:{cache_settings.port}',
                                              write_only=False,  # Ensure reading is enabled
                                              channel='socketio',  # Use a consistent channel name
+                                             logger=logger,
+                                             redis_options=redis_options,
                                              )
             logger.info(f'Using Redis as message broker [{cache_settings.host}:{cache_settings.port}]')
             return mgr

--- a/cea/interfaces/dashboard/settings.py
+++ b/cea/interfaces/dashboard/settings.py
@@ -8,9 +8,6 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from cea.interfaces.dashboard.constants import ENV_VAR_PREFIX
 from cea.interfaces.dashboard.lib.cache.settings import cache_settings
 from cea.interfaces.dashboard.lib.database.settings import database_settings
-from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
-
-logger = getCEAServerLogger("cea-server-settings")
 
 
 class StackAuthSettings(BaseSettings):
@@ -41,12 +38,23 @@ class Settings(BaseSettings):
     project_root: Optional[str] = None
 
     local: bool = Field(default=True, description="Run in local mode. Writes to local file")
+    log_level: str = Field(default="INFO", description="Log level for the server (DEBUG, INFO, WARNING, ERROR).")
     cors_origin: str = Field(default="*", description="CORS origin(s) allowed to access the API. Use '*' for all origins (not recommended for production). For multiple origins, provide a comma-separated list (e.g. 'http://localhost:3000,https://mydomain.com')")
 
     workers: Optional[int] = Field(default=None, description="Number of workers")
 
     # Local only settings
     config_path: Optional[str] = "~/cea.config"
+
+    @field_validator('log_level', mode='before')
+    @classmethod
+    def validate_log_level(cls, v):
+        import logging
+        upper = str(v).upper()
+        if upper not in logging.getLevelNamesMapping():
+            valid = ', '.join(sorted(logging.getLevelNamesMapping()))
+            raise ValueError(f"Invalid log_level '{v}'. Must be one of: {valid}")
+        return upper
 
     @field_validator('cors_origin', mode='before')
     @classmethod
@@ -69,11 +77,6 @@ class Settings(BaseSettings):
                     f"Wildcard CORS origin ('*') is not allowed in non-local mode. "
                     f"Please set {(ENV_VAR_PREFIX + 'cors_origin').upper()} to your frontend URL(s)."
                 )
-            # Wildcard is the expected default for local mode — log at DEBUG only.
-            logger.debug(
-                "Using wildcard CORS origin ('*'). This is only safe for local development. "
-                "For production, set CEA_CORS_ORIGIN to specific domain(s)."
-            )
             return self
 
         # Validate each origin in comma-separated list

--- a/cea/interfaces/dashboard/utils.py
+++ b/cea/interfaces/dashboard/utils.py
@@ -15,6 +15,20 @@ class OutsideProjectRootError(Exception):
         super().__init__(f"Path `{path}` is not a valid path.")
         self.path = path
 
+
+
+def secure_join_under_root(base: Union[str, os.PathLike], *parts: Union[str, os.PathLike]) -> str:
+    """Join path components and enforce containment under ``base``.
+
+    Useful when appending user-provided path segments to a trusted parent.
+    """
+    root = secure_path(base)
+    candidate = os.path.realpath(os.path.join(root, *parts))
+    try:
+        return validate_path_within_root(candidate, root)
+    except ValueError:
+        raise OutsideProjectRootError(os.path.join(str(base), *map(str, parts)))
+
 def secure_path(path: Union[str, os.PathLike], root: Union[str, os.PathLike, None] = None) -> str:
     """
     Validates and sanitizes a file path to prevent directory traversal attacks.
@@ -69,7 +83,7 @@ def resolve_scenario_path(
         project_path = os.path.join(project_root, project_path)
 
     project_path = secure_path(project_path)
-    scenario_path = os.path.join(project_path, scenario)
+    scenario_path = secure_path(os.path.join(project_path, scenario))
 
     if not os.path.isdir(scenario_path):
         raise HTTPException(

--- a/cea/interfaces/dashboard/utils.py
+++ b/cea/interfaces/dashboard/utils.py
@@ -22,7 +22,7 @@ def secure_join_under_root(base: Union[str, os.PathLike], *parts: Union[str, os.
 
     Useful when appending user-provided path segments to a trusted parent.
     """
-    root = secure_path(base)
+    root = os.path.realpath(base)
     candidate = os.path.realpath(os.path.join(root, *parts))
     try:
         return validate_path_within_root(candidate, root)
@@ -83,7 +83,7 @@ def resolve_scenario_path(
         project_path = os.path.join(project_root, project_path)
 
     project_path = secure_path(project_path)
-    scenario_path = secure_path(os.path.join(project_path, scenario))
+    scenario_path = secure_join_under_root(project_path, scenario)
 
     if not os.path.isdir(scenario_path):
         raise HTTPException(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard now supports request-scoped project/scenario selection via `X-CEA-Project`, `X-CEA-Scenario-Name`, and `X-CEA-Child-Scenario` headers for concurrent workflows.
  * Added startup connectivity checks for cache (with automatic in-memory fallback when Redis isn’t reachable).

* **Bug Fixes**
  * Improved filesystem safety for scenario resolution and safer ZIP extraction to prevent unsafe traversal.
  * Standardized scenario handling across dashboards, canvases, inputs, map layers, pathways, and tools.

* **Documentation**
  * Updated dashboard docs with explicit logging guidance and detailed stateless/request-scoped behavior.

* **Refactor**
  * Simplified API contracts to use a single scenario input per endpoint.
  * Switched configuration persistence to local-only (stateless mode no longer persists server-side).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->