### PR TITLE
Enforce server-side scenario resolution for jobs

### DIFF
--- a/cea/interfaces/dashboard/AGENTS.md
+++ b/cea/interfaces/dashboard/AGENTS.md
@@ -100,7 +100,7 @@ Client → Server (jobs.py) → Worker (cea/worker.py) → Server
 
 ## Job Lifecycle
 
-**Creation** (`POST /jobs/new`): Creates `JobInfo` UUID+PENDING, handles file uploads to `/tmp/cea_job_{job_id}_*`.
+**Creation** (`POST /jobs/new`): Creates `JobInfo` UUID+PENDING, handles file uploads to `/tmp/cea_job_{job_id}_*`. `parameters["scenario"]` is server-resolved from `X-CEA-*` headers via `resolve_job_scenario()`/`script_takes_scenario_path()` (`api/utils.py`) — never trust a client-supplied value. `scenario` is a reserved parameter name across the *entire* config schema: `general:scenario` (a `ScenarioParameter`) is the only parameter anywhere allowed to be named `scenario` — enforced by `test_only_general_scenario_is_named_scenario` (`cea/tests/test_script_parameters.py`). If you need a config value with different semantics (e.g. the name of a scenario still to be created), name it something else, e.g. `new-scenario-name`.
 
 **Start** (`POST /jobs/start/{job_id}`): Auth-checked, row-locked. Spawns `python -m cea.worker {job_id} {server_url}`.
 
@@ -218,6 +218,8 @@ Scenario context travels as `X-CEA-*` request headers. Falls back to `config.sce
 **Child scenario**: `X-CEA-Child-Scenario: <pathway_name>/<year>` is a logical token — the backend resolves it to a filesystem path via `InputLocator.get_state_in_time_scenario_folder(pathway_name, year)`. No filesystem path is sent by the client; the physical layout (`outputs/pathways/<name>/state_<year>`) stays an implementation detail.
 
 **Canvas compare mode**: send per-request `headers` on each Axios call to target different scenarios concurrently — one global header/cookie cannot express this, which is why headers (not cookies) were chosen.
+
+**Job creation** (`POST /jobs/new`): the same rule applies to the request body, not just other routes' path params. Clients must not compute a `scenario` job parameter themselves — `create_new_job` (`server/jobs.py`) resolves and overrides it from these same headers for any script whose `scenario` parameter is a `ScenarioParameter`. See `server/AGENTS.md`.
 
 **Future phase (separate plan)**: URL path hierarchy `PUT /projects/{id}/scenarios/{name}/...` requires a `project_id → project_path` mapping table (works for local and non-local modes). Deferred: no `project_id` migration needed until online multi-user requires stable IDs.
 

--- a/cea/interfaces/dashboard/AGENTS.md
+++ b/cea/interfaces/dashboard/AGENTS.md
@@ -100,7 +100,7 @@ Client → Server (jobs.py) → Worker (cea/worker.py) → Server
 
 ## Job Lifecycle
 
-**Creation** (`POST /jobs/new`): Creates `JobInfo` UUID+PENDING, handles file uploads to `/tmp/cea_job_{job_id}_*`. `parameters["scenario"]` is server-resolved from `X-CEA-*` headers via `resolve_job_scenario()`/`script_takes_scenario_path()` (`api/utils.py`) — never trust a client-supplied value. `scenario` is a reserved parameter name across the *entire* config schema: `general:scenario` (a `ScenarioParameter`) is the only parameter anywhere allowed to be named `scenario` — enforced by `test_only_general_scenario_is_named_scenario` (`cea/tests/test_script_parameters.py`). If you need a config value with different semantics (e.g. the name of a scenario still to be created), name it something else, e.g. `new-scenario-name`.
+**Creation** (`POST /jobs/new`): Creates `JobInfo` UUID+PENDING, handles file uploads to `/tmp/cea_job_{job_id}_*`. Scenario resolution, client-value overriding, and the reserved `scenario` name are server-side contracts — see `server/AGENTS.md`.
 
 **Start** (`POST /jobs/start/{job_id}`): Auth-checked, row-locked. Spawns `python -m cea.worker {job_id} {server_url}`.
 

--- a/cea/interfaces/dashboard/api/pathways.py
+++ b/cea/interfaces/dashboard/api/pathways.py
@@ -21,6 +21,7 @@ from cea.datamanagement.district_pathways.pathway_timeline import (
     create_pathway_year,
     create_pathway,
     delete_or_clear_state,
+    delete_pathway,
     get_pathway_overview,
     get_pathway_timeline,
     get_year_editor_options,
@@ -80,6 +81,22 @@ async def post_pathway(config: CEAConfig, payload: CreatePathwayPayload) -> dict
     except FileExistsError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.delete("/{pathway_name}")
+async def delete_pathway_route(config: CEAConfig, pathway_name: str) -> dict[str, Any]:
+    try:
+        return await run_in_threadpool(delete_pathway, config, pathway_name)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
             detail=str(exc),
         ) from exc
     except ValueError as exc:

--- a/cea/interfaces/dashboard/api/utils.py
+++ b/cea/interfaces/dashboard/api/utils.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 import cea.config
 import cea.inputlocator
+import cea.scripts
 from fastapi import Depends, Header, HTTPException, status
 from pydantic import BaseModel
 from typing_extensions import Annotated
@@ -245,6 +246,27 @@ def _should_validate(p: cea.config.Parameter) -> bool:
     return False
 
 
+def script_takes_scenario_path(script_name: str, config: cea.config.Configuration) -> bool:
+    """True if ``script_name`` declares a parameter named ``scenario`` that is a
+    :py:class:`cea.config.ScenarioParameter` -- i.e. the reserved "current active
+    scenario" path.
+
+    Raises cea.ScriptNotFoundException for unknown script names.
+    """
+    script = cea.scripts.by_name(script_name, plugins=config.plugins)
+    try:
+        for _, parameter in config.matching_parameters(script.parameters):
+            if parameter.name == "scenario":
+                return isinstance(parameter, cea.config.ScenarioParameter)
+    except KeyError:
+        # scripts.yml (or a plugin's) references a section/parameter this config
+        # doesn't know about -- treat as "no scenario parameter" and let the normal
+        # parameter-validation path surface the real error.
+        logger.warning("Could not expand parameters for script %s", script_name)
+        return False
+    return False
+
+
 class CEAScenarioHeaders(BaseModel):
     x_cea_project: Optional[str] = None
     x_cea_scenario_name: Optional[str] = None
@@ -286,6 +308,30 @@ def get_effective_scenario_lenient(
 
 CEAScenario = Annotated[str, Depends(get_effective_scenario)]
 CEAScenarioLenient = Annotated[str, Depends(get_effective_scenario_lenient)]
+
+
+def get_effective_scenario_optional(
+    config: CEAConfig,
+    project_root: CEAProjectRoot,
+    cea_headers: Annotated[CEAScenarioHeaders, Header()],
+) -> Optional[str]:
+    """Like ``get_effective_scenario_lenient``, but returns ``None`` instead of raising
+    400 when the request carries no scenario context at all.
+
+    For endpoints whose need for a scenario depends on the request payload rather than
+    the route itself (POST /server/jobs/new: only scripts with a ScenarioParameter need
+    one), so the caller can decide whether the absence is actually an error. Malformed
+    context (an absolute project in non-local mode, a path-traversal attempt, a bad
+    child-scenario token, ...) still raises 400 via `_resolve_scenario_from_headers` --
+    only a *missing* project/scenario-name pair in non-local mode short-circuits to None.
+    """
+    if cea_headers.x_cea_project is None or cea_headers.x_cea_scenario_name is None:
+        if not isinstance(config, CEALocalConfig):
+            return None
+    return _get_effective_scenario(config, project_root, require_exists=False, cea_headers=cea_headers)
+
+
+CEAScenarioOptional = Annotated[Optional[str], Depends(get_effective_scenario_optional)]
 
 
 def _get_effective_project(

--- a/cea/interfaces/dashboard/server/AGENTS.md
+++ b/cea/interfaces/dashboard/server/AGENTS.md
@@ -22,7 +22,10 @@ Client → Server (jobs.py) → Worker (cea/worker.py) → Server
 
 ## Job Lifecycle
 
-**Creation** (`POST /jobs/new`): Creates `JobInfo` UUID+PENDING, handles file uploads to `/tmp/cea_job_{job_id}_*`. `parameters["scenario"]` is server-resolved from `X-CEA-*` headers via `resolve_job_scenario()`/`script_takes_scenario_path()` (`api/utils.py`) — never trust a client-supplied value. `scenario` is a reserved parameter name across the *entire* config schema: `general:scenario` (a `ScenarioParameter`) is the only parameter anywhere allowed to be named `scenario` — enforced by `test_only_general_scenario_is_named_scenario` (`cea/tests/test_script_parameters.py`). If you need a config value with different semantics (e.g. the name of a scenario still to be created), name it something else, e.g. `new-scenario-name`.
+**Creation** (`POST /jobs/new`): Creates `JobInfo` UUID+PENDING, handles file uploads to `/tmp/cea_job_{job_id}_*`.
+- **Scenario resolution**: `parameters["scenario"]` is server-resolved from `X-CEA-*` headers via `resolve_job_scenario()`/`script_takes_scenario_path()` (`api/utils.py`).
+- **Overriding client values**: a client-supplied `parameters["scenario"]` is never trusted — the server-resolved value always wins.
+- **Reserved name**: `scenario` is reserved across the *entire* config schema; `general:scenario` (a `ScenarioParameter`) is the only parameter anywhere allowed to be named `scenario` — enforced by `test_only_general_scenario_is_named_scenario` (`cea/tests/test_script_parameters.py`). If you need a config value with different semantics (e.g. the name of a scenario still to be created), name it something else, e.g. `new-scenario-name`.
 
 **Start** (`POST /jobs/start/{job_id}`): Auth-checked, row-locked. Spawns `python -m cea.worker {job_id} {server_url}`.
 

--- a/cea/interfaces/dashboard/server/AGENTS.md
+++ b/cea/interfaces/dashboard/server/AGENTS.md
@@ -22,7 +22,7 @@ Client → Server (jobs.py) → Worker (cea/worker.py) → Server
 
 ## Job Lifecycle
 
-**Creation** (`POST /jobs/new`): Creates `JobInfo` UUID+PENDING, handles file uploads to `/tmp/cea_job_{job_id}_*`.
+**Creation** (`POST /jobs/new`): Creates `JobInfo` UUID+PENDING, handles file uploads to `/tmp/cea_job_{job_id}_*`. `parameters["scenario"]` is server-resolved from `X-CEA-*` headers via `resolve_job_scenario()`/`script_takes_scenario_path()` (`api/utils.py`) — never trust a client-supplied value. `scenario` is a reserved parameter name across the *entire* config schema: `general:scenario` (a `ScenarioParameter`) is the only parameter anywhere allowed to be named `scenario` — enforced by `test_only_general_scenario_is_named_scenario` (`cea/tests/test_script_parameters.py`). If you need a config value with different semantics (e.g. the name of a scenario still to be created), name it something else, e.g. `new-scenario-name`.
 
 **Start** (`POST /jobs/start/{job_id}`): Auth-checked, row-locked. Spawns `python -m cea.worker {job_id} {server_url}`.
 

--- a/cea/interfaces/dashboard/server/jobs.py
+++ b/cea/interfaces/dashboard/server/jobs.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import tempfile
 import uuid
-from typing import Dict, Any, List, Annotated
+from typing import Dict, Any, List, Annotated, Optional
 from urllib.parse import urlparse
 
 import psutil
@@ -20,8 +20,9 @@ from sqlalchemy.orm import defer
 from sqlmodel import select, desc
 from starlette.datastructures import UploadFile as _UploadFile
 
-from cea.interfaces.dashboard.api.utils import CEAProjectID
-from cea.interfaces.dashboard.dependencies import CEAServerUrl, CEAWorkerProcesses, CEAServerSettings, \
+import cea
+from cea.interfaces.dashboard.api.utils import CEAProjectID, CEAScenarioOptional, script_takes_scenario_path
+from cea.interfaces.dashboard.dependencies import CEAConfig, CEAServerUrl, CEAWorkerProcesses, CEAServerSettings, \
     CEAUserID, CEAStreams
 from cea.interfaces.dashboard.lib.auth import create_worker_token
 from cea.interfaces.dashboard.lib.database.models import JobInfo, JobState, get_current_time
@@ -273,9 +274,39 @@ async def get_job_info(session: SessionDep, job_id: str, user_id: CEAUserID) -> 
     return JobInfoResponse.from_job_info(job)
 
 
+def resolve_job_scenario(script: str, config, scenario: Optional[str]) -> Optional[str]:
+    """Return the scenario path to use for this job, or ``None`` 
+    if the script does not take a ``ScenarioParameter`` (in which case the
+    client's ``parameters["scenario"]`` is used).
+
+    ``scenario`` is the request's header-resolved scenario context (``CEAScenarioOptional``
+    -- ``None`` when no X-CEA-Project/X-CEA-Scenario-Name pair was sent).
+
+    Raises HTTPException 422 for an unknown script name, 400 when a scenario-taking
+    script has no scenario context to resolve.
+    """
+    try:
+        needs_scenario = script_takes_scenario_path(script, config)
+    except cea.ScriptNotFoundException as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                            detail=f"Unknown script: {script}.") from e
+
+    if not needs_scenario:
+        return None
+
+    if scenario is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Scenario context required: send X-CEA-Project and X-CEA-Scenario-Name headers.",
+        )
+
+    return scenario
+
+
 @router.post("/new")
 async def create_new_job(request: Request, session: SessionDep, project_id: CEAProjectID, user_id: CEAUserID,
-                         settings: CEAServerSettings) -> JobSummaryResponse:
+                         settings: CEAServerSettings, config: CEAConfig,
+                         scenario: CEAScenarioOptional) -> JobSummaryResponse:
     """Post a new job to the list of jobs to complete"""
     content_type = request.headers.get("content-type", "")
 
@@ -310,8 +341,14 @@ async def create_new_job(request: Request, session: SessionDep, project_id: CEAP
     else:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported content type.")
 
-    if script is None:
+    if script is None or not isinstance(script, str) or not script.strip():
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Missing required field: 'script'.")
+
+    parameters = parameters or {}
+
+    # Resolve (and validate) the script's scenario requirement up front, before any temp
+    # files are created for this job -- a rejected request should leave nothing to clean up.
+    resolved_scenario = resolve_job_scenario(script, config, scenario)
 
     # Create job first with empty parameters to get job ID for temp file handling
     job = JobInfo(script=script, parameters={}, project_id=project_id, created_by=user_id)
@@ -319,6 +356,12 @@ async def create_new_job(request: Request, session: SessionDep, project_id: CEAP
     try:
         # Process parameters to handle any UploadFile instances
         parameters = await process_job_parameters(parameters, job.id)
+
+        if resolved_scenario is not None:
+            if parameters.get("scenario") not in (None, resolved_scenario):
+                logger.debug("Overriding client-supplied scenario %r with %r for job %s",
+                            parameters.get("scenario"), resolved_scenario, job.id)
+            parameters["scenario"] = resolved_scenario
 
         # FIXME: Forcing remote multiprocessing to be disabled for now,
         #  find solution for restricting number of processes per user

--- a/cea/interfaces/dashboard/server/jobs.py
+++ b/cea/interfaces/dashboard/server/jobs.py
@@ -345,6 +345,8 @@ async def create_new_job(request: Request, session: SessionDep, project_id: CEAP
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Missing required field: 'script'.")
 
     parameters = parameters or {}
+    if not isinstance(parameters, dict):
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Field 'parameters' must be an object.")
 
     # Resolve (and validate) the script's scenario requirement up front, before any temp
     # files are created for this job -- a rejected request should leave nothing to clean up.

--- a/cea/tests/test_dashboard_project_dependency.py
+++ b/cea/tests/test_dashboard_project_dependency.py
@@ -139,3 +139,71 @@ def test_get_effective_project_lenient_allows_missing_directory(tmp_path, monkey
     )
 
     assert result == str(missing)
+
+
+# ---------------------------------------------------------------------------
+# get_effective_scenario_optional (POST /server/jobs/new's scenario dependency --
+# like CEAScenarioLenient, but returns None instead of 400 when the request carries
+# no scenario context at all, since only some scripts need one)
+# ---------------------------------------------------------------------------
+
+
+def _scenario_headers(project=None, scenario_name=None):
+    return CEAScenarioHeaders(x_cea_project=project, x_cea_scenario_name=scenario_name)
+
+
+def _fake_local_config_with_scenario(scenario_path):
+    config = object.__new__(CEALocalConfig)
+    config.__dict__["scenario"] = scenario_path
+    return config
+
+
+def test_scenario_optional_no_headers_non_local_returns_none():
+    # config=object() is not a CEALocalConfig instance, i.e. non-local mode.
+    result = api_utils.get_effective_scenario_optional(
+        config=object(), project_root=None, cea_headers=_scenario_headers()
+    )
+    assert result is None
+
+
+def test_scenario_optional_no_headers_local_falls_back_to_config_scenario(monkeypatch):
+    monkeypatch.setattr(api_utils, "secure_path", lambda path, root=None: path)
+    config = _fake_local_config_with_scenario("/home/user/projects/demo/baseline")
+
+    result = api_utils.get_effective_scenario_optional(
+        config=config, project_root=None, cea_headers=_scenario_headers()
+    )
+
+    assert result == "/home/user/projects/demo/baseline"
+
+
+def test_scenario_optional_project_header_only_non_local_returns_none():
+    # Incomplete pair (project without scenario-name) in non-local mode is an absence
+    # of context, not an error -- must not raise.
+    result = api_utils.get_effective_scenario_optional(
+        config=object(), project_root=None, cea_headers=_scenario_headers(project="my-project")
+    )
+    assert result is None
+
+
+def test_scenario_optional_full_headers_resolves_joined_path(monkeypatch):
+    monkeypatch.setattr(api_utils, "secure_path", lambda path, root=None: path)
+
+    result = api_utils.get_effective_scenario_optional(
+        config=object(), project_root="/data/projects",
+        cea_headers=_scenario_headers(project="my-project", scenario_name="baseline"),
+    )
+
+    assert result == os.path.join("/data/projects", "my-project", "baseline")
+
+
+def test_scenario_optional_absolute_project_non_local_still_raises_400():
+    # Proves the None short-circuit didn't open a bypass around the existing
+    # absolute-path rejection -- a *malformed* header pair still raises; only
+    # *absence* of headers returns None.
+    with pytest.raises(HTTPException) as exc_info:
+        api_utils.get_effective_scenario_optional(
+            config=object(), project_root=None,
+            cea_headers=_scenario_headers(project="/abs/path", scenario_name="baseline"),
+        )
+    assert exc_info.value.status_code == 400

--- a/cea/tests/test_pathway_api.py
+++ b/cea/tests/test_pathway_api.py
@@ -110,6 +110,9 @@ def test_delete_pathway_route(pathway_api_fixture):
     missing_response = client.delete("/pathways/demo")
     assert missing_response.status_code == 404
 
+    invalid_response = client.delete("/pathways/invalid*name")
+    assert invalid_response.status_code == 400
+
 
 def test_get_timeline_returns_required_years_without_manual_state_field(
     pathway_api_fixture,

--- a/cea/tests/test_pathway_api.py
+++ b/cea/tests/test_pathway_api.py
@@ -95,6 +95,22 @@ def test_list_create_and_overview_pathways(pathway_api_fixture):
     assert create_response.status_code == 200
 
 
+def test_delete_pathway_route(pathway_api_fixture):
+    client = pathway_api_fixture["client"]
+    locator = pathway_api_fixture["locator"]
+
+    pathway_folder = Path(locator.get_district_pathway_folder("demo"))
+    assert pathway_folder.exists()
+
+    response = client.delete("/pathways/demo")
+    assert response.status_code == 200
+    assert response.json()["pathway_name"] == "demo"
+    assert not pathway_folder.exists()
+
+    missing_response = client.delete("/pathways/demo")
+    assert missing_response.status_code == 404
+
+
 def test_get_timeline_returns_required_years_without_manual_state_field(
     pathway_api_fixture,
 ):

--- a/cea/tests/test_script_parameters.py
+++ b/cea/tests/test_script_parameters.py
@@ -1,8 +1,15 @@
 """Test for duplicate parameters in script definitions"""
 
 import unittest
+
+import pytest
+from fastapi import HTTPException
+
+import cea
 import cea.scripts
 import cea.config
+from cea.interfaces.dashboard.api.utils import script_takes_scenario_path
+from cea.interfaces.dashboard.server.jobs import resolve_job_scenario
 
 
 class TestScriptParameters(unittest.TestCase):
@@ -41,6 +48,57 @@ class TestScriptParameters(unittest.TestCase):
                 for param, sections in info.items():
                     error_msg += f"  - '{param}' appears in sections: {' '.join(sections)}\n"
             self.fail(error_msg)
+
+
+def test_only_general_scenario_is_named_scenario(config):
+    """`scenario` is a reserved parameter name across the entire config schema,
+    `general:scenario` (a ScenarioParameter -- the current active scenario path)
+    is the only parameter anywhere allowed to be named `scenario`.
+    """
+    offenders = []
+    for section in config.sections.values():
+        parameter = section.parameters.get('scenario')
+        if parameter is None:
+            continue
+        if section.name != 'general' or not isinstance(parameter, cea.config.ScenarioParameter):
+            offenders.append(f"{section.name}:scenario is {type(parameter).__name__}")
+
+    if offenders:
+        error_msg = "\nFound non-reserved 'scenario' parameters outside [general]:\n"
+        for entry in offenders:
+            error_msg += f"  - {entry}\n"
+        pytest.fail(error_msg)
+
+
+def test_script_takes_scenario_path(config):
+    # general:scenario -- the reserved active-scenario path
+    assert script_takes_scenario_path('demand', config) is True
+    # a script with no 'scenario' parameter at all
+    assert script_takes_scenario_path('extract-reference-case', config) is False
+
+    with pytest.raises(cea.ScriptNotFoundException):
+        script_takes_scenario_path('no-such-script', config)
+
+
+def test_resolve_job_scenario(config):
+    # scenario-taking script + resolved context -> the resolved path is forced in
+    assert resolve_job_scenario('demand', config, '/root/proj/baseline') == '/root/proj/baseline'
+
+    # scenario-taking script + no context -> 400, fail fast
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_job_scenario('demand', config, None)
+    assert exc_info.value.status_code == 400
+
+    # extract-reference-case doesn't take a ScenarioParameter -- no override, and no 400
+    # even when there is no scenario context (this is the guarantee that scenario-less
+    # scripts keep working after this change)
+    assert resolve_job_scenario('extract-reference-case', config, '/root/proj/baseline') is None
+    assert resolve_job_scenario('extract-reference-case', config, None) is None
+
+    # unknown script -> 422
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_job_scenario('no-such-script', config, None)
+    assert exc_info.value.status_code == 422
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Updates dashboard job creation to derive `parameters["scenario"]` from `X-CEA-*` headers on the server instead of trusting client payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job creation now resolves scenario context from request headers.
  * Scenario-aware scripts receive the resolved scenario automatically.
  * Added the ability to delete pathways through the dashboard API.

* **Bug Fixes**
  * Client-supplied scenario values are overridden for consistency.
  * Unknown scripts, missing scenario context, and invalid scenario paths now return clear validation errors.
  * Improved handling of missing or empty job parameters.

* **Documentation**
  * Updated job lifecycle and scenario context guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->