### PR TITLE
Consolidate route auth dependencies and create sub-app for demo scenarios

### DIFF
--- a/cea/interfaces/dashboard/AGENTS.md
+++ b/cea/interfaces/dashboard/AGENTS.md
@@ -11,6 +11,31 @@ The dashboard UI (React frontend) is in a **separate repository** — not here.
 
 ---
 
+# API Auth
+
+Route dependencies declare **security intent**; the deployment mode decides how
+it is proven.
+
+**No proxy is assumed.** The server runs locally or online and self-enforces auth
+in both cases. Never rely on a gateway or reverse proxy to pre-filter requests.
+
+**Default auth:** `require_authenticated` runs as an app-level dependency on every
+route. In non-local mode it rejects unauthenticated callers (those that resolve to
+`LOCAL_USER_ID`). No per-route annotation needed — add new routes freely and they
+get auth for free.
+
+**Public exceptions** are listed in `_PUBLIC_ROUTES` in `dependencies.py`:
+session refresh, logout, and health-check endpoints. New public routes must be
+added there explicitly (fail-secure by default).
+
+| Primitive | When to use |
+|---|---|
+| `require_authenticated` | App-level. Do not add to individual routes. |
+| `CEAUser` / `CEAUserID` | Routes that need to know *who* the caller is (ownership, quotas). |
+| `require_public_demo_read(demo_id)` | Path-param dependency for anonymous read of allowlisted demo ids. Used on `/api/demo/*` routes (Phase 2). |
+
+---
+
 # Dashboard Job System
 
 ## Architecture

--- a/cea/interfaces/dashboard/AGENTS.md
+++ b/cea/interfaces/dashboard/AGENTS.md
@@ -32,7 +32,25 @@ added there explicitly (fail-secure by default).
 |---|---|
 | `require_authenticated` | App-level. Do not add to individual routes. |
 | `CEAUser` / `CEAUserID` | Routes that need to know *who* the caller is (ownership, quotas). |
-| `require_public_demo_read(demo_id)` | Path-param dependency for anonymous read of allowlisted demo ids. Used on `/api/demo/*` routes (Phase 2). |
+| `require_public_demo_read(demo_id)` | Path-param dependency for anonymous read of allowlisted demo ids. Used in `api/demo.py`. |
+
+**Public demo sub-app** — `api/demo.py` is a standalone `FastAPI()` instance mounted
+at `/api/demo` by `app.py` when `Settings.public_demo_scenarios` is non-empty. Because
+it is a sub-app (not a router), it does **not** inherit the main app's
+`require_authenticated` dependency — the anonymous boundary is structural, not a code
+branch. No edit to `require_authenticated` or `_PUBLIC_ROUTES` is needed.
+
+`Settings.public_demo_scenarios` (`Dict[str, str]`, default `{}`):
+- Env: `CEA_PUBLIC_DEMO_SCENARIOS="demo1:/abs/path/scenario1,demo2:/abs/path/scenario2"`
+- JSON format also accepted: `'{"demo1": "/abs/path"}'`
+- Empty → sub-app not mounted → zero overhead (local mode never needs this).
+
+The sub-app resolves scenario paths exclusively through `require_public_demo_read`,
+which checks `demo_id` against the allowlist. No arbitrary filesystem paths are
+accepted. No write verbs are defined — the surface is read-only by construction.
+
+**Topology**: built in-process now; can be promoted to a standalone service with no
+code change (deploy `demo_app` alone, gateway `/api/demo/*` to it).
 
 ---
 

--- a/cea/interfaces/dashboard/AGENTS.md
+++ b/cea/interfaces/dashboard/AGENTS.md
@@ -150,8 +150,9 @@ Treat the dashboard server as stateless. Do not persist request-scoped selection
 Both dependencies read scenario context from `X-CEA-*` headers first; if absent they fall back to query params. They enforce `project_root` boundaries in both cases; in non-local mode, absolute `X-CEA-Project` / `project` values are rejected.
 
 **Route path safety helpers** (`utils.py`):
-- Use `InputLocator(scenario)` directly in all route handlers — `CEAScenario` / `CEAScenarioLenient` already sanitise the path, and `resolve_scenario_path` applies `secure_path` to the final joined path for cross-scenario routes.
+- Use `InputLocator(scenario)` directly in route handlers — `CEAScenario` / `CEAScenarioLenient` already sanitise the path.
 - Use `secure_join_under_root(base, user_segment)` when appending user-provided path segments before filesystem checks.
+- See `api/AGENTS.md` for the full DO/DON'T pattern.
 
 **`save()` behaviour**: `CEALocalConfig.save()` writes `~/cea.config`; `CEAStatelessConfig.save()` is a no-op. Call `config.save()` unconditionally where appropriate — it does the right thing in both modes.
 

--- a/cea/interfaces/dashboard/api/AGENTS.md
+++ b/cea/interfaces/dashboard/api/AGENTS.md
@@ -11,6 +11,25 @@
 - `POST /api/pathways/{pathway_name}/years/{year}/validate-state` - Manual baked-state validation.
 
 ## Key Patterns
+### DO: Use CEAScenario / CEAScenarioLenient for any route that reads a scenario
+`CEAScenario` handles header parsing (`X-CEA-Project`, `X-CEA-Scenario-Name`, `X-CEA-Child-Scenario`),
+project-root boundary enforcement, and path sanitisation in one dependency. Never accept raw
+`project: str` + `scenario: str` query params and call `resolve_scenario_path` manually — that
+pattern bypasses the header contract and duplicates security logic.
+
+Use `CEAScenario` when the scenario directory must exist; `CEAScenarioLenient` when it may not
+(e.g. metadata/config endpoints). Both enforce path boundaries.
+
+```python
+# DO
+async def get_data(scenario: CEAScenario):
+    locator = cea.inputlocator.InputLocator(scenario)
+
+# DON'T
+async def get_data(project_root: CEAProjectRoot, project: str, scenario: str):
+    scenario_path = resolve_scenario_path(project_root, project, scenario)
+```
+
 ### DO: Keep routes thin and delegate to pathway domain helpers
 ```python
 return await run_in_threadpool(get_pathway_timeline, config, pathway_name)

--- a/cea/interfaces/dashboard/api/AGENTS.md
+++ b/cea/interfaces/dashboard/api/AGENTS.md
@@ -18,7 +18,9 @@ return await run_in_threadpool(get_pathway_timeline, config, pathway_name)
 
 ### DO: Treat any route that writes logs or status files as a normal authenticated write
 ```python
-@router.post("/{pathway_name}/years/{year}/validate-state", dependencies=[CEASeverDemoAuthCheck])
+@router.post("/{pathway_name}/years/{year}/validate-state")
+# No per-route auth annotation needed — require_authenticated runs app-wide.
+# Add to _PUBLIC_ROUTES in dependencies.py only if the route must be publicly accessible.
 ```
 
 ### DO: Preserve structured 409 payloads for stock-only edit rules

--- a/cea/interfaces/dashboard/api/demo.py
+++ b/cea/interfaces/dashboard/api/demo.py
@@ -1,0 +1,148 @@
+"""
+Public demo sub-app — anonymous, read-only, allowlist-scoped.
+
+Mounted at /api/demo by app.py when public_demo_scenarios is configured.
+This is a standalone FastAPI app and does NOT inherit the main app's
+require_authenticated dependency — the anonymous boundary is structural.
+
+Routes wrap the normal API routers (inputs, map-layers, canvas, reports)
+rather than duplicating their logic. The key mechanism is two
+dependency_overrides that replace get_effective_scenario /
+get_effective_scenario_lenient with require_public_demo_read, which reads
+{demo_id} from the URL path and checks it against the configured allowlist.
+This makes CEAScenario resolve to the allowlisted path instead of the
+user's project root.
+
+URL shape: /api/demo/scenarios/{demo_id}/<domain>/...
+
+Write routes are excluded via _filter_routes. Canvas export is excluded
+because it needs CEAConfig to re-render all plot cards. Reports /scenarios
+is excluded because it uses CEAProjectRoot + project rather than CEAScenario.
+
+To add a new demo resource:
+  1. Add an entry to CEA_PUBLIC_DEMO_SCENARIOS (or Settings.public_demo_scenarios).
+  2. Optionally extend the routes below to expose more data for that scenario.
+
+Topology note: this sub-app can be extracted into a standalone service with
+no code change — deploy it alone and gateway /api/demo/* to it.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, status
+from fastapi.routing import APIRoute
+
+import cea.interfaces.dashboard.api.canvas as canvas_module
+import cea.interfaces.dashboard.api.inputs as inputs_module
+import cea.interfaces.dashboard.api.map_layers as map_layers_module
+import cea.interfaces.dashboard.api.reports as reports_module
+from cea.interfaces.dashboard.api.utils import (
+    get_effective_scenario,
+    get_effective_scenario_lenient,
+)
+from cea.interfaces.dashboard.dependencies import CEAServerSettings
+
+app = FastAPI(title="CEA Demo", description="Public read-only demo scenarios.")
+
+
+def require_public_demo_read(demo_id: str, settings: CEAServerSettings) -> str:
+    """
+    Resolve an allowlisted demo id to its scenario path.
+
+    Used as both the router-level guard (_demo_guard) and the dependency override for
+    get_effective_scenario / get_effective_scenario_lenient. {demo_id} comes from the URL
+    path; normal routes resolve scenario via headers/query params relative to the user's
+    project root (get_effective_scenario → CEAProjectRoot → CEAUserID) — this replaces
+    that chain with a simple allowlist lookup, so no user context is needed.
+
+    Raises 404 for unknown ids — no arbitrary filesystem paths are ever accepted.
+    Never uses CEAScenario, CEAProjectRoot, or CEAUserID; safe for anonymous callers.
+    """
+    path = settings.public_demo_scenarios.get(demo_id)
+    if path is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Demo scenario not found.")
+    return path
+
+
+app.dependency_overrides[get_effective_scenario] = require_public_demo_read
+app.dependency_overrides[get_effective_scenario_lenient] = require_public_demo_read
+
+# Router-level guard for routes that have no CEAScenario dependency (e.g. /features).
+# Routes that do use CEAScenario are already guarded by the dependency_overrides above.
+_demo_guard = [Depends(require_public_demo_read)]
+
+
+def _filter_routes(
+    router,
+    *,
+    allowed_methods: set | None = None,
+    exclude_paths: set | None = None,
+) -> APIRouter:
+    """Return a new APIRouter with only routes whose method set intersects
+    allowed_methods (default GET) and whose path is not in exclude_paths."""
+    allowed_methods = allowed_methods or {"GET"}
+    exclude_paths = exclude_paths or set()
+    filtered = APIRouter()
+    for route in router.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        if route.path in exclude_paths:
+            continue
+        if route.methods & allowed_methods:
+            filtered.routes.append(route)
+    return filtered
+
+
+# ── Inputs ─────────────────────────────────────────────────────────────────
+# All GET routes from inputs.router; PUT / POST (save, upload) excluded.
+
+app.include_router(
+    _filter_routes(inputs_module.router),
+    prefix="/scenarios/{demo_id}/inputs",
+    dependencies=_demo_guard,
+)
+
+
+# ── Map layers ─────────────────────────────────────────────────────────────
+# GET catalog + POST-as-read parameter queries (choices, range, generate,
+# check). choice/delete is a genuine write — excluded.
+
+app.include_router(
+    _filter_routes(
+        map_layers_module.router,
+        allowed_methods={"GET", "POST"},
+        exclude_paths={"/{layer_category}/{layer_name}/{parameter}/choice/delete"},
+    ),
+    prefix="/scenarios/{demo_id}/map-layers",
+    dependencies=_demo_guard,
+)
+
+
+# ── Canvas ─────────────────────────────────────────────────────────────────
+# GET list and read. /{name}/export excluded: it re-renders all plot cards
+# via capture_canvas_data(config, ...) which needs a full CEAConfig object.
+
+app.include_router(
+    _filter_routes(canvas_module.router, exclude_paths={"/{name}/export"}),
+    prefix="/scenarios/{demo_id}/canvas",
+    dependencies=_demo_guard,
+)
+
+
+# ── Reports ────────────────────────────────────────────────────────────────
+# GET routes only. /scenarios excluded — uses CEAProjectRoot + project, not CEAScenario.
+
+app.include_router(
+    _filter_routes(reports_module.router, exclude_paths={"/scenarios"}),
+    prefix="/scenarios/{demo_id}/reports",
+    dependencies=_demo_guard,
+)
+
+
+# ── Scenario list ──────────────────────────────────────────────────────────
+
+@app.get("/scenarios")
+async def list_demo_scenarios(settings: CEAServerSettings):
+    """List all allowlisted demo scenario ids."""
+    return {
+        "scenarios": [{"id": demo_id, "name": demo_id} for demo_id in settings.public_demo_scenarios]
+    }

--- a/cea/interfaces/dashboard/api/demo.py
+++ b/cea/interfaces/dashboard/api/demo.py
@@ -103,7 +103,7 @@ app.include_router(
 
 
 # ── Map layers ─────────────────────────────────────────────────────────────
-# GET catalog + POST-as-read parameter queries (choices, range, generate,
+# GET catalogue + POST-as-read parameter queries (choices, range, generate,
 # check). choice/delete is a genuine write — excluded.
 
 app.include_router(

--- a/cea/interfaces/dashboard/api/downloads.py
+++ b/cea/interfaces/dashboard/api/downloads.py
@@ -370,29 +370,30 @@ async def get_download_url(
 async def download_file(
     download_id: str,
     session: CEASession,
-    user_id: Optional[str] = None,  # From CEAUserID dependency (cookies/session)
+    user_id: CEAUserID,
     token: Optional[str] = None  # From query parameter (pre-signed URL)
 ):
     """
     Download the prepared zip file.
     Supports two authentication methods:
-    1. Session-based (cookies) via user_id dependency
-    2. Token-based (pre-signed URL) via token query parameter
+    1. Session-based (cookies) via the CEAUserID dependency
+    2. Token-based (pre-signed URL) via the token query parameter
 
+    Token takes precedence when both are present.
     File is deleted immediately after download (single-use policy).
 
     Args:
         download_id: Download ID
         session: Database session
-        user_id: Current user ID from session (optional if using token)
-        token: JWT token from pre-signed URL (optional if using session)
+        user_id: Current user ID resolved from session cookies by CEAUserID
+        token: JWT token from pre-signed URL (optional)
 
     Returns:
         File response with zip file
 
     Raises:
         HTTPException 401: If no authentication provided
-        HTTPException 403: If token invalid or user not authorized
+        HTTPException 403: If token invalid or user not authorised
         HTTPException 404: If download not found
         HTTPException 409: If download already in progress
         HTTPException 410: If download already completed

--- a/cea/interfaces/dashboard/api/inputs.py
+++ b/cea/interfaces/dashboard/api/inputs.py
@@ -27,7 +27,7 @@ from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
 import cea.schemas
 from cea.databases import CEADatabase, CEADatabaseException
 from cea.datamanagement.format_helper.cea4_verify_db import cea4_verify_db
-from cea.interfaces.dashboard.dependencies import CEASeverDemoAuthCheck
+
 from cea.interfaces.dashboard.utils import (
     secure_path,
     secure_join_under_root,
@@ -166,7 +166,7 @@ class InputForm(BaseModel):
     schedules: Dict[str, Any] = Field(default_factory=dict)
 
 
-@router.put('/all-inputs', dependencies=[CEASeverDemoAuthCheck])
+@router.put('/all-inputs')
 async def save_all_inputs(scenario: CEAScenario, form: InputForm):
     locator = cea.inputlocator.InputLocator(scenario)
 
@@ -460,7 +460,7 @@ async def get_input_database_data(scenario: CEAScenario):
     return cea_db.to_dict()
 
 
-@router.put('/databases', dependencies=[CEASeverDemoAuthCheck])
+@router.put('/databases')
 async def put_input_database_data(scenario: CEAScenario, payload: Dict[str, Any]):
     locator = cea.inputlocator.InputLocator(scenario)
     try:
@@ -477,7 +477,7 @@ async def put_input_database_data(scenario: CEAScenario, payload: Dict[str, Any]
         )
 
 
-@router.post('/databases/upload', dependencies=[CEASeverDemoAuthCheck])
+@router.post('/databases/upload')
 async def upload_input_database(scenario: CEAScenario, file: UploadFile):
     locator = cea.inputlocator.InputLocator(scenario)
 
@@ -588,7 +588,7 @@ async def upload_input_database(scenario: CEAScenario, file: UploadFile):
 
     return await run_in_threadpool(do_upload)
 
-@router.get('/databases/download', dependencies=[CEASeverDemoAuthCheck])
+@router.get('/databases/download')
 async def download_input_database(scenario: CEAScenario):
     locator = cea.inputlocator.InputLocator(scenario)
     filename = 'database.zip'

--- a/cea/interfaces/dashboard/api/inputs.py
+++ b/cea/interfaces/dashboard/api/inputs.py
@@ -85,7 +85,7 @@ NETWORK_KEYS = ['dc', 'dh']
 
 @router.get("/")
 async def get_keys():
-    return {'buildingProperties': INPUT_KEYS, 'geoJSONs': GEOJSON_KEYS}
+    return {'buildingProperties': list(INPUT_KEYS), 'geoJSONs': GEOJSON_KEYS}
 
 
 @router.get('/building-properties/{db}')

--- a/cea/interfaces/dashboard/api/pathways.py
+++ b/cea/interfaces/dashboard/api/pathways.py
@@ -30,7 +30,7 @@ from cea.datamanagement.district_pathways.pathway_timeline import (
     validate_baked_state,
     validate_pathway_log,
 )
-from cea.interfaces.dashboard.dependencies import CEAConfig, CEASeverDemoAuthCheck
+from cea.interfaces.dashboard.dependencies import CEAConfig
 from cea.interfaces.dashboard.api.utils import CEAScenario
 
 
@@ -73,7 +73,7 @@ async def get_overview(config: CEAConfig) -> dict[str, Any]:
     return await run_in_threadpool(get_pathway_overview, config)
 
 
-@router.post("/", dependencies=[CEASeverDemoAuthCheck])
+@router.post("/")
 async def post_pathway(config: CEAConfig, payload: CreatePathwayPayload) -> dict[str, Any]:
     try:
         return await run_in_threadpool(create_pathway, config, payload.pathway_name)
@@ -89,7 +89,7 @@ async def post_pathway(config: CEAConfig, payload: CreatePathwayPayload) -> dict
         ) from exc
 
 
-@router.post("/{pathway_name}/duplicate", dependencies=[CEASeverDemoAuthCheck])
+@router.post("/{pathway_name}/duplicate")
 async def duplicate_pathway(
     config: CEAConfig, pathway_name: str, payload: DuplicatePathwayPayload
 ) -> dict[str, Any]:
@@ -186,7 +186,7 @@ async def get_template_usage(config: CEAConfig, template_name: str) -> dict[str,
     return {"usage": usage}
 
 
-@router.delete("/templates/{template_name}", dependencies=[CEASeverDemoAuthCheck])
+@router.delete("/templates/{template_name}")
 async def delete_template(
     config: CEAConfig,
     template_name: str,
@@ -319,7 +319,7 @@ async def get_timeline(config: CEAConfig, pathway_name: str) -> dict[str, Any]:
         ) from exc
 
 
-@router.post("/{pathway_name}/years/{year}", dependencies=[CEASeverDemoAuthCheck])
+@router.post("/{pathway_name}/years/{year}")
 async def post_year(config: CEAConfig, pathway_name: str, year: int) -> dict[str, Any]:
     try:
         return await run_in_threadpool(create_pathway_year, config, pathway_name, year)
@@ -377,7 +377,7 @@ async def get_editor_options(
         ) from exc
 
 
-@router.post("/{pathway_name}/years/{year}/building-events", dependencies=[CEASeverDemoAuthCheck])
+@router.post("/{pathway_name}/years/{year}/building-events")
 async def post_building_events(
     config: CEAConfig,
     pathway_name: str,
@@ -405,7 +405,7 @@ async def post_building_events(
         ) from exc
 
 
-@router.post("/{pathway_name}/years/{year}/apply-templates", dependencies=[CEASeverDemoAuthCheck])
+@router.post("/{pathway_name}/years/{year}/apply-templates")
 async def post_apply_templates(
     config: CEAConfig,
     pathway_name: str,
@@ -432,7 +432,7 @@ async def post_apply_templates(
         ) from exc
 
 
-@router.put("/{pathway_name}/years/{year}/yaml", dependencies=[CEASeverDemoAuthCheck])
+@router.put("/{pathway_name}/years/{year}/yaml")
 async def put_year_yaml(
     config: CEAConfig,
     pathway_name: str,
@@ -459,7 +459,7 @@ async def put_year_yaml(
         ) from exc
 
 
-@router.delete("/{pathway_name}/years/{year}", dependencies=[CEASeverDemoAuthCheck])
+@router.delete("/{pathway_name}/years/{year}")
 async def delete_year(config: CEAConfig, pathway_name: str, year: int) -> dict[str, Any]:
     try:
         return await run_in_threadpool(delete_or_clear_state, config, pathway_name, year)
@@ -490,7 +490,7 @@ async def delete_year(config: CEAConfig, pathway_name: str, year: int) -> dict[s
         ) from exc
 
 
-@router.post("/{pathway_name}/years/{year}/validate-state", dependencies=[CEASeverDemoAuthCheck])
+@router.post("/{pathway_name}/years/{year}/validate-state")
 async def post_validate_state(
     config: CEAConfig,
     pathway_name: str,

--- a/cea/interfaces/dashboard/api/project.py
+++ b/cea/interfaces/dashboard/api/project.py
@@ -26,7 +26,7 @@ from cea.datamanagement.databases_verification import verify_input_geometry_zone
 from cea.datamanagement.surroundings_helper import generate_empty_surroundings
 from cea.interfaces.dashboard.dependencies import CEAConfig, CEAProjectRoot, CEAProjectInfo, \
     create_project, CEAUserID, \
-    CEASeverDemoAuthCheck, CEAServerLimits
+    CEAServerLimits
 from cea.interfaces.dashboard.lib.database.session import SessionDep
 from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
 from cea.interfaces.dashboard.settings import get_settings
@@ -258,7 +258,7 @@ async def get_project_info(project_root: CEAProjectRoot, project: str) -> Projec
     return ProjectInfo(**project_info)
 
 
-@router.post('/', dependencies=[CEASeverDemoAuthCheck])
+@router.post('/')
 async def create_new_project(project_root: CEAProjectRoot, new_project: NewProject,
                              user_id: CEAUserID, session: SessionDep, limit_settings: CEAServerLimits):
     """
@@ -381,7 +381,7 @@ async def get_state_folder(
 
 # TODO: Rename this endpoint once the old one is removed
 # Temporary endpoint to prevent breaking existing frontend
-@router.post('/scenario/v2', dependencies=[CEASeverDemoAuthCheck])
+@router.post('/scenario/v2')
 async def create_new_scenario_v2(project_root: CEAProjectRoot, scenario_form: Annotated[CreateScenario, Form()],
                                  limit_settings: CEAServerLimits):
     project_path = scenario_form.project
@@ -709,7 +709,7 @@ async def put(config: CEAConfig, scenario: str, payload: Dict[str, Any]):
         )
 
 
-@router.delete('/', dependencies=[CEASeverDemoAuthCheck])
+@router.delete('/')
 async def delete_project(project_root: CEAProjectRoot, project_info: ProjectPath):
     """Delete project"""
     project_path = project_info.project
@@ -736,7 +736,7 @@ async def delete_project(project_root: CEAProjectRoot, project_info: ProjectPath
                    'Try and refresh the page again.',
         )
 
-@router.delete('/scenario', dependencies=[CEASeverDemoAuthCheck])
+@router.delete('/scenario')
 async def delete_scenario(project_root: CEAProjectRoot, scenario_info: ScenarioPath):
     """Delete scenario from project"""
     project_path = scenario_info.project
@@ -769,7 +769,7 @@ async def delete_scenario(project_root: CEAProjectRoot, scenario_info: ScenarioP
 
 
 
-@router.post('/scenario/{scenario}/duplicate', dependencies=[CEASeverDemoAuthCheck])
+@router.post('/scenario/{scenario}/duplicate')
 async def duplicate_scenario(project_info: CEAProjectInfo, scenario: str, new_scenario_info: NewScenarioInfo):
     """Duplicate Scenario"""
     scenario_path = secure_path(os.path.join(project_info.project, scenario))

--- a/cea/interfaces/dashboard/api/reports.py
+++ b/cea/interfaces/dashboard/api/reports.py
@@ -19,7 +19,7 @@ from fastapi.responses import HTMLResponse, JSONResponse
 import cea.config
 import cea.inputlocator
 import cea.scripts
-from cea.interfaces.dashboard.api.utils import CEAScenario, CEAScenarioLenient, validate_scenario_name_or_subpath
+from cea.interfaces.dashboard.api.utils import CEAScenario, validate_scenario_name_or_subpath
 from cea.interfaces.dashboard.dependencies import CEAConfig, CEAProjectRoot
 from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
 from cea.interfaces.dashboard.lib.plot_dispatch import render_plot_html
@@ -338,7 +338,7 @@ async def get_report_plot(
 @router.post("/plot-custom", response_class=HTMLResponse)
 async def get_custom_plot(
     config: CEAConfig,
-    effective_scenario: CEAScenarioLenient,
+    effective_scenario: CEAScenario,
     payload: dict,
 ):
     """Render a plot using the visualisation system with custom parameters.
@@ -374,6 +374,11 @@ async def get_custom_plot(
         )
 
     if scenario:
+        if not isinstance(scenario, str):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="scenario must be a string",
+            )
         # Resolve the payload scenario against the project directory of the
         # effective scenario (from headers or config). Supports bare names and
         # relative sub-paths (e.g. canvas pathway-single child states).

--- a/cea/interfaces/dashboard/api/reports.py
+++ b/cea/interfaces/dashboard/api/reports.py
@@ -19,10 +19,11 @@ from fastapi.responses import HTMLResponse, JSONResponse
 import cea.config
 import cea.inputlocator
 import cea.scripts
+from cea.interfaces.dashboard.api.utils import CEAScenario, CEAScenarioLenient, validate_scenario_name_or_subpath
 from cea.interfaces.dashboard.dependencies import CEAConfig, CEAProjectRoot
 from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
 from cea.interfaces.dashboard.lib.plot_dispatch import render_plot_html
-from cea.interfaces.dashboard.utils import resolve_scenario_path, secure_path
+from cea.interfaces.dashboard.utils import secure_join_under_root, secure_path
 from cea.utilities.standardize_coordinates import get_geographic_coordinate_system
 
 logger = getCEAServerLogger("cea-server-reports")
@@ -30,18 +31,11 @@ logger = getCEAServerLogger("cea-server-reports")
 router = APIRouter()
 
 
-_resolve_scenario_path = resolve_scenario_path
-
-
-
-
-
 
 @router.get("/whatifs")
-async def get_whatifs(project_root: CEAProjectRoot, project: str, scenario: str):
+async def get_whatifs(scenario: CEAScenario):
     """List what-if names that have final-energy results in the given scenario."""
-    scenario_path = _resolve_scenario_path(project_root, project, scenario)
-    locator = cea.inputlocator.InputLocator(scenario_path)
+    locator = cea.inputlocator.InputLocator(scenario)
 
     analysis_parent = locator.get_analysis_parent_folder()
     if not os.path.isdir(analysis_parent):
@@ -266,9 +260,7 @@ SUPPORTED_FEATURES = list(FEATURE_SUMMARY_MAP.keys())
 
 @router.get("/summary")
 async def get_summary(
-    project_root: CEAProjectRoot,
-    project: str,
-    scenario: str,
+    scenario: CEAScenario,
     feature: str,
     whatif: Optional[str] = None,
 ):
@@ -279,8 +271,7 @@ async def get_summary(
             detail=f"Unsupported feature: {feature}. Supported: {SUPPORTED_FEATURES}",
         )
 
-    scenario_path = _resolve_scenario_path(project_root, project, scenario)
-    locator = cea.inputlocator.InputLocator(scenario_path)
+    locator = cea.inputlocator.InputLocator(scenario)
 
     summary_fn = FEATURE_SUMMARY_MAP[feature]
     return summary_fn(locator, whatif)
@@ -289,9 +280,7 @@ async def get_summary(
 @router.get("/plot", response_class=HTMLResponse)
 async def get_report_plot(
     config: CEAConfig,
-    project_root: CEAProjectRoot,
-    project: str,
-    scenario: str,
+    scenario: CEAScenario,
     feature: str,
     whatif: Optional[str] = None,
 ):
@@ -301,7 +290,7 @@ async def get_report_plot(
     """
     from cea.visualisation.plot_main import plot_all
 
-    scenario_path = _resolve_scenario_path(project_root, project, scenario)
+    scenario_path = scenario
 
     # Feature-to-plot-section mapping
     feature_map = {
@@ -322,12 +311,10 @@ async def get_report_plot(
     # Build context dict for plot_all
     context = {"feature": plot_feature}
 
-    # Override scenario in config temporarily
-    original_scenario = config.scenario
-    try:
-        config.project = os.path.dirname(scenario_path)
-        config.scenario_name = os.path.basename(scenario_path)
+    config.project = os.path.dirname(scenario_path)
+    config.scenario_name = os.path.basename(scenario_path)
 
+    try:
         whatif_override = [whatif] if whatif else None
         fig = plot_all(config, scenario_path, context, hide_title=False,
                        whatif_names_override=whatif_override)
@@ -346,16 +333,12 @@ async def get_report_plot(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error generating plot: {e}",
         )
-    finally:
-        # Restore original scenario
-        config.project = os.path.dirname(original_scenario)
-        config.scenario_name = os.path.basename(original_scenario)
 
 
 @router.post("/plot-custom", response_class=HTMLResponse)
 async def get_custom_plot(
     config: CEAConfig,
-    project_root: CEAProjectRoot,
+    effective_scenario: CEAScenarioLenient,
     payload: dict,
 ):
     """Render a plot using the visualisation system with custom parameters.
@@ -391,21 +374,21 @@ async def get_custom_plot(
         )
 
     if scenario:
-        # Pass the scenario string through verbatim so deep child
-        # paths (canvas pathway-single columns target child states by
-        # their relative path under the parent scenario, e.g.
-        # `<scenario>/outputs/pathways/<name>/state_<year>`) resolve
-        # against the active project. Mirrors how `/api/inputs/all-
-        # inputs` handles the same input.
-        scenario_path = _resolve_scenario_path(
-            project_root,
-            config.project,
-            scenario,
+        # Resolve the payload scenario against the project directory of the
+        # effective scenario (from headers or config). Supports bare names and
+        # relative sub-paths (e.g. canvas pathway-single child states).
+        project_path = os.path.dirname(effective_scenario)
+        scenario_path = secure_join_under_root(
+            project_path, validate_scenario_name_or_subpath(scenario)
         )
+        if not os.path.isdir(scenario_path):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Scenario not found: {scenario}",
+            )
     else:
-        scenario_path = config.scenario
+        scenario_path = effective_scenario
 
-    original_scenario = config.scenario
     try:
         html = render_plot_html(
             config,
@@ -469,11 +452,10 @@ async def get_custom_plot(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error generating plot: {e}",
         )
-    finally:
-        config.project = os.path.dirname(original_scenario)
-        config.scenario_name = os.path.basename(original_scenario)
 
 
+# TODO: Remove get_scenarios — duplicates GET /api/project/?project=... which already returns
+#       scenarios_list. Frontend should call that endpoint instead.
 @router.get("/scenarios")
 async def get_scenarios(project_root: CEAProjectRoot, project: str):
     """List scenarios for a project (for inter-mode comparison)."""
@@ -493,11 +475,12 @@ async def get_scenarios(project_root: CEAProjectRoot, project: str):
     return {"scenarios": scenarios}
 
 
+# TODO: Remove get_zone_geojson — duplicates GET /api/inputs/geojson/zone which already serves
+#       zone geometry via CEAScenario. Frontend should call that endpoint instead.
 @router.get("/zone-geojson")
-async def get_zone_geojson(project_root: CEAProjectRoot, project: str, scenario: str):
+async def get_zone_geojson(scenario: CEAScenario):
     """Return zone geometry as GeoJSON for map thumbnail rendering."""
-    scenario_path = _resolve_scenario_path(project_root, project, scenario)
-    locator = cea.inputlocator.InputLocator(scenario_path)
+    locator = cea.inputlocator.InputLocator(scenario)
     zone_path = locator.get_zone_geometry()
 
     if not os.path.isfile(zone_path):

--- a/cea/interfaces/dashboard/api/tools.py
+++ b/cea/interfaces/dashboard/api/tools.py
@@ -15,7 +15,7 @@ import cea.scripts
 from cea.schemas import schemas
 from .utils import deconstruct_parameters
 from cea.interfaces.dashboard.utils import secure_path, OutsideProjectRootError, secure_join_under_root
-from cea.interfaces.dashboard.dependencies import CEAConfig, CEASeverDemoAuthCheck
+from cea.interfaces.dashboard.dependencies import CEAConfig
 from cea.interfaces.dashboard.api.utils import CEAScenario, CEAScenarioLenient
 from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
 
@@ -169,7 +169,7 @@ async def get_tool_properties(config: CEAConfig, tool_name: str, scenario: CEASc
     )
 
 
-@router.post('/{tool_name}/default', dependencies=[CEASeverDemoAuthCheck])
+@router.post('/{tool_name}/default')
 async def restore_default_config(config: CEAConfig, tool_name: str):
     """Restore the default configuration values for the CEA"""
     default_config = cea.config.Configuration(config_file=cea.config.DEFAULT_CONFIG)
@@ -200,7 +200,7 @@ async def restore_default_config(config: CEAConfig, tool_name: str):
     return 'Success'
 
 
-@router.post('/{tool_name}/save-config', dependencies=[CEASeverDemoAuthCheck])
+@router.post('/{tool_name}/save-config')
 async def save_tool_config(config: CEAConfig, tool_name: str, payload: Dict[str, Any]):
     """
     Save the configuration for this tool to the configuration file.

--- a/cea/interfaces/dashboard/api/tools.py
+++ b/cea/interfaces/dashboard/api/tools.py
@@ -142,22 +142,17 @@ async def get_tool_list(config: CEAConfig) -> Dict[str, List[ToolDescription]]:
     return result
 
 
-@router.get('/{tool_name}')
-async def get_tool_properties(config: CEAConfig, tool_name: str, scenario: CEAScenarioLenient) -> ToolProperties:
+def _build_tool_properties(tool_name: str, config) -> ToolProperties:
     # TODO: Add plugin support
-    config.scenario = scenario
     script = cea.scripts.by_name(tool_name, plugins=config.plugins)
-
     parameters = []
     categories = defaultdict(list)
     for _, parameter in config.matching_parameters(script.parameters):
         parameter_dict = deconstruct_parameters(parameter, config)
-
         if parameter.category:
             categories[parameter.category].append(parameter_dict)
         else:
             parameters.append(parameter_dict)
-
     return ToolProperties(
         name=tool_name,
         label=script.label,
@@ -169,11 +164,18 @@ async def get_tool_properties(config: CEAConfig, tool_name: str, scenario: CEASc
     )
 
 
-@router.post('/{tool_name}/default')
-async def restore_default_config(config: CEAConfig, tool_name: str, scenario: CEAScenarioLenient):
-    """Restore the default configuration values for the CEA"""
-    # Bind the request scenario so scenario-dependent parameters parse correctly
+@router.get('/{tool_name}')
+async def get_tool_properties(config: CEAConfig, tool_name: str, scenario: CEAScenarioLenient) -> ToolProperties:
     config.scenario = scenario
+    return _build_tool_properties(tool_name, config)
+
+
+@router.post('/{tool_name}/default')
+async def restore_default_config(config: CEAConfig, tool_name: str, scenario: CEAScenarioLenient) -> ToolProperties:
+    """Restore the default configuration values for the CEA"""
+    config.scenario = scenario
+    default_config = cea.config.Configuration(config_file=cea.config.DEFAULT_CONFIG)
+    default_config.scenario = scenario
 
     candidates = []
     set_empty = []
@@ -182,7 +184,7 @@ async def restore_default_config(config: CEAConfig, tool_name: str, scenario: CE
         if parameter.name == 'scenario':
             continue
 
-        default_value = config.sections[parameter.section.name].parameters[parameter.name].get()
+        default_value = default_config.sections[parameter.section.name].parameters[parameter.name].get()
         # Set empty string for non-nullable parameters with empty default values, bypassing validation
         if not default_value and default_value is not False and default_value != 0 and not parameter.nullable:
             set_empty.append(parameter)
@@ -195,8 +197,7 @@ async def restore_default_config(config: CEAConfig, tool_name: str, scenario: CE
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail={'message': 'Validation failed', 'field_errors': e.args[0]})
 
     config.save()
-
-    return 'Success'
+    return _build_tool_properties(tool_name, config)
 
 
 @router.post('/{tool_name}/save-config')

--- a/cea/interfaces/dashboard/api/tools.py
+++ b/cea/interfaces/dashboard/api/tools.py
@@ -170,11 +170,10 @@ async def get_tool_properties(config: CEAConfig, tool_name: str, scenario: CEASc
 
 
 @router.post('/{tool_name}/default')
-async def restore_default_config(config: CEAConfig, tool_name: str):
+async def restore_default_config(config: CEAConfig, tool_name: str, scenario: CEAScenarioLenient):
     """Restore the default configuration values for the CEA"""
-    default_config = cea.config.Configuration(config_file=cea.config.DEFAULT_CONFIG)
-    # Ensure that parameters that depend on scenario files will be parsed correctly
-    default_config.scenario = config.scenario
+    # Bind the request scenario so scenario-dependent parameters parse correctly
+    config.scenario = scenario
 
     candidates = []
     set_empty = []
@@ -183,7 +182,7 @@ async def restore_default_config(config: CEAConfig, tool_name: str):
         if parameter.name == 'scenario':
             continue
 
-        default_value = default_config.sections[parameter.section.name].parameters[parameter.name].get()
+        default_value = config.sections[parameter.section.name].parameters[parameter.name].get()
         # Set empty string for non-nullable parameters with empty default values, bypassing validation
         if not default_value and default_value is not False and default_value != 0 and not parameter.nullable:
             set_empty.append(parameter)
@@ -201,11 +200,12 @@ async def restore_default_config(config: CEAConfig, tool_name: str):
 
 
 @router.post('/{tool_name}/save-config')
-async def save_tool_config(config: CEAConfig, tool_name: str, payload: Dict[str, Any]):
+async def save_tool_config(config: CEAConfig, tool_name: str, payload: Dict[str, Any], scenario: CEAScenarioLenient):
     """
     Save the configuration for this tool to the configuration file.
     Validates all parameters before saving and returns field-level errors if validation fails.
     """
+    config.scenario = scenario
     field_errors = {}
 
     # Validate all parameters first
@@ -238,7 +238,7 @@ async def save_tool_config(config: CEAConfig, tool_name: str, payload: Dict[str,
 
 
 @router.post('/{tool_name}/validate-field')
-async def validate_field(config: CEAConfig, tool_name: str, payload: Dict[str, Any]):
+async def validate_field(config: CEAConfig, tool_name: str, payload: Dict[str, Any], scenario: CEAScenarioLenient):
     """
     Validate a single field value using the parameter's encode() method.
 
@@ -247,6 +247,7 @@ async def validate_field(config: CEAConfig, tool_name: str, payload: Dict[str, A
     - value: the value to validate
     - form_values: dict of current form values to set on config before validation
     """
+    config.scenario = scenario
     parameter_name = payload.get('parameter_name')
     value = payload.get('value')
     form_values = payload.get('form_values', {})
@@ -286,7 +287,7 @@ async def validate_field(config: CEAConfig, tool_name: str, payload: Dict[str, A
 
 
 @router.post('/{tool_name}/parameter-metadata')
-async def get_parameter_metadata(config: CEAConfig, tool_name: str, payload: Dict[str, Any]):
+async def get_parameter_metadata(config: CEAConfig, tool_name: str, payload: Dict[str, Any], scenario: CEAScenarioLenient):
     """
     Get updated parameter metadata based on current form values.
     Does NOT save to config - uses temporary in-memory config state.
@@ -298,6 +299,7 @@ async def get_parameter_metadata(config: CEAConfig, tool_name: str, payload: Dic
     - form_values: dict of current form values
     - affected_parameters: optional list of parameter names to get metadata for
     """
+    config.scenario = scenario
     form_values = payload.get('form_values', {})
     affected_parameters = payload.get('affected_parameters', None)
 

--- a/cea/interfaces/dashboard/api/utils.py
+++ b/cea/interfaces/dashboard/api/utils.py
@@ -94,7 +94,7 @@ class ScenarioQuery(BaseModel):
         except ValidationError as exc:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=exc.errors(),
+                detail="; ".join(e["msg"] for e in exc.errors()),
             ) from exc
 
     def resolve(self, config, project_root=None) -> str:

--- a/cea/interfaces/dashboard/app.py
+++ b/cea/interfaces/dashboard/app.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 import os
 import signal
 
-from fastapi import FastAPI, status, Request
+from fastapi import FastAPI, Depends, status, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -16,6 +16,7 @@ from cea.interfaces.dashboard.lib.cache.provider import cleanup_cache_connection
 from cea.interfaces.dashboard.lib.cors import CORSConfig
 from cea.interfaces.dashboard.lib.logs import logger, getCEAServerLogger
 from cea.interfaces.dashboard.lib.socketio import socket_app
+from cea.interfaces.dashboard.dependencies import require_authenticated
 from cea.interfaces.dashboard.settings import get_settings
 
 zombie_logger = getCEAServerLogger("cea-server-zombie")
@@ -95,7 +96,7 @@ async def lifespan(_: FastAPI):
     await cleanup_cache_connections()
 
 
-app = FastAPI(lifespan=lifespan)
+app = FastAPI(lifespan=lifespan, dependencies=[Depends(require_authenticated)])
 socket_app.other_asgi_app = app
 
 # Setup CORS

--- a/cea/interfaces/dashboard/app.py
+++ b/cea/interfaces/dashboard/app.py
@@ -140,6 +140,17 @@ app.include_router(api.router, prefix='/api')
 app.include_router(plots.router, prefix='/plots')
 app.include_router(server.router, prefix='/server')
 
+# Mount the public demo sub-app when demo scenarios are configured.
+# The sub-app is a standalone FastAPI instance and does NOT inherit the
+# require_authenticated dependency above — the anonymous boundary is structural.
+if get_settings().public_demo_scenarios:
+    from cea.interfaces.dashboard.api.demo import app as demo_app
+    app.mount("/api/demo", demo_app)
+    logger.info(
+        "Public demo sub-app mounted at /api/demo (%d scenario(s))",
+        len(get_settings().public_demo_scenarios),
+    )
+
 
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):

--- a/cea/interfaces/dashboard/dependencies.py
+++ b/cea/interfaces/dashboard/dependencies.py
@@ -269,4 +269,3 @@ CEAServerSettings = Annotated[Settings, Depends(get_settings)]
 CEAAuthClient = Annotated[AuthClient, Depends(get_auth_client)]
 CEAServerLimits = Annotated[LimitSettings, Depends(get_limits)]
 
-RequireAuthenticated = Depends(require_authenticated)

--- a/cea/interfaces/dashboard/dependencies.py
+++ b/cea/interfaces/dashboard/dependencies.py
@@ -198,18 +198,35 @@ def get_auth_client(request: Request) -> Optional[AuthClient]:
     return None
 
 
-def check_auth_for_demo(request: Request, user_id: CEAUserID):
-    """Check if user is authorized when not in local mode"""
-    # Pass if local mode
+# Routes publicly accessible without authentication in non-local mode.
+# Every other route is gated by require_authenticated (applied at app level).
+_PUBLIC_ROUTES: frozenset = frozenset({
+    "/api/user/session/refresh",  # token refresh — must work with an expired access token
+    "/api/user/logout",           # session teardown — should work even if token is stale
+    "/server/alive",              # health check — monitoring must not need a session
+    "/server/version",            # version info — safe to expose publicly
+})
+
+
+def require_authenticated(request: Request, user_id: CEAUserID):
+    """App-level auth guard: every route requires an authenticated user in non-local mode.
+
+    In local (single-user desktop) mode this is a no-op — all routes are open.
+    In non-local mode any caller that resolves to LOCAL_USER_ID (the anonymous
+    sentinel returned when no valid session token is present) receives 401.
+
+    Routes in _PUBLIC_ROUTES are explicitly excluded (session and health-check
+    endpoints).  No proxy is assumed — the server self-enforces auth.
+    """
     if settings.local:
         return
-
-    # Check if user is authorized
+    if request.url.path in _PUBLIC_ROUTES:
+        return
     if user_id == LOCAL_USER_ID:
-        logger.info(f"Unauthorized access \"{request.method} {request.url.path}\": `{user_id}`")
+        logger.info(f"Unauthenticated access \"{request.method} {request.url.path}\"")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Unauthorized",
+            detail="Authentication required.",
         )
 
 def get_limits(user: CEAUser) -> LimitSettings:
@@ -239,4 +256,4 @@ CEAServerSettings = Annotated[Settings, Depends(get_settings)]
 CEAAuthClient = Annotated[AuthClient, Depends(get_auth_client)]
 CEAServerLimits = Annotated[LimitSettings, Depends(get_limits)]
 
-CEASeverDemoAuthCheck = Depends(check_auth_for_demo)
+RequireAuthenticated = Depends(require_authenticated)

--- a/cea/interfaces/dashboard/dependencies.py
+++ b/cea/interfaces/dashboard/dependencies.py
@@ -207,6 +207,12 @@ _PUBLIC_ROUTES: frozenset = frozenset({
     "/server/version",            # version info — safe to expose publicly
 })
 
+# Path prefixes exempt from session auth. The route handler is responsible for
+# its own auth when its path matches one of these prefixes.
+_PUBLIC_ROUTE_PREFIXES: tuple = (
+    "/api/downloads/",  # pre-signed token downloads — anchor tags don't send cookies
+)
+
 
 def require_authenticated(request: Request, user_id: CEAUserID, settings: CEAServerSettings):
     """App-level auth guard: every route requires an authenticated user in non-local mode.
@@ -215,15 +221,22 @@ def require_authenticated(request: Request, user_id: CEAUserID, settings: CEASer
     In non-local mode any caller that resolves to LOCAL_USER_ID (the anonymous
     sentinel returned when no valid session token is present) receives 401.
 
-    Routes in _PUBLIC_ROUTES are explicitly excluded (session and health-check
-    endpoints).  No proxy is assumed — the server self-enforces auth.
+    Routes in _PUBLIC_ROUTES / _PUBLIC_ROUTE_PREFIXES are explicitly excluded.
+    No proxy is assumed — the server self-enforces auth.
     """
     if settings.local:
         return
     if request.url.path in _PUBLIC_ROUTES:
         return
+    if request.url.path.startswith(_PUBLIC_ROUTE_PREFIXES):
+        return
     if user_id == LOCAL_USER_ID:
-        logger.info(f"Unauthenticated access \"{request.method} {request.url.path}\"")
+        # FIXME: LOCAL_USER_ID is overloaded — it is the sentinel for both the
+        # local-desktop user (harmless; local mode exits above) and anonymous
+        # callers in non-local mode. Rename / split these two concepts so the
+        # guard here is unambiguous.
+        safe_path = request.url.path.replace("\r", "\\r").replace("\n", "\\n")
+        logger.info('Unauthenticated access "%s %s"', request.method, safe_path)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Authentication required.",

--- a/cea/interfaces/dashboard/dependencies.py
+++ b/cea/interfaces/dashboard/dependencies.py
@@ -21,16 +21,16 @@ from cea.plots.cache import PlotCache
 
 IGNORE_CONFIG_SECTIONS = {"server", "development", "schemas"}
 
-settings = get_settings()
-
 
 class CEALocalConfig(cea.config.Configuration):
-    def __init__(self, config_file: str = settings.config_path):
+    def __init__(self, config_file: str):
+        self._config_path = config_file
         super().__init__(os.path.expanduser(config_file))
 
-    def save(self, config_file: str = settings.config_path) -> None:
-        logger.info(f"Saving config to {config_file}")
-        super().save(os.path.expanduser(config_file))
+    def save(self, config_file: str = None) -> None:
+        path = config_file if config_file is not None else self._config_path
+        logger.info(f"Saving config to {path}")
+        super().save(os.path.expanduser(path))
 
 
 class CEAStatelessConfig(cea.config.Configuration):
@@ -50,7 +50,7 @@ class CEAStatelessConfig(cea.config.Configuration):
         logger.debug("save() is a no-op in non-local (stateless) mode")
 
 
-def get_cea_config() -> cea.config.Configuration:
+def get_cea_config(settings: CEAServerSettings) -> cea.config.Configuration:
     """Return a config instance for this request.
 
     Local mode: disk-backed CEALocalConfig (reads/writes ~/cea.config, keeps
@@ -60,7 +60,7 @@ def get_cea_config() -> cea.config.Configuration:
     if settings.local:
         if settings.config_path is None:
             raise ValueError("No config provided")
-        return CEALocalConfig()
+        return CEALocalConfig(settings.config_path)
     return CEAStatelessConfig()
 
 
@@ -121,14 +121,14 @@ async def get_streams() -> AsyncDictCache:
     return await get_dict_cache("streams", default_ttl=STREAM_CACHE_TTL)
 
 
-def get_server_url():
+def get_server_url(settings: CEAServerSettings) -> str:
     host = settings.host
     port = settings.port
     worker_url = f"http://{host}:{port}/server"
     return worker_url
 
 
-def get_project_root(user_id: CEAUserID) -> Optional[str]:
+def get_project_root(user_id: CEAUserID, settings: CEAServerSettings) -> Optional[str]:
     """Get the project root for the current user"""
     project_root = settings.project_root
 
@@ -142,7 +142,7 @@ def get_project_root(user_id: CEAUserID) -> Optional[str]:
     return project_root
 
 
-def get_user_id(auth_client: CEAAuthClient) -> str:
+def get_user_id(auth_client: CEAAuthClient, settings: CEAServerSettings) -> str:
     # Return local user if local mode
     if settings.local:
         logger.info(f"Using `{LOCAL_USER_ID}`")
@@ -160,7 +160,7 @@ def get_user_id(auth_client: CEAAuthClient) -> str:
     return LOCAL_USER_ID
 
 
-def get_user(auth_client: CEAAuthClient) -> Dict[str, str]:
+def get_user(auth_client: CEAAuthClient, settings: CEAServerSettings) -> Dict[str, str]:
     if settings.local:
         return {'id': LOCAL_USER_ID}
 
@@ -186,7 +186,7 @@ def get_user(auth_client: CEAAuthClient) -> Dict[str, str]:
     return {'id': LOCAL_USER_ID}
 
 
-def get_auth_client(request: Request) -> Optional[AuthClient]:
+def get_auth_client(request: Request, settings: CEAServerSettings) -> Optional[AuthClient]:
     if settings.local:
         return None
 
@@ -208,7 +208,7 @@ _PUBLIC_ROUTES: frozenset = frozenset({
 })
 
 
-def require_authenticated(request: Request, user_id: CEAUserID):
+def require_authenticated(request: Request, user_id: CEAUserID, settings: CEAServerSettings):
     """App-level auth guard: every route requires an authenticated user in non-local mode.
 
     In local (single-user desktop) mode this is a no-op — all routes are open.

--- a/cea/interfaces/dashboard/lib/socketio.py
+++ b/cea/interfaces/dashboard/lib/socketio.py
@@ -5,7 +5,6 @@ import socketio
 
 from socketio.exceptions import ConnectionRefusedError
 
-from cea.interfaces.dashboard.dependencies import settings
 from cea.interfaces.dashboard.lib.auth import CEAAuthError
 from cea.interfaces.dashboard.lib.auth.providers import StackAuth
 from cea.interfaces.dashboard.lib.cache.settings import cache_settings
@@ -115,7 +114,7 @@ def cookie_string_to_dict(cookie_string: str) -> Dict[str, str]:
 
 @sio.event
 async def connect(sid, environ, auth):
-    if settings.local:
+    if get_settings().local:
         await sio.enter_room(sid, f"user-{LOCAL_USER_ID}")
         return True
 

--- a/cea/interfaces/dashboard/server/jobs.py
+++ b/cea/interfaces/dashboard/server/jobs.py
@@ -21,7 +21,7 @@ from sqlmodel import select, desc
 from starlette.datastructures import UploadFile as _UploadFile
 
 from cea.interfaces.dashboard.dependencies import CEAServerUrl, CEAWorkerProcesses, CEAProjectID, CEAServerSettings, \
-    CEAUserID, CEASeverDemoAuthCheck, CEAStreams
+    CEAUserID, CEAStreams
 from cea.interfaces.dashboard.lib.database.models import JobInfo, JobState, get_current_time
 from cea.interfaces.dashboard.lib.database.session import SessionDep
 from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
@@ -159,7 +159,7 @@ def cleanup_job_temp_files(job_id: str):
         logger.error(f"Error cleaning up temp files for job {job_id}: {e}")
 
 
-@router.get("/", dependencies=[CEASeverDemoAuthCheck])
+@router.get("/")
 @router.get("/list")
 async def get_jobs(
     session: SessionDep,
@@ -208,7 +208,7 @@ async def get_job_info(session: SessionDep, job_id: str) -> JobInfoResponse:
     return JobInfoResponse.from_job_info(job, stdout=job.stdout, stderr=job.stderr)
 
 
-@router.post("/new", dependencies=[CEASeverDemoAuthCheck])
+@router.post("/new")
 async def create_new_job(request: Request, session: SessionDep, project_id: CEAProjectID, user_id: CEAUserID,
                          settings: CEAServerSettings) -> JobInfoResponse:
     """Post a new job to the list of jobs to complete"""
@@ -378,7 +378,7 @@ async def set_job_error(session: SessionDep, job_id: str, error: JobError, strea
     return job_payload
 
 
-@router.post('/start/{job_id}', dependencies=[CEASeverDemoAuthCheck])
+@router.post('/start/{job_id}')
 async def start_job(session: SessionDep, worker_processes: CEAWorkerProcesses, server_url: CEAServerUrl, job_id: str,
                     user_id: CEAUserID, settings: CEAServerSettings):
     """Start a ``cea-worker`` subprocess for the script. (FUTURE: add support for cloud-based workers"""
@@ -438,7 +438,7 @@ async def start_job(session: SessionDep, worker_processes: CEAWorkerProcesses, s
     return job_id
 
 
-@router.post("/cancel/{job_id}", dependencies=[CEASeverDemoAuthCheck])
+@router.post("/cancel/{job_id}")
 async def cancel_job(session: SessionDep, job_id: str, user_id: CEAUserID,
                      worker_processes: CEAWorkerProcesses, streams: CEAStreams) -> JobInfoResponse:
     # Lock the row to prevent concurrent modifications (TOCTOU protection)
@@ -550,7 +550,7 @@ async def kill_job(session, job_id: str, worker_processes, streams) -> JobInfoRe
     return job_payload
 
 
-@router.delete("/{job_id}", dependencies=[CEASeverDemoAuthCheck])
+@router.delete("/{job_id}")
 async def delete_job(session: SessionDep, job_id: str, user_id: CEAUserID) -> JobInfoResponse:
     """
     Mark a job as deleted (soft delete). The job row is not removed from the database,

--- a/cea/interfaces/dashboard/settings.py
+++ b/cea/interfaces/dashboard/settings.py
@@ -1,9 +1,9 @@
 from functools import lru_cache
 import os
-from typing import Dict, Optional
+from typing import Annotated, Dict, Optional
 
 from pydantic import field_validator, model_validator, Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from cea.interfaces.dashboard.constants import ENV_VAR_PREFIX
 from cea.interfaces.dashboard.lib.cache.settings import cache_settings
@@ -46,7 +46,7 @@ class Settings(BaseSettings):
     # Local only settings
     config_path: Optional[str] = "~/cea.config"
 
-    public_demo_scenarios: Dict[str, str] = Field(
+    public_demo_scenarios: Annotated[Dict[str, str], NoDecode] = Field(
         default_factory=dict,
         description=(
             "Map of demo_id -> absolute scenario path for public read-only demo access. "
@@ -73,11 +73,17 @@ class Settings(BaseSettings):
     @field_validator('public_demo_scenarios', mode='before')
     @classmethod
     def parse_demo_scenarios(cls, v):
-        """Accept 'id:path,id:path' strings from env vars (or dicts from code)."""
+        """Accept 'id:path,id:path' strings or JSON objects from env vars (or dicts from code)."""
         if isinstance(v, str):
+            import json
             v = v.strip()
             if not v:
                 return {}
+            if v.startswith("{"):
+                try:
+                    return json.loads(v)
+                except json.JSONDecodeError as e:
+                    raise ValueError(f"Invalid JSON for public_demo_scenarios: {e}") from e
             result = {}
             for item in v.split(","):
                 item = item.strip()
@@ -88,8 +94,13 @@ class Settings(BaseSettings):
                         f"Invalid demo scenario entry '{item}'. "
                         "Expected format: 'demo_id:/abs/path/to/scenario'."
                     )
-                demo_id, path = item.split(":", 1)
-                result[demo_id.strip()] = path.strip()
+                demo_id, path = (part.strip() for part in item.split(":", 1))
+                if not demo_id or not path or not os.path.isabs(path):
+                    raise ValueError(
+                        f"Invalid demo scenario entry '{item}'. "
+                        "Expected non-empty demo_id and absolute scenario path."
+                    )
+                result[demo_id] = path
             return result
         return v
 

--- a/cea/interfaces/dashboard/settings.py
+++ b/cea/interfaces/dashboard/settings.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
 import os
-from typing import Optional
+from typing import Dict, Optional
 
 from pydantic import field_validator, model_validator, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -46,6 +46,15 @@ class Settings(BaseSettings):
     # Local only settings
     config_path: Optional[str] = "~/cea.config"
 
+    public_demo_scenarios: Dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Map of demo_id -> absolute scenario path for public read-only demo access. "
+            "Env: CEA_PUBLIC_DEMO_SCENARIOS='demo1:/abs/path1,demo2:/abs/path2' (or JSON). "
+            "Empty (default) means the /api/demo sub-app is not mounted."
+        ),
+    )
+
     @field_validator('log_level', mode='before')
     @classmethod
     def validate_log_level(cls, v):
@@ -60,6 +69,29 @@ class Settings(BaseSettings):
     @classmethod
     def normalise_cors_origin(cls, v):
         return v.strip() if isinstance(v, str) else v
+    
+    @field_validator('public_demo_scenarios', mode='before')
+    @classmethod
+    def parse_demo_scenarios(cls, v):
+        """Accept 'id:path,id:path' strings from env vars (or dicts from code)."""
+        if isinstance(v, str):
+            v = v.strip()
+            if not v:
+                return {}
+            result = {}
+            for item in v.split(","):
+                item = item.strip()
+                if not item:
+                    continue
+                if ":" not in item:
+                    raise ValueError(
+                        f"Invalid demo scenario entry '{item}'. "
+                        "Expected format: 'demo_id:/abs/path/to/scenario'."
+                    )
+                demo_id, path = item.split(":", 1)
+                result[demo_id.strip()] = path.strip()
+            return result
+        return v
 
     @model_validator(mode='after')
     def validate_cors_origin(self):

--- a/cea/tests/test_dashboard_auth.py
+++ b/cea/tests/test_dashboard_auth.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from cea.interfaces.dashboard.dependencies import _PUBLIC_ROUTES, require_authenticated
+from cea.interfaces.dashboard.lib.database.models import LOCAL_USER_ID
+
+
+def _make_request(path: str) -> Request:
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("utf-8"),
+        "query_string": b"",
+        "headers": [],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+    return Request(scope)
+
+
+def test_requires_authentication_by_default_in_non_local_mode(monkeypatch):
+    from cea.interfaces.dashboard import dependencies as deps
+
+    monkeypatch.setattr(deps, "settings", SimpleNamespace(local=False))
+    request = _make_request("/api/inputs/buildings")
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_authenticated(request=request, user_id=LOCAL_USER_ID)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Authentication required."
+
+
+def test_public_routes_explicitly_opt_out_of_auth_in_non_local_mode(monkeypatch):
+    from cea.interfaces.dashboard import dependencies as deps
+
+    monkeypatch.setattr(deps, "settings", SimpleNamespace(local=False))
+
+    for path in _PUBLIC_ROUTES:
+        request = _make_request(path)
+        # Public allowlist routes should bypass the global auth gate.
+        require_authenticated(request=request, user_id=LOCAL_USER_ID)
+
+
+def test_local_mode_bypasses_authentication_guard(monkeypatch):
+    from cea.interfaces.dashboard import dependencies as deps
+
+    monkeypatch.setattr(deps, "settings", SimpleNamespace(local=True))
+    request = _make_request("/api/inputs/buildings")
+
+    require_authenticated(request=request, user_id=LOCAL_USER_ID)

--- a/cea/tests/test_dashboard_auth.py
+++ b/cea/tests/test_dashboard_auth.py
@@ -1,57 +1,43 @@
-from types import SimpleNamespace
-
+"""Tests for require_authenticated — no monkeypatching; Settings passed directly."""
 import pytest
-from fastapi import HTTPException
-from starlette.requests import Request
+from fastapi import Request
+from fastapi.exceptions import HTTPException
 
-from cea.interfaces.dashboard.dependencies import _PUBLIC_ROUTES, require_authenticated
+from cea.interfaces.dashboard.dependencies import require_authenticated, _PUBLIC_ROUTES
 from cea.interfaces.dashboard.lib.database.models import LOCAL_USER_ID
+from cea.interfaces.dashboard.settings import Settings
+
+LOCAL = Settings.model_construct(local=True)
+NON_LOCAL = Settings.model_construct(local=False)
+AUTHENTICATED_USER = "user_abc123"
+PUBLIC_PATH = next(iter(_PUBLIC_ROUTES))
+PROTECTED_PATH = "/api/project/"
 
 
 def _make_request(path: str) -> Request:
     scope = {
         "type": "http",
-        "http_version": "1.1",
         "method": "GET",
-        "scheme": "http",
         "path": path,
-        "raw_path": path.encode("utf-8"),
         "query_string": b"",
         "headers": [],
-        "client": ("testclient", 50000),
-        "server": ("testserver", 80),
     }
     return Request(scope)
 
 
-def test_requires_authentication_by_default_in_non_local_mode(monkeypatch):
-    from cea.interfaces.dashboard import dependencies as deps
+def test_local_mode_always_passes():
+    require_authenticated(_make_request(PROTECTED_PATH), LOCAL_USER_ID, LOCAL)
 
-    monkeypatch.setattr(deps, "settings", SimpleNamespace(local=False))
-    request = _make_request("/api/inputs/buildings")
 
+def test_non_local_authenticated_user_passes():
+    require_authenticated(_make_request(PROTECTED_PATH), AUTHENTICATED_USER, NON_LOCAL)
+
+
+def test_non_local_unauthenticated_on_protected_path_raises_401():
     with pytest.raises(HTTPException) as exc_info:
-        require_authenticated(request=request, user_id=LOCAL_USER_ID)
-
+        require_authenticated(_make_request(PROTECTED_PATH), LOCAL_USER_ID, NON_LOCAL)
     assert exc_info.value.status_code == 401
-    assert exc_info.value.detail == "Authentication required."
 
 
-def test_public_routes_explicitly_opt_out_of_auth_in_non_local_mode(monkeypatch):
-    from cea.interfaces.dashboard import dependencies as deps
-
-    monkeypatch.setattr(deps, "settings", SimpleNamespace(local=False))
-
-    for path in _PUBLIC_ROUTES:
-        request = _make_request(path)
-        # Public allowlist routes should bypass the global auth gate.
-        require_authenticated(request=request, user_id=LOCAL_USER_ID)
-
-
-def test_local_mode_bypasses_authentication_guard(monkeypatch):
-    from cea.interfaces.dashboard import dependencies as deps
-
-    monkeypatch.setattr(deps, "settings", SimpleNamespace(local=True))
-    request = _make_request("/api/inputs/buildings")
-
-    require_authenticated(request=request, user_id=LOCAL_USER_ID)
+def test_non_local_unauthenticated_on_public_path_passes():
+    require_authenticated(_make_request(PUBLIC_PATH), LOCAL_USER_ID, NON_LOCAL)

--- a/cea/tests/test_dashboard_demo.py
+++ b/cea/tests/test_dashboard_demo.py
@@ -1,0 +1,170 @@
+"""Tests for the public demo sub-app — no monkeypatching; Settings passed directly."""
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from cea.interfaces.dashboard.api.demo import require_public_demo_read
+from cea.interfaces.dashboard.settings import Settings
+
+# ---------------------------------------------------------------------------
+# Unit tests — require_public_demo_read (direct-call style, like test_dashboard_auth.py)
+# ---------------------------------------------------------------------------
+
+DEMO_SCENARIOS = {"city-a": "/data/scenarios/city_a", "city-b": "/data/scenarios/city_b"}
+SETTINGS_WITH_DEMOS = Settings.model_construct(public_demo_scenarios=DEMO_SCENARIOS)
+SETTINGS_EMPTY = Settings.model_construct(public_demo_scenarios={})
+
+
+def test_known_demo_id_returns_path():
+    path = require_public_demo_read("city-a", SETTINGS_WITH_DEMOS)
+    assert path == "/data/scenarios/city_a"
+
+
+def test_unknown_demo_id_raises_404():
+    with pytest.raises(HTTPException) as exc_info:
+        require_public_demo_read("unknown", SETTINGS_WITH_DEMOS)
+    assert exc_info.value.status_code == 404
+
+
+def test_empty_allowlist_raises_404():
+    with pytest.raises(HTTPException) as exc_info:
+        require_public_demo_read("city-a", SETTINGS_EMPTY)
+    assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Settings parsing — public_demo_scenarios field validator
+# ---------------------------------------------------------------------------
+
+
+def test_settings_parses_id_colon_path_format():
+    Settings.model_construct()
+    parsed = Settings.parse_demo_scenarios("demo1:/a/b,demo2:/c/d")
+    assert parsed == {"demo1": "/a/b", "demo2": "/c/d"}
+
+
+def test_settings_parses_empty_string_to_empty_dict():
+    parsed = Settings.parse_demo_scenarios("")
+    assert parsed == {}
+
+
+def test_settings_parses_dict_passthrough():
+    d = {"x": "/some/path"}
+    assert Settings.parse_demo_scenarios(d) is d
+
+
+def test_settings_raises_on_invalid_entry():
+    with pytest.raises(ValueError, match="Expected format"):
+        Settings.parse_demo_scenarios("no-colon-here")
+
+
+# ---------------------------------------------------------------------------
+# HTTP tests — demo sub-app (TestClient, like test_pathway_api.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_demo_client(demo_scenarios: dict):
+    """Build a TestClient for the demo sub-app with an injected allowlist.
+
+    Only overrides get_settings (test-scoped). The module-level overrides
+    for get_effective_scenario / get_effective_scenario_lenient are preserved
+    by removing only the test-added key in teardown.
+    """
+    from cea.interfaces.dashboard.api.demo import app as demo_app
+    from cea.interfaces.dashboard.settings import get_settings
+
+    settings = Settings.model_construct(public_demo_scenarios=demo_scenarios)
+    demo_app.dependency_overrides[get_settings] = lambda: settings
+    client = TestClient(demo_app, raise_server_exceptions=True)
+    return client, demo_app, get_settings
+
+
+def test_list_demo_scenarios_returns_configured_ids():
+    client, demo_app, get_settings_fn = _make_demo_client(
+        {"city-a": "/data/city_a", "city-b": "/data/city_b"}
+    )
+    try:
+        resp = client.get("/scenarios")
+        assert resp.status_code == 200
+        ids = {s["id"] for s in resp.json()["scenarios"]}
+        assert ids == {"city-a", "city-b"}
+    finally:
+        demo_app.dependency_overrides.pop(get_settings_fn, None)
+
+
+def test_list_demo_scenarios_empty_when_not_configured():
+    client, demo_app, get_settings_fn = _make_demo_client({})
+    try:
+        resp = client.get("/scenarios")
+        assert resp.status_code == 200
+        assert resp.json()["scenarios"] == []
+    finally:
+        demo_app.dependency_overrides.pop(get_settings_fn, None)
+
+
+def test_unknown_demo_id_returns_404_from_http():
+    client, demo_app, get_settings_fn = _make_demo_client({"city-a": "/data/city_a"})
+    try:
+        # reports static route: guarded by _demo_guard (no CEAScenario dependency)
+        resp = client.get("/scenarios/nonexistent/reports/features")
+        assert resp.status_code == 404
+        # inputs static route: also guarded by _demo_guard
+        resp2 = client.get("/scenarios/nonexistent/inputs/")
+        assert resp2.status_code == 404
+        # inputs scenario route: guarded by get_effective_scenario override
+        resp3 = client.get("/scenarios/nonexistent/inputs/geojson/zone")
+        assert resp3.status_code == 404
+    finally:
+        demo_app.dependency_overrides.pop(get_settings_fn, None)
+
+
+def test_demo_sub_app_has_no_write_routes():
+    """No mutating verbs (PUT, PATCH, DELETE) in the demo sub-app.
+
+    POST is allowed only for map-layer parameter queries (choices, range,
+    generate, check) which use a request body for filter params — same
+    pattern as the normal routes. canvas/export is excluded because it
+    re-renders plot cards via CEAConfig. Any other POST is unexpected.
+    """
+    from cea.interfaces.dashboard.api.demo import app as demo_app
+
+    mutating_methods = {"PUT", "PATCH", "DELETE"}
+    allowed_post_paths = {
+        "/scenarios/{demo_id}/map-layers/{layer_category}/{layer_name}/{parameter}/choices",
+        "/scenarios/{demo_id}/map-layers/{layer_category}/{layer_name}/{parameter}/range",
+        "/scenarios/{demo_id}/map-layers/{layer_category}/{layer_name}/generate",
+        "/scenarios/{demo_id}/map-layers/{layer_category}/{layer_name}/check",
+    }
+
+    bad_routes = []
+    for route in demo_app.routes:
+        if not hasattr(route, "methods"):
+            continue
+        if route.methods & mutating_methods:
+            bad_routes.append(route)
+        elif "POST" in route.methods and route.path not in allowed_post_paths:
+            bad_routes.append(route)
+
+    assert bad_routes == [], (
+        f"Demo sub-app must not expose mutating routes; found: {bad_routes}"
+    )
+
+
+def test_global_auth_guard_not_weakened():
+    """The main app's require_authenticated must still reject anonymous callers in
+    non-local mode — mounting the demo sub-app must not affect this."""
+    from fastapi import Request
+    from fastapi.exceptions import HTTPException
+
+    from cea.interfaces.dashboard.dependencies import require_authenticated
+    from cea.interfaces.dashboard.lib.database.models import LOCAL_USER_ID
+
+    non_local = Settings.model_construct(local=False)
+    scope = {
+        "type": "http", "method": "GET", "path": "/api/project/",
+        "query_string": b"", "headers": [],
+    }
+    request = Request(scope)
+    with pytest.raises(HTTPException) as exc_info:
+        require_authenticated(request, LOCAL_USER_ID, non_local)
+    assert exc_info.value.status_code == 401

--- a/cea/tests/test_pathway_api.py
+++ b/cea/tests/test_pathway_api.py
@@ -8,7 +8,7 @@ import geopandas as gpd
 import pandas as pd
 import pytest
 import yaml
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 from shapely.geometry import Polygon
 
@@ -47,7 +47,7 @@ def pathway_api_fixture():
     _write_demo_pathway(locator)
     _write_demo_templates(locator)
 
-    app = FastAPI()
+    app = FastAPI(dependencies=[Depends(require_authenticated)])
     app.include_router(pathways_router, prefix="/api/pathways")
     app.dependency_overrides[get_cea_config] = lambda: config
     app.dependency_overrides[require_authenticated] = lambda: None

--- a/cea/tests/test_pathway_api.py
+++ b/cea/tests/test_pathway_api.py
@@ -24,7 +24,7 @@ from cea.datamanagement.district_pathways.pathway_status import (
 )
 from cea.inputlocator import InputLocator
 from cea.interfaces.dashboard.api.pathways import router as pathways_router
-from cea.interfaces.dashboard.dependencies import check_auth_for_demo, get_cea_config
+from cea.interfaces.dashboard.dependencies import require_authenticated, get_cea_config
 
 InputLocator._cleanup_temp_directory = lambda self: None  # type: ignore[method-assign]
 
@@ -50,7 +50,7 @@ def pathway_api_fixture():
     app = FastAPI()
     app.include_router(pathways_router, prefix="/api/pathways")
     app.dependency_overrides[get_cea_config] = lambda: config
-    app.dependency_overrides[check_auth_for_demo] = lambda: None
+    app.dependency_overrides[require_authenticated] = lambda: None
 
     yield {
         "client": TestClient(app),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public demo sub-app under `/api/demo` with allowlisted, read-only scenario endpoints and a `/scenarios` listing.

* **Bug Fixes**
  * Strengthened dashboard authentication with a global guard plus explicit public-route allowlisting, while keeping the demo boundary anonymous.
  * Reduced unsafe/manual scenario path resolution by using typed scenario inputs and secure locators across reports and scenario-dependent routes.
  * Updated download endpoint user identity to use session-derived typing.

* **Documentation**
  * Expanded dashboard API documentation for authentication patterns, public demo access, and safer scenario input handling.

* **Tests**
  * Added unit and end-to-end tests for authentication and demo behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->