### PR TITLE
Drop /api prefix from dashboard routes

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,3 +15,8 @@ jobs:
         uses: astral-sh/ruff-action@v2
         with:
           src: ./cea
+          # Pinned to match the pixi-locked local version (see pyproject.toml's
+          # lint dependency group). pyproject.toml's [tool.ruff] doesn't set an
+          # explicit lint.select, so the active ruleset is whatever ruff's
+          # default is for a given release. Update CI version once the local version is updated.
+          version: 0.15.20

--- a/cea/interfaces/dashboard/AGENTS.md
+++ b/cea/interfaces/dashboard/AGENTS.md
@@ -57,7 +57,7 @@ ownership checks (`job.created_by != user_id`) work unchanged — the worker
 just resolves to the job's creator instead of `LOCAL_USER_ID`.
 
 **Public demo sub-app** — `api/demo.py` is a standalone `FastAPI()` instance mounted
-at `/api/demo` by `app.py` when `Settings.public_demo_scenarios` is non-empty. Because
+at `/demo` by `app.py` when `Settings.public_demo_scenarios` is non-empty. Because
 it is a sub-app (not a router), it does **not** inherit the main app's
 `require_authenticated` dependency — the anonymous boundary is structural, not a code
 branch. No edit to `require_authenticated` or `_PUBLIC_ROUTES` is needed.
@@ -72,7 +72,7 @@ which checks `demo_id` against the allowlist. No arbitrary filesystem paths are
 accepted. No write verbs are defined — the surface is read-only by construction.
 
 **Topology**: built in-process now; can be promoted to a standalone service with no
-code change (deploy `demo_app` alone, gateway `/api/demo/*` to it).
+code change (deploy `demo_app` alone, gateway `/demo/*` to it).
 
 ---
 

--- a/cea/interfaces/dashboard/api/AGENTS.md
+++ b/cea/interfaces/dashboard/api/AGENTS.md
@@ -1,14 +1,14 @@
 # Dashboard API
 
 ## Main API
-- `GET /api/pathways/overview` - Shared span plus lightweight year lanes for all pathways.
-- `GET /api/pathways/{pathway_name}/timeline` - Detailed active-pathway rows for the timeline panel.
-- `POST /api/pathways/{pathway_name}/years/{year}` - Create a new explicit year only when it is not a stock-only state.
-- `GET /api/pathways/{pathway_name}/years/{year}/editor-options` - Building/template choices for the year editors.
-- `POST /api/pathways/{pathway_name}/years/{year}/building-events` - Save building add/remove edits.
-- `POST /api/pathways/{pathway_name}/years/{year}/apply-templates` - Apply Step 2 templates directly from the panel.
-- `PUT /api/pathways/{pathway_name}/years/{year}/yaml` - Expert-mode YAML save.
-- `POST /api/pathways/{pathway_name}/years/{year}/validate-state` - Manual baked-state validation.
+- `GET /pathways/overview` - Shared span plus lightweight year lanes for all pathways.
+- `GET /pathways/{pathway_name}/timeline` - Detailed active-pathway rows for the timeline panel.
+- `POST /pathways/{pathway_name}/years/{year}` - Create a new explicit year only when it is not a stock-only state.
+- `GET /pathways/{pathway_name}/years/{year}/editor-options` - Building/template choices for the year editors.
+- `POST /pathways/{pathway_name}/years/{year}/building-events` - Save building add/remove edits.
+- `POST /pathways/{pathway_name}/years/{year}/apply-templates` - Apply Step 2 templates directly from the panel.
+- `PUT /pathways/{pathway_name}/years/{year}/yaml` - Expert-mode YAML save.
+- `POST /pathways/{pathway_name}/years/{year}/validate-state` - Manual baked-state validation.
 
 ## Route Design Principles
 
@@ -111,9 +111,9 @@ if os.path.commonpath((base_dir, candidate)) != base_dir:
 	return []
 ```
 
-### DO: Reserve `/api/pathways/*` for dashboard-specific pathway UX
+### DO: Reserve `/pathways/*` for dashboard-specific pathway UX
 ```python
-# Timeline/editor actions should not be routed through `/api/tools/*`.
+# Timeline/editor actions should not be routed through `/tools/*`.
 ```
 
 ### DO: Use InputLocator directly for CEAScenario-derived paths

--- a/cea/interfaces/dashboard/api/canvas.py
+++ b/cea/interfaces/dashboard/api/canvas.py
@@ -8,23 +8,23 @@ a thin HTTP-facing wrapper that exposes those primitives.
 Endpoints (all scenario-scoped via the standard
 ``?project=&scenario=`` query params, mirroring ``reports.py``):
 
-  GET    /api/canvas/                    list saved canvas names
-  POST   /api/canvas/                    create a new (empty)
+  GET    /canvas/                    list saved canvas names
+  POST   /canvas/                    create a new (empty)
                                          canvas; body `{ name }`
                                          → returns `{ name }`
                                          (sanitised); 409 if the
                                          name is taken
-  GET    /api/canvas/{name}              read state
-  PUT    /api/canvas/{name}              sparse autosave; body any
+  GET    /canvas/{name}              read state
+  PUT    /canvas/{name}              sparse autosave; body any
                                          subset of `{ canvas,
                                          layout, feature_card }`
-  DELETE /api/canvas/{name}              delete folder
-  POST   /api/canvas/{name}/duplicate    copy an existing canvas;
+  DELETE /canvas/{name}              delete folder
+  POST   /canvas/{name}/duplicate    copy an existing canvas;
                                          optional body `{ name }`
                                          picks a target name (defaults
                                          to ``"<source> (copy)"``)
-  GET    /api/canvas/{name}/export       capture-on-share + zip
-  POST   /api/canvas/import              upload a canvas zip;
+  GET    /canvas/{name}/export       capture-on-share + zip
+  POST   /canvas/import              upload a canvas zip;
                                          optional `?as=<new>`
                                          escape hatch for renaming
 

--- a/cea/interfaces/dashboard/api/demo.py
+++ b/cea/interfaces/dashboard/api/demo.py
@@ -1,7 +1,7 @@
 """
 Public demo sub-app — anonymous, read-only, allowlist-scoped.
 
-Mounted at /api/demo by app.py when public_demo_scenarios is configured.
+Mounted at /demo by app.py when public_demo_scenarios is configured.
 This is a standalone FastAPI app and does NOT inherit the main app's
 require_authenticated dependency — the anonymous boundary is structural.
 
@@ -13,7 +13,7 @@ get_effective_scenario_lenient with require_public_demo_read, which reads
 This makes CEAScenario resolve to the allowlisted path instead of the
 user's project root.
 
-URL shape: /api/demo/scenarios/{demo_id}/<domain>/...
+URL shape: /demo/scenarios/{demo_id}/<domain>/...
 
 Write routes are excluded via _filter_routes. Canvas export is excluded
 because it needs CEAConfig to re-render all plot cards. Reports /scenarios
@@ -27,7 +27,7 @@ To add a new demo resource:
   2. Optionally extend the routes below to expose more data for that scenario.
 
 Topology note: this sub-app can be extracted into a standalone service with
-no code change — deploy it alone and gateway /api/demo/* to it.
+no code change — deploy it alone and gateway /demo/* to it.
 """
 from __future__ import annotations
 
@@ -247,11 +247,28 @@ app.include_router(
 
 # ── Scenario list ──────────────────────────────────────────────────────────
 
+def _demo_route_prefixes() -> list[str]:
+    """Domains the demo sub-app actually serves, derived from its own route
+    table rather than hardcoded — stays correct as routers are added/removed
+    above. Consumed by the frontend to decide which requests are demo-eligible
+    (see GUI repo's demoClient interceptor); this is a routing hint, not a
+    security control — the anonymous boundary is enforced structurally by
+    require_public_demo_read regardless of what the client sends."""
+    marker = "/scenarios/{demo_id}/"
+    prefixes = {
+        route.path[len(marker):].split("/", 1)[0]
+        for route in app.routes
+        if isinstance(route, APIRoute) and route.path.startswith(marker)
+    }
+    return sorted(f"/{p}/" for p in prefixes if p)
+
+
 @app.get("/scenarios")
 async def list_demo_scenarios(settings: CEAServerSettings):
     """List all allowlisted demo scenario ids."""
     return {
-        "scenarios": [{"id": demo_id, "name": demo_id} for demo_id in settings.public_demo_scenarios]
+        "scenarios": [{"id": demo_id, "name": demo_id} for demo_id in settings.public_demo_scenarios],
+        "route_prefixes": _demo_route_prefixes(),
     }
 
 

--- a/cea/interfaces/dashboard/api/downloads.py
+++ b/cea/interfaces/dashboard/api/downloads.py
@@ -336,7 +336,7 @@ async def get_download_url(
     expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
 
     # Build URL
-    download_url = f"/api/downloads/{download_id}?token={token}"
+    download_url = f"/downloads/{download_id}?token={token}"
 
     logger.info(f"Generated download URL for {download_id}, expires in {expires_in}s")
 

--- a/cea/interfaces/dashboard/api/kpis.py
+++ b/cea/interfaces/dashboard/api/kpis.py
@@ -3,7 +3,7 @@ KPIs API — registry-driven Key Performance Indicators surfaced in
 the Canvas Builder and OverviewCard ribbon.
 
 Endpoint:
-  GET /api/kpis/?feature=&whatif=
+  GET /kpis/?feature=&whatif=
     Scenario is resolved from X-CEA-* headers. Returns every KPI in
     the requested ``feature`` for the given scenario. Each KPI
     either reports its ``value`` + ``unit`` (cache hit or

--- a/cea/interfaces/dashboard/api/reports.py
+++ b/cea/interfaces/dashboard/api/reports.py
@@ -2,9 +2,9 @@
 Reports API — provides data for the comparison dashboard.
 
 Endpoints:
-  GET /api/reports/whatifs         — list what-if names available in a scenario
-  GET /api/reports/summary        — KPI summary for a scenario + what-if + feature
-  GET /api/reports/plot           — plot HTML div for a scenario + what-if + feature
+  GET /reports/whatifs         — list what-if names available in a scenario
+  GET /reports/summary        — KPI summary for a scenario + what-if + feature
+  GET /reports/plot           — plot HTML div for a scenario + what-if + feature
 """
 
 import os
@@ -466,7 +466,7 @@ async def get_custom_plot(
         )
 
 
-# TODO: Remove get_zone_geojson — duplicates GET /api/inputs/geojson/zone which already serves
+# TODO: Remove get_zone_geojson — duplicates GET /inputs/geojson/zone which already serves
 #       zone geometry via CEAScenario. Frontend should call that endpoint instead.
 @router.get("/zone-geojson")
 async def get_zone_geojson(scenario: CEAScenario):

--- a/cea/interfaces/dashboard/app.py
+++ b/cea/interfaces/dashboard/app.py
@@ -116,7 +116,7 @@ app.add_middleware(
 app.mount("/socket.io", socket_app, "socketio")
 
 # Import other routers
-app.include_router(api.router, prefix='/api')
+app.include_router(api.router)
 app.include_router(plots.router, prefix='/plots')
 app.include_router(server.router, prefix='/server')
 
@@ -125,9 +125,9 @@ app.include_router(server.router, prefix='/server')
 # require_authenticated dependency above — the anonymous boundary is structural.
 if get_settings().public_demo_scenarios:
     from cea.interfaces.dashboard.api.demo import app as demo_app
-    app.mount("/api/demo", demo_app)
+    app.mount("/demo", demo_app)
     logger.debug(
-        "Public demo sub-app mounted at /api/demo (%d scenario(s))",
+        "Public demo sub-app mounted at /demo (%d scenario(s))",
         len(get_settings().public_demo_scenarios),
     )
 

--- a/cea/interfaces/dashboard/dependencies.py
+++ b/cea/interfaces/dashboard/dependencies.py
@@ -261,16 +261,16 @@ def get_auth_client(request: Request, settings: CEAServerSettings) -> Optional[A
 # Routes publicly accessible without authentication in non-local mode.
 # Every other route is gated by require_authenticated (applied at app level).
 _PUBLIC_ROUTES: frozenset = frozenset({
-    "/api/user/session/refresh",  # token refresh — must work with an expired access token
-    "/api/user/logout",           # session teardown — should work even if token is stale
-    "/server/alive",              # health check — monitoring must not need a session
-    "/server/version",            # version info — safe to expose publicly
+    "/user/session/refresh",  # token refresh — must work with an expired access token
+    "/user/logout",           # session teardown — should work even if token is stale
+    "/server/alive",          # health check — monitoring must not need a session
+    "/server/version",        # version info — safe to expose publicly
 })
 
 # Path prefixes exempt from session auth. The route handler is responsible for
 # its own auth when its path matches one of these prefixes.
 _PUBLIC_ROUTE_PREFIXES: tuple = (
-    "/api/downloads/",  # pre-signed token downloads — anchor tags don't send cookies
+    "/downloads/",  # pre-signed token downloads — anchor tags don't send cookies
 )
 
 

--- a/cea/interfaces/dashboard/lib/plot_dispatch.py
+++ b/cea/interfaces/dashboard/lib/plot_dispatch.py
@@ -1,7 +1,7 @@
 """
 Shared plot-rendering primitive used by:
 
-  * ``/api/reports/plot-custom`` — live render for the Canvas Builder.
+  * ``/reports/plot-custom`` — live render for the Canvas Builder.
   * ``canvas_capture`` — snapshot the rendered HTML alongside the
     saved canvas so the zip export is self-contained.
 

--- a/cea/interfaces/dashboard/lib/socketio.py
+++ b/cea/interfaces/dashboard/lib/socketio.py
@@ -34,7 +34,11 @@ def _get_cors_origin():
     if cors_origin == '*':
         return []
 
-    return cors_origin
+    # Parse comma-separated origins into a list, matching app.py's REST CORS
+    # parsing — python-socketio treats a raw comma-joined string as a single
+    # literal origin, so without this a second origin silently breaks
+    # websocket CORS for every origin, not just the new one.
+    return [o.strip() for o in cors_origin.split(",")]
 
 
 def _get_client_manager():

--- a/cea/interfaces/dashboard/settings.py
+++ b/cea/interfaces/dashboard/settings.py
@@ -62,7 +62,7 @@ class Settings(BaseSettings):
         description=(
             "Map of demo_id -> absolute scenario path for public read-only demo access. "
             "Env: CEA_PUBLIC_DEMO_SCENARIOS='demo1:/abs/path1,demo2:/abs/path2' (or JSON). "
-            "Empty (default) means the /api/demo sub-app is not mounted."
+            "Empty (default) means the /demo sub-app is not mounted."
         ),
     )
 

--- a/cea/kpi/option_generators.py
+++ b/cea/kpi/option_generators.py
@@ -9,7 +9,7 @@ output folders) and return a list of ``{value, label}`` dicts.
 
 Generators are registered via the ``register`` decorator below;
 :func:`run_generator` is the dispatch entry point used by the
-``/api/kpis/<id>/parameters`` endpoint.
+``/kpis/<id>/parameters`` endpoint.
 
 Adding a new generator:
 

--- a/cea/kpi/status.py
+++ b/cea/kpi/status.py
@@ -29,7 +29,7 @@ by recomputing, never a hard failure.
 
 Concurrency: every read-modify-write sequence (``write_kpi``,
 ``clear_kpi``) holds a cross-process file lock on the JSON's
-sidecar so two parallel /api/kpis/ requests, two pre-warm
+sidecar so two parallel /kpis/ requests, two pre-warm
 fan-outs, or one of each cannot interleave a stale read with a
 fresh write and clobber each other's entries. Lone reads
 (``read_status``, ``read_kpi``) are uncontended and skip the

--- a/cea/tests/test_dashboard_auth.py
+++ b/cea/tests/test_dashboard_auth.py
@@ -14,7 +14,7 @@ NON_LOCAL = Settings.model_construct(local=False)
 NON_LOCAL_WITH_ROOT = Settings.model_construct(local=False, project_root="/data/projects")
 AUTHENTICATED_USER = "user_abc123"
 PUBLIC_PATH = next(iter(_PUBLIC_ROUTES))
-PROTECTED_PATH = "/api/project/"
+PROTECTED_PATH = "/project/"
 
 
 def _make_request(path: str) -> Request:
@@ -47,7 +47,7 @@ def test_non_local_unauthenticated_on_public_path_passes():
 
 
 def test_get_project_root_rejects_no_session_in_non_local_mode():
-    """Anonymous callers on auth-exempt prefixes (e.g. /api/downloads/) must get a
+    """Anonymous callers on auth-exempt prefixes (e.g. /downloads/) must get a
     clean 401 here, not a TypeError from os.path.join(root, None)."""
     with pytest.raises(HTTPException) as exc_info:
         get_project_root(None, NON_LOCAL_WITH_ROOT)

--- a/cea/tests/test_dashboard_demo.py
+++ b/cea/tests/test_dashboard_demo.py
@@ -700,7 +700,7 @@ def test_global_auth_guard_not_weakened():
 
     non_local = Settings.model_construct(local=False)
     scope = {
-        "type": "http", "method": "GET", "path": "/api/project/",
+        "type": "http", "method": "GET", "path": "/project/",
         "query_string": b"", "headers": [],
     }
     request = Request(scope)

--- a/cea/tests/test_dashboard_demo.py
+++ b/cea/tests/test_dashboard_demo.py
@@ -619,6 +619,8 @@ _EXPECTED_DEMO_ROUTES = {
     ("GET", "/scenarios"),
     ("GET", "/scenarios/{demo_id}/canvas/"),
     ("GET", "/scenarios/{demo_id}/canvas/{name}"),
+    ("GET", "/scenarios/{demo_id}/databases/region"),
+    ("GET", "/scenarios/{demo_id}/databases/schema"),
     ("GET", "/scenarios/{demo_id}/inputs/"),
     ("GET", "/scenarios/{demo_id}/inputs/all-inputs"),
     ("GET", "/scenarios/{demo_id}/inputs/building-properties"),

--- a/cea/tests/test_dashboard_public_routes.py
+++ b/cea/tests/test_dashboard_public_routes.py
@@ -1,0 +1,50 @@
+"""Guards against the mount-prefix / auth-literal drift the /api prefix removal
+was exposed to: _PUBLIC_ROUTES and _PUBLIC_ROUTE_PREFIXES in dependencies.py are
+plain string literals matched against request.url.path in require_authenticated
+(see app.py's app-level dependency). Nothing previously asserted these literals
+actually resolve against the real route table built by app.py's include_router
+calls - a prefix change there with no matching update here would silently
+de-publish token refresh/logout (a lockout) or re-gate token-authenticated
+downloads behind a session cookie they're designed not to need, and nothing
+would fail until it broke in production.
+
+This imports the real cea.interfaces.dashboard.app module for its route table
+only - it does not start the app (no TestClient context manager, no lifespan).
+"""
+from fastapi.routing import APIRoute
+
+import cea.interfaces.dashboard.app as dashboard_app_module
+from cea.interfaces.dashboard.dependencies import _PUBLIC_ROUTES, _PUBLIC_ROUTE_PREFIXES
+
+
+def _real_route_paths() -> set[str]:
+    return {
+        route.path
+        for route in dashboard_app_module.app.routes
+        if isinstance(route, APIRoute)
+    }
+
+
+def test_public_routes_resolve_against_real_app():
+    """Every exact _PUBLIC_ROUTES entry must be a real, currently-mounted route."""
+    real_paths = _real_route_paths()
+    missing = _PUBLIC_ROUTES - real_paths
+    assert not missing, (
+        f"_PUBLIC_ROUTES entries with no matching route in app.routes: {sorted(missing)}. "
+        "These paths are exempted from auth by dependencies.py but don't resolve to "
+        "anything - either the route was removed/renamed, or the literal is stale "
+        "(e.g. left over from a router mount-prefix change)."
+    )
+
+
+def test_public_route_prefixes_resolve_against_real_app():
+    """Every _PUBLIC_ROUTE_PREFIXES entry must match at least one real route,
+    otherwise the exemption is dead and gates nothing."""
+    real_paths = _real_route_paths()
+    for prefix in _PUBLIC_ROUTE_PREFIXES:
+        matches = [p for p in real_paths if p.startswith(prefix)]
+        assert matches, (
+            f"_PUBLIC_ROUTE_PREFIXES entry {prefix!r} matches no route in app.routes - "
+            "the exemption is dead. If the underlying router's mount prefix changed, "
+            "update this literal to match."
+        )

--- a/cea/tests/test_pathway_api.py
+++ b/cea/tests/test_pathway_api.py
@@ -57,7 +57,7 @@ def pathway_api_fixture(monkeypatch):
     _write_demo_templates(locator)
 
     app = FastAPI(dependencies=[Depends(require_authenticated)])
-    app.include_router(pathways_router, prefix="/api/pathways")
+    app.include_router(pathways_router, prefix="/pathways")
     app.dependency_overrides[get_cea_config] = lambda: config
     app.dependency_overrides[require_authenticated] = lambda: None
     app.dependency_overrides[get_settings] = lambda: test_settings
@@ -77,11 +77,11 @@ def pathway_api_fixture(monkeypatch):
 def test_list_create_and_overview_pathways(pathway_api_fixture):
     client = pathway_api_fixture["client"]
 
-    response = client.get("/api/pathways/")
+    response = client.get("/pathways/")
     assert response.status_code == 200
     assert response.json() == {"pathways": ["demo"]}
 
-    overview = client.get("/api/pathways/overview")
+    overview = client.get("/pathways/overview")
     assert overview.status_code == 200
     payload = overview.json()
     assert payload["span"] == {"start_year": 2020, "end_year": 2040}
@@ -89,7 +89,7 @@ def test_list_create_and_overview_pathways(pathway_api_fixture):
     assert payload["pathways"][0]["years"] == [2020, 2030, 2040]
 
     create_response = client.post(
-        "/api/pathways/",
+        "/pathways/",
         json={"pathway_name": "new-pathway"},
     )
     assert create_response.status_code == 200
@@ -100,7 +100,7 @@ def test_get_timeline_returns_required_years_without_manual_state_field(
 ):
     client = pathway_api_fixture["client"]
 
-    response = client.get("/api/pathways/demo/timeline")
+    response = client.get("/pathways/demo/timeline")
     assert response.status_code == 200
 
     payload = response.json()
@@ -125,11 +125,11 @@ def test_post_year_rejects_empty_placeholder_for_stock_and_gap_years(pathway_api
     client = pathway_api_fixture["client"]
     locator = pathway_api_fixture["locator"]
 
-    stock_response = client.post("/api/pathways/demo/years/2020")
+    stock_response = client.post("/pathways/demo/years/2020")
     assert stock_response.status_code == 409
     assert stock_response.json()["detail"]["requires_edit"] is True
 
-    manual_response = client.post("/api/pathways/demo/years/2050")
+    manual_response = client.post("/pathways/demo/years/2050")
     assert manual_response.status_code == 409
     assert manual_response.json()["detail"]["requires_edit"] is True
 
@@ -142,7 +142,7 @@ def test_building_events_endpoint_updates_yaml(pathway_api_fixture):
     locator = pathway_api_fixture["locator"]
 
     response = client.post(
-        "/api/pathways/demo/years/2035/building-events",
+        "/pathways/demo/years/2035/building-events",
         json={
             "new_buildings": ["B2"],
             "demolished_buildings": ["B1"],
@@ -156,7 +156,7 @@ def test_building_events_endpoint_updates_yaml(pathway_api_fixture):
         "demolished_buildings": ["B1"],
     }
 
-    timeline = client.get("/api/pathways/demo/timeline").json()
+    timeline = client.get("/pathways/demo/timeline").json()
     rows = {row["year"]: row for row in timeline["years"]}
     assert rows[2035]["state_kind"] == "manual"
 
@@ -166,7 +166,7 @@ def test_apply_templates_route_merges_modifications(pathway_api_fixture):
     locator = pathway_api_fixture["locator"]
 
     response = client.post(
-        "/api/pathways/demo/years/2020/apply-templates",
+        "/pathways/demo/years/2020/apply-templates",
         json={"template_names": ["upgrade-wall"]},
     )
     assert response.status_code == 200
@@ -175,7 +175,7 @@ def test_apply_templates_route_merges_modifications(pathway_api_fixture):
     assert 2020 in log_data
     assert "STANDARD1" in log_data[2020]["modifications"]
 
-    timeline = client.get("/api/pathways/demo/timeline").json()
+    timeline = client.get("/pathways/demo/timeline").json()
     rows = {row["year"]: row for row in timeline["years"]}
     assert rows[2020]["state_kind"] == "mixed"
 
@@ -261,7 +261,7 @@ building_events:
 modifications: {}
 """
     response = client.put(
-        "/api/pathways/demo/years/2031/yaml",
+        "/pathways/demo/years/2031/yaml",
         json={"raw_yaml": raw_yaml},
     )
     assert response.status_code == 200
@@ -295,23 +295,23 @@ def test_validate_state_records_status_and_timeline_detects_log_drift(pathway_ap
         workflow=[],
     )
 
-    validate_response = client.post("/api/pathways/demo/years/2030/validate-state")
+    validate_response = client.post("/pathways/demo/years/2030/validate-state")
     assert validate_response.status_code == 200
     assert validate_response.json()["is_valid"] is True
 
-    timeline = client.get("/api/pathways/demo/timeline").json()
+    timeline = client.get("/pathways/demo/timeline").json()
     row = {item["year"]: item for item in timeline["years"]}[2030]
     assert row["status"]["validation"]["state"] == "validated"
     assert row["status"]["bake"]["state"] == "baked"
     assert row["status"]["simulation"]["state"] == "simulated"
 
     edit_response = client.post(
-        "/api/pathways/demo/years/2030/apply-templates",
+        "/pathways/demo/years/2030/apply-templates",
         json={"template_names": ["upgrade-wall"]},
     )
     assert edit_response.status_code == 200
 
-    timeline_after_edit = client.get("/api/pathways/demo/timeline").json()
+    timeline_after_edit = client.get("/pathways/demo/timeline").json()
     row_after_edit = {item["year"]: item for item in timeline_after_edit["years"]}[2030]
     assert row_after_edit["status"]["validation"]["state"] == "changed_after_validation"
     assert row_after_edit["status"]["bake"]["state"] == "changed_after_bake"
@@ -322,11 +322,11 @@ def test_delete_manual_and_clear_mixed_state(pathway_api_fixture):
     client = pathway_api_fixture["client"]
     locator = pathway_api_fixture["locator"]
 
-    manual_delete = client.delete("/api/pathways/demo/years/2030")
+    manual_delete = client.delete("/pathways/demo/years/2030")
     assert manual_delete.status_code == 200
     assert 2030 not in _read_log(locator, "demo")
 
-    mixed_clear = client.delete("/api/pathways/demo/years/2040")
+    mixed_clear = client.delete("/pathways/demo/years/2040")
     assert mixed_clear.status_code == 200
     log_data = _read_log(locator, "demo")
     assert 2040 not in log_data

--- a/cea/visualisation/special/comfort_chart.py
+++ b/cea/visualisation/special/comfort_chart.py
@@ -94,7 +94,7 @@ class ComfortChartPlot(cea.plots.demand.DemandSingleBuildingPlotBase):
         Historically this also wrote `output_path` and opened the file
         in a system browser; both side effects belong to the old CLI
         workflow and have been dropped. Canvas Builder consumes the
-        return value via `/api/reports/plot-custom`.
+        return value via `/reports/plot-custom`.
         """
         # Get all the traces directly (this works and shows curves)
         traces = self.calc_graph()

--- a/docs/developer/run-cea-in-docker.rst
+++ b/docs/developer/run-cea-in-docker.rst
@@ -91,4 +91,4 @@ command so that the container does not persist after it exits after running the 
   understand it well enough myself to feel confident enough to explain. But here are some observations:
    * The ``-t`` flag connects the container to your terminal, so you can see the output. You can drop this argument, but then you'll not be able to see any error messages etc. of the backend.
    * The ``-p 5050:5050`` flag connects the port 5050 on the host machine (your computer) to the port 5050 in the container (an instance of the cea-server docker image).
-   * If you browse to http://localhost:5050/api/ you will see a description of the api you can use. This is the same api used by the CityEnergyAnalyst-GUI project, so you can essentially do anything that can be done in the GUI programmatically using this api.
+   * If you browse to http://localhost:5050/ you will see a description of the api you can use. This is the same api used by the CityEnergyAnalyst-GUI project, so you can essentially do anything that can be done in the GUI programmatically using this api.


### PR DESCRIPTION
Removes the global `/api` mount prefix so dashboard endpoints are now served at root paths (e.g. `/pathways`, `/reports`, `/downloads`) and moves the public demo sub-app mount from `/api/demo` to `/demo`. Updates auth exemption literals to match the new paths, adjusts tests and docs accordingly, and adds regression tests to ensure `_PUBLIC_ROUTES` / `_PUBLIC_ROUTE_PREFIXES` always resolve against the real app route table. Also improves demo scenario discovery by returning served route prefixes and fixes Socket.IO CORS parsing for comma-separated origins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dashboard API routes are now available without the `/api` prefix.
  - The public demo is accessible at `/demo`.
  - Demo scenario responses include available route prefixes.
  - Download, KPI, report, pathway, and project URLs use the updated paths.

- **Bug Fixes**
  - Improved handling of comma-separated CORS origins.

- **Documentation**
  - Updated API examples, Docker instructions, and endpoint references.

- **Tests**
  - Added validation for public routes and authentication exemptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->