### PR TITLE
Restrict job access to owners

### DIFF
--- a/cea/interfaces/dashboard/api/downloads.py
+++ b/cea/interfaces/dashboard/api/downloads.py
@@ -544,8 +544,9 @@ async def delete_download(
     Returns:
         Success message
     """
+    # Lock row for update to prevent racing an in-flight download_file transfer
     result = await session.execute(
-        select(Download).where(Download.id == download_id)
+        select(Download).where(Download.id == download_id).with_for_update()
     )
     download = result.scalar_one_or_none()
 

--- a/cea/interfaces/dashboard/api/downloads.py
+++ b/cea/interfaces/dashboard/api/downloads.py
@@ -11,9 +11,8 @@ from sqlmodel import select
 from starlette.responses import FileResponse
 from starlette.background import BackgroundTask
 
-from cea.interfaces.dashboard.api.utils import CEAProject
+from cea.interfaces.dashboard.api.utils import CEAProject, CEAProjectID
 from cea.interfaces.dashboard.dependencies import (
-    CEAProjectID,
     CEAUserID
 )
 from cea.interfaces.dashboard.lib.database.session import SessionDep as CEASession

--- a/cea/interfaces/dashboard/api/project.py
+++ b/cea/interfaces/dashboard/api/project.py
@@ -265,6 +265,14 @@ async def create_new_project(project_root: CEAProjectRoot, new_project: NewProje
         try:
             # Add project to database
             await create_project(project, user_id, session)
+        except sqlalchemy.exc.IntegrityError as e:
+            # Project uri already exists (e.g. concurrent request created it first) -- leave
+            # the folder in place since another request may still be using it
+            logger.error(e)
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Project already exists",
+            )
         except sqlalchemy.exc.SQLAlchemyError as e:
             # Remove folder if failed to create in database
             logger.error(e)

--- a/cea/interfaces/dashboard/api/utils.py
+++ b/cea/interfaces/dashboard/api/utils.py
@@ -13,7 +13,9 @@ from fastapi import Depends, Header, HTTPException, status
 from pydantic import BaseModel
 from typing_extensions import Annotated
 
-from cea.interfaces.dashboard.dependencies import CEAConfig, CEALocalConfig, CEAProjectRoot
+from cea.interfaces.dashboard.dependencies import CEAConfig, CEALocalConfig, CEAProjectRoot, CEAUserID, \
+    get_or_create_project_id
+from cea.interfaces.dashboard.lib.database.session import SessionDep
 from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
 from cea.interfaces.dashboard.utils import secure_path
 
@@ -321,3 +323,17 @@ def get_effective_project_lenient(
 
 CEAProject = Annotated[str, Depends(get_effective_project)]
 CEAProjectLenient = Annotated[str, Depends(get_effective_project_lenient)]
+
+
+async def get_project_id(
+    project_path: CEAProjectLenient,
+    owner_id: CEAUserID,
+    session: SessionDep,
+) -> str:
+    """Resolve the DB project id for the request's effective project (X-CEA-Project header,
+    falling back to config.project in local mode only — see _resolve_project_from_headers).
+    Creates the Project row the first time this project path is seen."""
+    return await get_or_create_project_id(project_path, owner_id, session)
+
+
+CEAProjectID = Annotated[str, Depends(get_project_id)]

--- a/cea/interfaces/dashboard/dependencies.py
+++ b/cea/interfaces/dashboard/dependencies.py
@@ -88,13 +88,14 @@ async def create_project(project_uri: str, owner_id: CEAUserID, session: Session
     return project
 
 
-async def get_project_id(session: SessionDep, owner_id: CEAUserID,
-                         project_root: CEAProjectRoot, project_info: CEAProjectInfo):
-    """Get the project ID from the project URI."""
-    project_uri = project_info.project
-    if project_root is not None:
-        project_uri = os.path.join(project_root, project_uri)
+async def get_or_create_project_id(project_uri: str, owner_id: CEAUserID, session: SessionDep) -> str:
+    """Look up the Project row for a resolved project URI, creating it if this is the first
+    time it's seen.
 
+    Callers must resolve ``project_uri`` themselves (e.g. via the request-scoped
+    ``X-CEA-Project`` header through ``CEAProjectID`` in ``api/utils.py``) — this helper does
+    no path resolution of its own.
+    """
     result = await session.execute(select(Project).where(Project.uri == project_uri))
     project = result.scalar()
 
@@ -315,7 +316,6 @@ CEAUserID = Annotated[str, Depends(get_user_id)]
 CEAUser = Annotated[dict, Depends(get_user)]
 CEAConfig = Annotated[cea.config.Configuration, Depends(get_cea_config)]
 CEAProjectInfo = Annotated[ProjectInfo, Depends(get_project_info)]
-CEAProjectID = Annotated[str, Depends(get_project_id)]
 CEAPlotCache = Annotated[dict, Depends(get_plot_cache)]
 CEAWorkerProcesses = Annotated[AsyncDictCache, Depends(get_worker_processes)]
 CEAStreams = Annotated[AsyncDictCache, Depends(get_streams)]

--- a/cea/interfaces/dashboard/dependencies.py
+++ b/cea/interfaces/dashboard/dependencies.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Optional, Dict
 
 from fastapi import Depends, Request, HTTPException, status
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 from typing_extensions import Annotated
 
@@ -99,8 +100,14 @@ async def get_project_id(session: SessionDep, owner_id: CEAUserID,
 
     # If project not found, create a new one
     if not project:
-        logger.info(f"Creating project in database: {project_uri}")
-        project = await create_project(project_uri, owner_id, session)
+        try:
+            logger.info(f"Creating project in database: {project_uri}")
+            project = await create_project(project_uri, owner_id, session)
+        except IntegrityError:
+            # Lost a race with a concurrent request creating the same project (uri is unique)
+            await session.rollback()
+            result = await session.execute(select(Project).where(Project.uri == project_uri))
+            project = result.scalar_one()
 
     return project.id
 

--- a/cea/interfaces/dashboard/lib/database/models.py
+++ b/cea/interfaces/dashboard/lib/database/models.py
@@ -80,7 +80,7 @@ class User(SQLModel, table=True):
 
 class Project(SQLModel, table=True):
     id: str = Field(default_factory=lambda: uuid.uuid4().hex, primary_key=True)
-    uri: str = Field(nullable=False, index=True)
+    uri: str = Field(nullable=False, unique=True, index=True)
     owner: str = Field(foreign_key=f"{user_table_ref}.id", index=True)
 
 

--- a/cea/interfaces/dashboard/server/downloads.py
+++ b/cea/interfaces/dashboard/server/downloads.py
@@ -123,7 +123,10 @@ async def enforce_user_download_limit(session: AsyncSession, user_id: str, limit
         user_id: User ID to check
         limit: Maximum number of active downloads per user
     """
-    # Query user's active downloads (not yet downloaded)
+    # Query user's active downloads (not yet downloaded). Locked, and left uncommitted
+    # here so the lock is held through create_download's insert -- otherwise a
+    # concurrent request can slip in between this delete and that insert and still
+    # push the user over the limit (TOCTOU).
     result = await session.execute(
         select(Download)
         .where(
@@ -131,6 +134,7 @@ async def enforce_user_download_limit(session: AsyncSession, user_id: str, limit
             Download.state != DownloadState.DOWNLOADED
         )
         .order_by(Download.created_at.desc())
+        .with_for_update()
     )
     downloads = result.scalars().all()
 
@@ -142,8 +146,6 @@ async def enforce_user_download_limit(session: AsyncSession, user_id: str, limit
         for download in to_delete:
             await cleanup_download(session, download)
             await session.delete(download)
-
-        await session.commit()
 
 
 async def cleanup_download(session: AsyncSession, download: Download):

--- a/cea/interfaces/dashboard/server/jobs.py
+++ b/cea/interfaces/dashboard/server/jobs.py
@@ -9,12 +9,12 @@ import subprocess
 import sys
 import tempfile
 import uuid
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Annotated
 from urllib.parse import urlparse
 
 import psutil
 import sqlalchemy.exc
-from fastapi import APIRouter, HTTPException, status, Request, Query
+from fastapi import APIRouter, Depends, HTTPException, status, Request, Query
 from pydantic import BaseModel
 from sqlalchemy.orm import undefer_group
 from sqlmodel import select, desc
@@ -159,6 +159,50 @@ def cleanup_job_temp_files(job_id: str):
         logger.error(f"Error cleaning up temp files for job {job_id}: {e}")
 
 
+def _normalize_job_id(job_id: str) -> str:
+    """Validate job_id is a UUID and normalize it to the hex format JobInfo.id is stored in."""
+    try:
+        return uuid.UUID(job_id).hex
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid job_id format. Must be a valid UUID.")
+
+
+def _authorize_job_access(job: JobInfo | None, job_id: str, user_id: str) -> JobInfo:
+    """Raise 404/403 if job is missing or not owned by user_id, else return it."""
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    if job.created_by != user_id:
+        logger.warning(f"User {user_id} attempted to access job {job_id} owned by {job.created_by}")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not authorised to access this job"
+        )
+    return job
+
+
+async def locked_owned_job(session: SessionDep, job_id: str, user_id: CEAUserID) -> JobInfo:
+    """
+    Dependency: resolve path param {job_id} to its JobInfo row, verifying user_id
+    owns it (404 if missing, 403 if owned by someone else).
+
+    Takes a SELECT ... FOR UPDATE row lock (TOCTOU protection) -- every route using
+    this dependency mutates job state within the same request/transaction.
+    """
+    normalized_id = _normalize_job_id(job_id)
+    try:
+        result = await session.execute(
+            select(JobInfo).where(JobInfo.id == normalized_id).with_for_update()
+        )
+    except sqlalchemy.exc.OperationalError as e:
+        logger.error(e)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database error")
+    job = result.scalar_one_or_none()
+    return _authorize_job_access(job, normalized_id, user_id)
+
+
+LockedOwnedJob = Annotated[JobInfo, Depends(locked_owned_job)]
+
+
 @router.get("/")
 @router.get("/list")
 async def get_jobs(
@@ -203,17 +247,9 @@ async def get_jobs(
 @router.get("/{job_id}")
 async def get_job_info(session: SessionDep, job_id: str, user_id: CEAUserID) -> JobInfoResponse:
     """Return a JobInfo by id"""
-    job = await session.get(JobInfo, job_id, options=[undefer_group('logs')])
-    if not job:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
-
-    # Authorization check: only job creator (or the job's own worker callback) can view
-    if job.created_by != user_id:
-        logger.warning(f"User {user_id} attempted to view job {job_id} owned by {job.created_by}")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You are not authorised to view this job"
-        )
+    normalized_id = _normalize_job_id(job_id)
+    job = await session.get(JobInfo, normalized_id, options=[undefer_group('logs')])
+    job = _authorize_job_access(job, normalized_id, user_id)
 
     return JobInfoResponse.from_job_info(job, stdout=job.stdout, stderr=job.stderr)
 
@@ -288,23 +324,7 @@ async def create_new_job(request: Request, session: SessionDep, project_id: CEAP
 
 
 @router.post("/started/{job_id}")
-async def set_job_started(session: SessionDep, job_id: str, user_id: CEAUserID) -> JobInfoResponse:
-    # Lock the row to prevent concurrent modifications (TOCTOU protection)
-    result = await session.execute(
-        select(JobInfo).where(JobInfo.id == job_id).with_for_update()
-    )
-    job = result.scalar_one_or_none()
-    if not job:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
-
-    # Authorization check: only the job's own worker (or its creator) can report state
-    if job.created_by != user_id:
-        logger.warning(f"User {user_id} attempted to start-report job {job_id} owned by {job.created_by}")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You are not authorised to update this job"
-        )
-
+async def set_job_started(session: SessionDep, job: LockedOwnedJob) -> JobInfoResponse:
     try:
         job.state = JobState.STARTED
         job.start_time = get_current_time()
@@ -323,30 +343,14 @@ async def set_job_started(session: SessionDep, job_id: str, user_id: CEAUserID) 
 
 
 @router.post("/success/{job_id}")
-async def set_job_success(session: SessionDep, job_id: str, user_id: CEAUserID, streams: CEAStreams,
-                          worker_processes: CEAWorkerProcesses, output: JobOutput) -> JobInfoResponse:
-    # Lock the row to prevent concurrent modifications (TOCTOU protection)
-    result = await session.execute(
-        select(JobInfo).where(JobInfo.id == job_id).with_for_update()
-    )
-    job = result.scalar_one_or_none()
-    if not job:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
-
-    # Authorization check: only the job's own worker (or its creator) can report state
-    if job.created_by != user_id:
-        logger.warning(f"User {user_id} attempted to success-report job {job_id} owned by {job.created_by}")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You are not authorised to update this job"
-        )
-
+async def set_job_success(session: SessionDep, job: LockedOwnedJob,
+                          streams: CEAStreams, worker_processes: CEAWorkerProcesses, output: JobOutput) -> JobInfoResponse:
     try:
         job.state = JobState.SUCCESS
         job.error = None
         job.end_time = get_current_time()
 
-        stdout_capture = await streams.pop(job_id, [])
+        stdout_capture = await streams.pop(job.id, [])
         stdout_text = "".join(stdout_capture) if stdout_capture else None
         job.stdout = stdout_text
         await session.commit()
@@ -371,33 +375,17 @@ async def set_job_success(session: SessionDep, job_id: str, user_id: CEAUserID, 
 
 
 @router.post("/error/{job_id}")
-async def set_job_error(session: SessionDep, job_id: str, user_id: CEAUserID, error: JobError, streams: CEAStreams,
-                        worker_processes: CEAWorkerProcesses) -> JobInfoResponse:
+async def set_job_error(session: SessionDep, job: LockedOwnedJob,
+                        error: JobError, streams: CEAStreams, worker_processes: CEAWorkerProcesses) -> JobInfoResponse:
     message = error.message
     stacktrace = error.stacktrace
-
-    # Lock the row to prevent concurrent modifications (TOCTOU protection)
-    result = await session.execute(
-        select(JobInfo).where(JobInfo.id == job_id).with_for_update()
-    )
-    job = result.scalar_one_or_none()
-    if not job:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
-
-    # Authorization check: only the job's own worker (or its creator) can report state
-    if job.created_by != user_id:
-        logger.warning(f"User {user_id} attempted to error-report job {job_id} owned by {job.created_by}")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You are not authorised to update this job"
-        )
 
     try:
         job.state = JobState.ERROR
         job.error = message
         job.end_time = get_current_time()
 
-        stdout_capture = await streams.pop(job_id, [])
+        stdout_capture = await streams.pop(job.id, [])
         stdout_text = "".join(stdout_capture) if stdout_capture else None
         job.stdout = stdout_text
         job.stderr = stacktrace
@@ -419,21 +407,15 @@ async def set_job_error(session: SessionDep, job_id: str, user_id: CEAUserID, er
     event_payload = job_payload.to_event_payload()
     await emit_with_retry("cea-worker-error", event_payload, room=f"user-{job.created_by}")
 
-    logger.warning(f"Error found in job {job_id}: {message}")
+    logger.warning(f"Error found in job {job.id}: {message}")
     logger.error(f"stacktrace:\n{stacktrace}")
     return job_payload
 
 
 @router.post('/start/{job_id}')
-async def start_job(session: SessionDep, worker_processes: CEAWorkerProcesses, server_url: CEAServerUrl, job_id: str,
-                    user_id: CEAUserID):
+async def start_job(worker_processes: CEAWorkerProcesses, server_url: CEAServerUrl,
+                    job: LockedOwnedJob):
     """Start a ``cea-worker`` subprocess for the script. (FUTURE: add support for cloud-based workers"""
-
-    # Validate job_id is a valid UUID, normalized to the same hex format as JobInfo.id
-    try:
-        validated_job_id = uuid.UUID(job_id).hex
-    except ValueError:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid job_id format. Must be a valid UUID.")
 
     # Validate server_url is a valid HTTP/HTTPS URL
     try:
@@ -444,23 +426,6 @@ async def start_job(session: SessionDep, worker_processes: CEAWorkerProcesses, s
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid server_url. Missing hostname.")
     except Exception:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid server_url format.")
-
-    # Lock the row to prevent concurrent modifications (TOCTOU protection)
-    result = await session.execute(
-        select(JobInfo).where(JobInfo.id == job_id).with_for_update()
-    )
-    job = result.scalar_one_or_none()
-
-    if not job:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
-
-    # Authorization check: only job creator can start
-    if job.created_by != user_id:
-        logger.warning(f"User {user_id} attempted to start job {job_id} owned by {job.created_by}")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You are not authorized to start this job"
-        )
 
     # Validate job state: must be PENDING and not deleted
     if job.state != JobState.PENDING:
@@ -476,39 +441,22 @@ async def start_job(session: SessionDep, worker_processes: CEAWorkerProcesses, s
         )
 
     # Use validated parameters in command
-    command = [sys.executable, "-m", "cea.worker", "--suppress-warnings", validated_job_id, str(server_url)]
+    command = [sys.executable, "-m", "cea.worker", "--suppress-warnings", job.id, str(server_url)]
     logger.debug(f"command: {command}")
 
     # Pass the worker's auth token via env var, not argv: argv ends up in `ps` output
     # and in the debug log line above, while env vars do not.
-    worker_token = create_worker_token(validated_job_id, job.created_by)
+    worker_token = create_worker_token(job.id, job.created_by)
     worker_env = {**os.environ, "CEA_WORKER_TOKEN": worker_token}
     process = subprocess.Popen(command, env=worker_env)
 
-    await worker_processes.set(validated_job_id, process.pid)
-    return validated_job_id
+    await worker_processes.set(job.id, process.pid)
+    return job.id
 
 
 @router.post("/cancel/{job_id}")
-async def cancel_job(session: SessionDep, job_id: str, user_id: CEAUserID,
+async def cancel_job(session: SessionDep, job: LockedOwnedJob,
                      worker_processes: CEAWorkerProcesses, streams: CEAStreams) -> JobInfoResponse:
-    # Lock the row to prevent concurrent modifications (TOCTOU protection)
-    result = await session.execute(
-        select(JobInfo).where(JobInfo.id == job_id).with_for_update()
-    )
-    job = result.scalar_one_or_none()
-
-    if not job:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
-
-    # Authorization check: only job creator can cancel
-    if job.created_by != user_id:
-        logger.warning(f"User {user_id} attempted to cancel job {job_id} owned by {job.created_by}")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You are not authorized to cancel this job"
-        )
-
     # Validate state: can only cancel PENDING or STARTED jobs (protected by row lock)
     if job.state not in (JobState.PENDING, JobState.STARTED):
         raise HTTPException(
@@ -529,7 +477,7 @@ async def cancel_job(session: SessionDep, job_id: str, user_id: CEAUserID,
         job.end_time = get_current_time()
 
         # Save any remaining stream output before clearing
-        stdout_capture = await streams.pop(job_id, [])
+        stdout_capture = await streams.pop(job.id, [])
         stdout_text = "".join(stdout_capture) if stdout_capture else None
         job.stdout = stdout_text
 
@@ -537,7 +485,7 @@ async def cancel_job(session: SessionDep, job_id: str, user_id: CEAUserID,
         await session.refresh(job)
 
         # Terminate worker process gracefully to allow cleanup functions to run
-        await cleanup_worker_process(job_id, worker_processes, force=False)
+        await cleanup_worker_process(job.id, worker_processes, force=False)
 
         # Clean up temporary files for this job
         cleanup_job_temp_files(job.id)
@@ -602,7 +550,7 @@ async def kill_job(session, job_id: str, worker_processes, streams) -> JobInfoRe
 
 
 @router.delete("/{job_id}")
-async def delete_job(session: SessionDep, job_id: str, user_id: CEAUserID) -> JobInfoResponse:
+async def delete_job(session: SessionDep, job: LockedOwnedJob, user_id: CEAUserID) -> JobInfoResponse:
     """
     Mark a job as deleted (soft delete). The job row is not removed from the database,
     and the original completion state (SUCCESS/ERROR/CANCELED/KILLED) is preserved.
@@ -610,27 +558,6 @@ async def delete_job(session: SessionDep, job_id: str, user_id: CEAUserID) -> Jo
 
     Uses row-level locking to prevent TOCTOU race conditions.
     """
-    try:
-        # Lock the row to prevent concurrent modifications (TOCTOU protection)
-        result = await session.execute(
-            select(JobInfo).where(JobInfo.id == job_id).with_for_update()
-        )
-        job = result.scalar_one_or_none()
-    except sqlalchemy.exc.OperationalError as e:
-        logger.error(e)
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database error")
-
-    if not job:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
-
-    # Authorization check: only job creator can delete
-    if job.created_by != user_id:
-        logger.warning(f"User {user_id} attempted to delete job {job_id} owned by {job.created_by}")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You are not authorized to delete this job"
-        )
-
     if job.state == JobState.STARTED:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Job is still running")
 

--- a/cea/interfaces/dashboard/server/jobs.py
+++ b/cea/interfaces/dashboard/server/jobs.py
@@ -20,7 +20,8 @@ from sqlalchemy.orm import undefer_group
 from sqlmodel import select, desc
 from starlette.datastructures import UploadFile as _UploadFile
 
-from cea.interfaces.dashboard.dependencies import CEAServerUrl, CEAWorkerProcesses, CEAProjectID, CEAServerSettings, \
+from cea.interfaces.dashboard.api.utils import CEAProjectID
+from cea.interfaces.dashboard.dependencies import CEAServerUrl, CEAWorkerProcesses, CEAServerSettings, \
     CEAUserID, CEAStreams
 from cea.interfaces.dashboard.lib.auth import create_worker_token
 from cea.interfaces.dashboard.lib.database.models import JobInfo, JobState, get_current_time

--- a/cea/interfaces/dashboard/server/jobs.py
+++ b/cea/interfaces/dashboard/server/jobs.py
@@ -289,7 +289,11 @@ async def create_new_job(request: Request, session: SessionDep, project_id: CEAP
 
 @router.post("/started/{job_id}")
 async def set_job_started(session: SessionDep, job_id: str, user_id: CEAUserID) -> JobInfoResponse:
-    job = await session.get(JobInfo, job_id)
+    # Lock the row to prevent concurrent modifications (TOCTOU protection)
+    result = await session.execute(
+        select(JobInfo).where(JobInfo.id == job_id).with_for_update()
+    )
+    job = result.scalar_one_or_none()
     if not job:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
 
@@ -321,7 +325,11 @@ async def set_job_started(session: SessionDep, job_id: str, user_id: CEAUserID) 
 @router.post("/success/{job_id}")
 async def set_job_success(session: SessionDep, job_id: str, user_id: CEAUserID, streams: CEAStreams,
                           worker_processes: CEAWorkerProcesses, output: JobOutput) -> JobInfoResponse:
-    job = await session.get(JobInfo, job_id)
+    # Lock the row to prevent concurrent modifications (TOCTOU protection)
+    result = await session.execute(
+        select(JobInfo).where(JobInfo.id == job_id).with_for_update()
+    )
+    job = result.scalar_one_or_none()
     if not job:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
 
@@ -368,7 +376,11 @@ async def set_job_error(session: SessionDep, job_id: str, user_id: CEAUserID, er
     message = error.message
     stacktrace = error.stacktrace
 
-    job = await session.get(JobInfo, job_id)
+    # Lock the row to prevent concurrent modifications (TOCTOU protection)
+    result = await session.execute(
+        select(JobInfo).where(JobInfo.id == job_id).with_for_update()
+    )
+    job = result.scalar_one_or_none()
     if not job:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
 

--- a/cea/interfaces/dashboard/server/jobs.py
+++ b/cea/interfaces/dashboard/server/jobs.py
@@ -164,18 +164,19 @@ def cleanup_job_temp_files(job_id: str):
 async def get_jobs(
     session: SessionDep,
     project_id: CEAProjectID,
+    user_id: CEAUserID,
     limit: int = Query(50, ge=1, le=500, description="Number of jobs to return (most recent first)"),
     offset: int = Query(0, ge=0, description="Number of jobs to skip"),
     state: int | None = Query(None, description="Filter by job state (0=PENDING, 1=STARTED, 2=SUCCESS, 3=ERROR, 4=CANCELED, 5=KILLED)"),
     exclude_deleted: bool = Query(True, description="Exclude deleted jobs from results")
 ) -> List[JobInfo]:
     """
-    Get a paginated list of jobs for the current project with optional filtering.
+    Get a paginated list of jobs for the current user and project with optional filtering.
 
     Returns jobs ordered by creation time (most recent first), paginated by `limit` and `offset`.
     Jobs are filtered by deleted_at field rather than state to preserve completion states.
     """
-    query = select(JobInfo).where(JobInfo.project_id == project_id)
+    query = select(JobInfo).where(JobInfo.project_id == project_id, JobInfo.created_by == user_id)
 
     # Filter by state if specified
     if state is not None:
@@ -200,11 +201,20 @@ async def get_jobs(
 
 
 @router.get("/{job_id}")
-async def get_job_info(session: SessionDep, job_id: str) -> JobInfoResponse:
+async def get_job_info(session: SessionDep, job_id: str, user_id: CEAUserID) -> JobInfoResponse:
     """Return a JobInfo by id"""
     job = await session.get(JobInfo, job_id, options=[undefer_group('logs')])
     if not job:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+
+    # Authorization check: only job creator (or the job's own worker callback) can view
+    if job.created_by != user_id:
+        logger.warning(f"User {user_id} attempted to view job {job_id} owned by {job.created_by}")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not authorized to view this job"
+        )
+
     return JobInfoResponse.from_job_info(job, stdout=job.stdout, stderr=job.stderr)
 
 
@@ -278,10 +288,18 @@ async def create_new_job(request: Request, session: SessionDep, project_id: CEAP
 
 
 @router.post("/started/{job_id}")
-async def set_job_started(session: SessionDep, job_id: str) -> JobInfoResponse:
+async def set_job_started(session: SessionDep, job_id: str, user_id: CEAUserID) -> JobInfoResponse:
     job = await session.get(JobInfo, job_id)
     if not job:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+
+    # Authorization check: only the job's own worker (or its creator) can report state
+    if job.created_by != user_id:
+        logger.warning(f"User {user_id} attempted to start-report job {job_id} owned by {job.created_by}")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not authorized to update this job"
+        )
 
     try:
         job.state = JobState.STARTED
@@ -301,11 +319,19 @@ async def set_job_started(session: SessionDep, job_id: str) -> JobInfoResponse:
 
 
 @router.post("/success/{job_id}")
-async def set_job_success(session: SessionDep, job_id: str, streams: CEAStreams,
+async def set_job_success(session: SessionDep, job_id: str, user_id: CEAUserID, streams: CEAStreams,
                           worker_processes: CEAWorkerProcesses, output: JobOutput) -> JobInfoResponse:
     job = await session.get(JobInfo, job_id)
     if not job:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+
+    # Authorization check: only the job's own worker (or its creator) can report state
+    if job.created_by != user_id:
+        logger.warning(f"User {user_id} attempted to success-report job {job_id} owned by {job.created_by}")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not authorized to update this job"
+        )
 
     try:
         job.state = JobState.SUCCESS
@@ -337,7 +363,7 @@ async def set_job_success(session: SessionDep, job_id: str, streams: CEAStreams,
 
 
 @router.post("/error/{job_id}")
-async def set_job_error(session: SessionDep, job_id: str, error: JobError, streams: CEAStreams,
+async def set_job_error(session: SessionDep, job_id: str, user_id: CEAUserID, error: JobError, streams: CEAStreams,
                         worker_processes: CEAWorkerProcesses) -> JobInfoResponse:
     message = error.message
     stacktrace = error.stacktrace
@@ -345,6 +371,14 @@ async def set_job_error(session: SessionDep, job_id: str, error: JobError, strea
     job = await session.get(JobInfo, job_id)
     if not job:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+
+    # Authorization check: only the job's own worker (or its creator) can report state
+    if job.created_by != user_id:
+        logger.warning(f"User {user_id} attempted to error-report job {job_id} owned by {job.created_by}")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not authorized to update this job"
+        )
 
     try:
         job.state = JobState.ERROR

--- a/cea/interfaces/dashboard/server/jobs.py
+++ b/cea/interfaces/dashboard/server/jobs.py
@@ -212,7 +212,7 @@ async def get_job_info(session: SessionDep, job_id: str, user_id: CEAUserID) -> 
         logger.warning(f"User {user_id} attempted to view job {job_id} owned by {job.created_by}")
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="You are not authorized to view this job"
+            detail="You are not authorised to view this job"
         )
 
     return JobInfoResponse.from_job_info(job, stdout=job.stdout, stderr=job.stderr)
@@ -298,7 +298,7 @@ async def set_job_started(session: SessionDep, job_id: str, user_id: CEAUserID) 
         logger.warning(f"User {user_id} attempted to start-report job {job_id} owned by {job.created_by}")
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="You are not authorized to update this job"
+            detail="You are not authorised to update this job"
         )
 
     try:
@@ -330,7 +330,7 @@ async def set_job_success(session: SessionDep, job_id: str, user_id: CEAUserID, 
         logger.warning(f"User {user_id} attempted to success-report job {job_id} owned by {job.created_by}")
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="You are not authorized to update this job"
+            detail="You are not authorised to update this job"
         )
 
     try:
@@ -377,7 +377,7 @@ async def set_job_error(session: SessionDep, job_id: str, user_id: CEAUserID, er
         logger.warning(f"User {user_id} attempted to error-report job {job_id} owned by {job.created_by}")
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="You are not authorized to update this job"
+            detail="You are not authorised to update this job"
         )
 
     try:

--- a/cea/interfaces/dashboard/server/streams.py
+++ b/cea/interfaces/dashboard/server/streams.py
@@ -3,10 +3,10 @@ streams: maintain a list of streams containing ``cea-worker`` output for jobs.
 
 FIXME: when does this data get cleared?
 """
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request, status
 from sqlalchemy.orm import undefer_group
 
-from cea.interfaces.dashboard.dependencies import CEAStreams
+from cea.interfaces.dashboard.dependencies import CEAStreams, CEAUserID
 from cea.interfaces.dashboard.lib.database.models import JobInfo
 from cea.interfaces.dashboard.lib.database.session import SessionDep
 from cea.interfaces.dashboard.lib.logs import getCEAServerLogger
@@ -18,14 +18,22 @@ router = APIRouter()
 
 
 @router.get("/read/{job_id}")
-async def read_stream(session: SessionDep, streams: CEAStreams, job_id: str):
-    stdout = await streams.get(job_id)
+async def read_stream(session: SessionDep, streams: CEAStreams, job_id: str, user_id: CEAUserID):
+    job = await session.get(JobInfo, job_id, options=[undefer_group('logs')])
+    if job is None:
+        logger.info(f"read_stream: job {job_id} not found")
+        return ""  # Return empty string for non-existent jobs
 
+    # Authorization check: only the job's creator can read its output
+    if job.created_by != user_id:
+        logger.warning(f"User {user_id} attempted to read stream for job {job_id} owned by {job.created_by}")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not authorized to read this job's output"
+        )
+
+    stdout = await streams.get(job_id)
     if stdout is None:
-        job = await session.get(JobInfo, job_id, options=[undefer_group('logs')])
-        if job is None:
-            print(f"read_stream: job {job_id} not found")
-            return ""  # Return empty string for non-existent jobs
         stdout = job.stdout
     else:
         stdout = ''.join(stdout)
@@ -34,7 +42,19 @@ async def read_stream(session: SessionDep, streams: CEAStreams, job_id: str):
 
 
 @router.put("/write/{job_id}")
-async def write_stream(session: SessionDep, streams: CEAStreams, job_id: str, request: Request):
+async def write_stream(session: SessionDep, streams: CEAStreams, job_id: str, user_id: CEAUserID, request: Request):
+    job = await session.get(JobInfo, job_id)
+    if job is None:
+        return
+
+    # Authorization check: only the job's own worker (or its creator) can write output
+    if job.created_by != user_id:
+        logger.warning(f"User {user_id} attempted to write stream for job {job_id} owned by {job.created_by}")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not authorized to update this job's output"
+        )
+
     body = await request.body()
     message = body.decode("utf-8")
 
@@ -42,10 +62,5 @@ async def write_stream(session: SessionDep, streams: CEAStreams, job_id: str, re
     stream.append(message)
     await streams.set(job_id, stream)
 
-    job = await session.get(JobInfo, job_id)
-    if job is None:
-        return
-
-    user_id = job.created_by
     # emit the message using socket.io
-    await sio.emit('cea-worker-message', {"message": message, "jobid": job_id}, room=f"user-{user_id}")
+    await sio.emit('cea-worker-message', {"message": message, "jobid": job_id}, room=f"user-{job.created_by}")

--- a/cea/interfaces/dashboard/server/streams.py
+++ b/cea/interfaces/dashboard/server/streams.py
@@ -29,7 +29,7 @@ async def read_stream(session: SessionDep, streams: CEAStreams, job_id: str, use
         logger.warning(f"User {user_id} attempted to read stream for job {job_id} owned by {job.created_by}")
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="You are not authorized to read this job's output"
+            detail="You are not authorised to read this job's output"
         )
 
     stdout = await streams.get(job_id)
@@ -52,7 +52,7 @@ async def write_stream(session: SessionDep, streams: CEAStreams, job_id: str, us
         logger.warning(f"User {user_id} attempted to write stream for job {job_id} owned by {job.created_by}")
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="You are not authorized to update this job's output"
+            detail="You are not authorised to update this job's output"
         )
 
     body = await request.body()

--- a/cea/tests/test_dashboard_job_info.py
+++ b/cea/tests/test_dashboard_job_info.py
@@ -71,10 +71,10 @@ async def test_set_job_error_serialises_deferred_logs_without_lazy_loading(monke
     monkeypatch.setattr(jobs, "emit_with_retry", AsyncMock(return_value=True))
 
     async with db_session() as session:
+        job = await session.get(JobInfo, job_id)
         response = await jobs.set_job_error(
             session,
-            job_id,
-            "localuser",
+            job,
             jobs.JobError(message="mesh failed", stacktrace="traceback"),
             DummyStreams(["stdout line"]),
             DummyWorkerProcesses(),
@@ -112,10 +112,10 @@ async def test_set_job_success_keeps_datetime_fields_for_response_serialisation(
     monkeypatch.setattr(jobs, "emit_with_retry", AsyncMock(return_value=True))
 
     async with db_session() as session:
+        job = await session.get(JobInfo, job_id)
         response = await jobs.set_job_success(
             session,
-            job_id,
-            "localuser",
+            job,
             DummyStreams(["stdout line"]),
             DummyWorkerProcesses(),
             jobs.JobOutput(output={"status": "ok"}),

--- a/cea/tests/test_dashboard_job_info.py
+++ b/cea/tests/test_dashboard_job_info.py
@@ -74,6 +74,7 @@ async def test_set_job_error_serialises_deferred_logs_without_lazy_loading(monke
         response = await jobs.set_job_error(
             session,
             job_id,
+            "localuser",
             jobs.JobError(message="mesh failed", stacktrace="traceback"),
             DummyStreams(["stdout line"]),
             DummyWorkerProcesses(),
@@ -114,6 +115,7 @@ async def test_set_job_success_keeps_datetime_fields_for_response_serialisation(
         response = await jobs.set_job_success(
             session,
             job_id,
+            "localuser",
             DummyStreams(["stdout line"]),
             DummyWorkerProcesses(),
             jobs.JobOutput(output={"status": "ok"}),


### PR DESCRIPTION
Add user-based authorization across dashboard job and stream endpoints. Job listing now filters by both project and creator, and job detail/state-reporting/stream read-write routes return 403 when accessed by non-owners. Logging was updated for unauthorized attempts, stream reads now use server logging for missing jobs, and tests were adjusted for the new `user_id` parameter in job status handlers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Enforced job ownership across listing, details, execution control, status updates, and stream read/write (unauthorized → forbidden; missing → not found).
  * Added stronger row-level locking for job mutations, download limit enforcement, and download deletion to mitigate race conditions.
* **Bug Fixes**
  * Improved stream buffering/output selection.
  * Prevented duplicate project creation by adding a unique project URI and returning 409 when it already exists.
* **Tests**
  * Updated dashboard job tests to use job objects for state-change helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->